### PR TITLE
move surf to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ mio-uds = "0.6.7"
 num_cpus = "1.10.0"
 pin-utils = "0.1.0-alpha.4"
 slab = "0.4.2"
-surf = "1.0.1"
 
 [dev-dependencies]
 femme = "1.1.0"
 tempdir = "0.3.7"
+surf = "1.0.1"


### PR DESCRIPTION
I think maybe better, because only examples use it.