### PR TITLE
Rename 'task' variable in example

### DIFF
--- a/docs/src/concepts/tasks.md
+++ b/docs/src/concepts/tasks.md
@@ -15,7 +15,7 @@ async fn read_file(path: &str) -> Result<String, io::Error> {
 }
 
 fn main() {
-    let task = task::spawn(async {
+    let reader_task = task::spawn(async {
         let result = read_file("data.csv");
         match result {
             Ok(s) => println!("{}", s),
@@ -23,7 +23,7 @@ fn main() {
         }
     });
     println!("Started task!");
-    task::block_on(task);
+    task::block_on(reader_task);
     println!("Stopped task!");
 }
 ```


### PR DESCRIPTION
The collision between the 'task' variable and the 'task' import is confusing (task::block_on(task) especially).