### PR TITLE
Fix warning in stdin-timeout example

### DIFF
--- a/examples/stdin-timeout.rs
+++ b/examples/stdin-timeout.rs
@@ -5,7 +5,6 @@
 use std::time::Duration;
 
 use async_std::io;
-use async_std::prelude::*;
 use async_std::task;
 
 fn main() -> io::Result<()> {


### PR DESCRIPTION
Fixes an unused warning that fails our test suite. 