### PR TITLE
Add a small example on how to integrate threads

### DIFF
--- a/examples/integrate-thread.rs
+++ b/examples/integrate-thread.rs
@@ -1,0 +1,74 @@
+#![feature(async_await)]
+
+use async_std::task;
+
+use std::{thread,time};
+use futures::channel::oneshot;
+
+struct AsyncHandle<T> {
+    handle: thread::JoinHandle<T>,
+    notifier: oneshot::Receiver<()>,
+}
+
+impl<T> AsyncHandle<T> {
+    fn thread(&self) -> &std::thread::Thread {
+        self.handle.thread()
+    }
+
+    async fn join(self) -> std::thread::Result<T> {
+        // ignore results, the join handle will propagate panics
+        let _ = self.notifier.await;
+        self.handle.join()
+    }
+}
+
+
+fn spawn<F,T>(f: F) -> AsyncHandle<T>
+where
+    F: FnOnce() -> T,
+    F: Send + 'static,
+    T: Send + 'static,
+{
+    let (sender, receiver) = oneshot::channel::<()>();
+
+    let thread_handle = thread::spawn(move || {
+        let res = f();
+        sender.send(()).unwrap();
+        res
+    });
+
+    AsyncHandle {
+        handle: thread_handle,
+        notifier: receiver
+    }
+}
+
+fn main() {
+    let thread_handle = spawn(move || {
+        thread::sleep(time::Duration::from_millis(1000));
+        String::from("Finished")
+    });
+
+    task::block_on(async move {
+        println!("waiting for thread 1");
+        let thread_result = thread_handle.join().await;
+        match thread_result {
+            Ok(s) => println!("Result: {}", s),
+            Err(e) => println!("Error: {:?}", e),
+        }
+    });
+
+    let thread_handle = spawn(move || {
+        panic!("aaah!");
+        String::from("Finished!")
+    });
+
+    task::block_on(async move {
+        println!("waiting for thread 2");
+        let thread_result = thread_handle.join().await;
+        match thread_result {
+            Ok(s) => println!("Result: {}", s),
+            Err(e) => println!("Error: {:?}", e),
+        }
+    });
+}

--- a/examples/integrate-thread.rs
+++ b/examples/integrate-thread.rs
@@ -2,8 +2,8 @@
 
 use async_std::task;
 
-use std::{thread,time};
 use futures::channel::oneshot;
+use std::{thread, time};
 
 struct AsyncHandle<T> {
     handle: thread::JoinHandle<T>,
@@ -22,8 +22,7 @@ impl<T> AsyncHandle<T> {
     }
 }
 
-
-fn spawn<F,T>(f: F) -> AsyncHandle<T>
+fn spawn<F, T>(f: F) -> AsyncHandle<T>
 where
     F: FnOnce() -> T,
     F: Send + 'static,
@@ -39,7 +38,7 @@ where
 
     AsyncHandle {
         handle: thread_handle,
-        notifier: receiver
+        notifier: receiver,
     }
 }
 

--- a/examples/integrate-thread.rs
+++ b/examples/integrate-thread.rs
@@ -64,7 +64,7 @@ fn main() {
     });
 
     task::block_on(async move {
-        println!("waiting for panicing thread");
+        println!("waiting for panicking thread");
         let thread_result = panicing_thread.join().await;
         match thread_result {
             Ok(s) => println!("Result: {}", s),

--- a/examples/integrate-thread.rs
+++ b/examples/integrate-thread.rs
@@ -44,28 +44,28 @@ where
 }
 
 fn main() {
-    let thread_handle = spawn(move || {
+    let sleepy_thread = spawn(move || {
         thread::sleep(time::Duration::from_millis(1000));
         String::from("Finished")
     });
 
     task::block_on(async move {
-        println!("waiting for thread 1");
-        let thread_result = thread_handle.join().await;
+        println!("waiting for sleepy thread");
+        let thread_result = sleepy_thread.join().await;
         match thread_result {
             Ok(s) => println!("Result: {}", s),
             Err(e) => println!("Error: {:?}", e),
         }
     });
 
-    let thread_handle = spawn(move || {
+    let panicing_thread = spawn(move || {
         panic!("aaah!");
         String::from("Finished!")
     });
 
     task::block_on(async move {
-        println!("waiting for thread 2");
-        let thread_result = thread_handle.join().await;
+        println!("waiting for panicing thread");
+        let thread_result = panicing_thread.join().await;
         match thread_result {
             Ok(s) => println!("Result: {}", s),
             Err(e) => println!("Error: {:?}", e),


### PR DESCRIPTION
Wrote a small example on how to integrate threads and use a oneshot channel to figure out if a thread is finished. It wraps that all in a way that allows for panicking threads and makes sure that you can get the thread result as you are used to.

This is my first take at it, does it make sense/is it useful?

One jarring oddity is `join().await`, but I didn't want to go the whole way and implement a future in whole. We could do it, though, it's just a proxy.