### PR TITLE
Add Surf example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       env: BUILD_DOCS=1
     - rust: nightly
       os: osx
+      osx_image: xcode9.2
       env: BUILD_DOCS=1
     - rust: nightly-x86_64-pc-windows-msvc
       os: windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ mio-uds = "0.6.7"
 num_cpus = "1.10.0"
 pin-utils = "0.1.0-alpha.4"
 slab = "0.4.2"
+surf = "1.0.1"
 
 [dev-dependencies]
 femme = "1.1.0"

--- a/examples/surf-web.rs
+++ b/examples/surf-web.rs
@@ -1,0 +1,21 @@
+//! Sends an HTTP request to the Rust website.
+
+#![feature(async_await)]
+
+use async_std::task;
+
+fn main() -> Result<(), surf::Exception> {
+    task::block_on(async {
+        let url = "https://www.rust-lang.org";
+        let mut response = surf::get(url).await?;
+        let body = response.body_string().await?;
+
+        dbg!(url);
+        dbg!(response.status());
+        dbg!(response.version());
+        dbg!(response.headers());
+        dbg!(body.len());
+
+        Ok(())
+    })
+}


### PR DESCRIPTION
Let's try adding this Surf example again. We had to remove it before publishing initial version of `async-std` because it was breaking our Travis build and we had no time to fix it.