### PR TITLE
Revert "Manual: automated link checking using mdbook-linkcheck"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ env:
 
 before_script:
   - rustup component add rustfmt
-  - if [[ -n "$BUILD_DOCS" ]]; then (cargo install mdbook --force || true); fi
-  - if [[ -n "$BUILD_DOCS" ]]; then (cargo install mdbook-linkcheck --force || true); fi
 
 matrix:
   fast_finish: true

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -11,11 +11,3 @@ create-missing = false
 [output.html]
 git-repository-url = "https://github.com/async-rs/async-std"
 git-repository-icon = "fa-github"
-
-[output.linkcheck]
-# Should we check links on the internet? Enabling this option adds a
-# non-negligible performance impact
-follow-web-links = false
-# Are we allowed to link to files outside of the book's root directory? This
-# may help prevent linking to sensitive files (e.g. "../../../../etc/shadow")
-traverse-parent-directories = false


### PR DESCRIPTION
Reverts async-rs/async-std#61

This broke the netlify build.