### PR TITLE
Add readme section to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/async-std"
 description = "Async version of the Rust standard library"
 keywords = ["async", "await", "future", "std", "task"]
 categories = ["asynchronous", "concurrency", "network-programming"]
+readme = "README.md"
 
 [package.metadata.docs.rs]
 features = ["docs"]


### PR DESCRIPTION
This allows crates.io to render the readme directly on the crate page