### PR TITLE
remove async_await feature gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ $ cargo add async-std
 ## Hello world
 
 ```rust
-#![feature(async_await)]
-
 use async_std::task;
 
 fn main() {
@@ -52,8 +50,6 @@ fn main() {
 ## Low-Friction Sockets with Built-In Timeouts
 
 ```rust
-#![feature(async_await)]
-
 use std::time::Duration;
 
 use async_std::{

--- a/benches/task_local.rs
+++ b/benches/task_local.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, test)]
+#![feature(test)]
 
 extern crate test;
 

--- a/docs/src/tutorial/accept_loop.md
+++ b/docs/src/tutorial/accept_loop.md
@@ -6,8 +6,6 @@ Let's implement the scaffold of the server: a loop that binds a TCP socket to an
 First of all, let's add required import boilerplate:
 
 ```rust
-#![feature(async_await)]
-
 use std::net::ToSocketAddrs; // 1
 
 use async_std::{

--- a/docs/src/tutorial/all_together.md
+++ b/docs/src/tutorial/all_together.md
@@ -4,8 +4,6 @@
 At this point, we only need to start the broker to get a fully-functioning (in the happy case!) chat:
 
 ```rust
-#![feature(async_await)]
-
 use std::{
     net::ToSocketAddrs,
     sync::Arc,

--- a/docs/src/tutorial/handling_disconnection.md
+++ b/docs/src/tutorial/handling_disconnection.md
@@ -95,8 +95,6 @@ This also allows us to establish a useful invariant that the message channel str
 The final code looks like this:
 
 ```rust
-#![feature(async_await)]
-
 use std::{
     net::ToSocketAddrs,
     sync::Arc,

--- a/docs/src/tutorial/implementing_a_client.md
+++ b/docs/src/tutorial/implementing_a_client.md
@@ -15,8 +15,6 @@ Programming this with threads is cumbersome, especially when implementing clean 
 With async, we can just use the `select!` macro.
 
 ```rust
-#![feature(async_await)]
-
 use std::net::ToSocketAddrs;
 
 use futures::select;

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,7 +1,5 @@
 //! Spawns a task that says hello.
 
-#![feature(async_await)]
-
 use async_std::task;
 
 async fn say_hi() {

--- a/examples/line-count.rs
+++ b/examples/line-count.rs
@@ -1,7 +1,5 @@
 //! Counts the number of lines in a file given as an argument.
 
-#![feature(async_await)]
-
 use std::env::args;
 
 use async_std::fs::File;

--- a/examples/list-dir.rs
+++ b/examples/list-dir.rs
@@ -1,7 +1,5 @@
 //! Lists files in a directory given as an argument.
 
-#![feature(async_await)]
-
 use std::env::args;
 
 use async_std::fs;

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,7 +1,5 @@
 //! Prints the runtime's execution log on the standard output.
 
-#![feature(async_await)]
-
 use async_std::task;
 
 fn main() {

--- a/examples/print-file.rs
+++ b/examples/print-file.rs
@@ -1,7 +1,5 @@
 //! Prints a file given as an argument to stdout.
 
-#![feature(async_await)]
-
 use std::env::args;
 
 use async_std::fs::File;

--- a/examples/stdin-echo.rs
+++ b/examples/stdin-echo.rs
@@ -1,7 +1,5 @@
 //! Echoes lines read on stdin to stdout.
 
-#![feature(async_await)]
-
 use async_std::io;
 use async_std::prelude::*;
 use async_std::task;

--- a/examples/stdin-timeout.rs
+++ b/examples/stdin-timeout.rs
@@ -1,7 +1,5 @@
 //! Reads a line from stdin, or exits with an error if nothing is read in 5 seconds.
 
-#![feature(async_await)]
-
 use std::time::Duration;
 
 use async_std::io;

--- a/examples/surf-web.rs
+++ b/examples/surf-web.rs
@@ -1,7 +1,5 @@
 //! Sends an HTTP request to the Rust website.
 
-#![feature(async_await)]
-
 use async_std::task;
 
 fn main() -> Result<(), surf::Exception> {

--- a/examples/task-local.rs
+++ b/examples/task-local.rs
@@ -1,7 +1,5 @@
 //! Creates a task-local value.
 
-#![feature(async_await)]
-
 use std::cell::Cell;
 
 use async_std::prelude::*;

--- a/examples/task-name.rs
+++ b/examples/task-name.rs
@@ -1,7 +1,5 @@
 //! Spawns a named task that prints its name.
 
-#![feature(async_await)]
-
 use async_std::task;
 
 async fn print_name() {

--- a/examples/tcp-client.rs
+++ b/examples/tcp-client.rs
@@ -12,8 +12,6 @@
 //! $ cargo run --example tcp-client
 //! ```
 
-#![feature(async_await)]
-
 use async_std::io;
 use async_std::net::TcpStream;
 use async_std::prelude::*;

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -6,8 +6,6 @@
 //! $ nc localhost 8080
 //! ```
 
-#![feature(async_await)]
-
 use async_std::io;
 use async_std::net::{TcpListener, TcpStream};
 use async_std::prelude::*;

--- a/examples/udp-client.rs
+++ b/examples/udp-client.rs
@@ -12,8 +12,6 @@
 //! $ cargo run --example udp-client
 //! ```
 
-#![feature(async_await)]
-
 use async_std::io;
 use async_std::net::UdpSocket;
 use async_std::task;

--- a/examples/udp-echo.rs
+++ b/examples/udp-echo.rs
@@ -6,8 +6,6 @@
 //! $ nc -u localhost 8080
 //! ```
 
-#![feature(async_await)]
-
 use async_std::io;
 use async_std::net::UdpSocket;
 use async_std::task;

--- a/src/fs/canonicalize.rs
+++ b/src/fs/canonicalize.rs
@@ -23,7 +23,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/copy.rs
+++ b/src/fs/copy.rs
@@ -27,7 +27,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/create_dir.rs
+++ b/src/fs/create_dir.rs
@@ -21,7 +21,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/create_dir_all.rs
+++ b/src/fs/create_dir_all.rs
@@ -20,7 +20,6 @@ use crate::io;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/dir_builder.rs
+++ b/src/fs/dir_builder.rs
@@ -73,7 +73,6 @@ impl DirBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::DirBuilder;

--- a/src/fs/dir_entry.rs
+++ b/src/fs/dir_entry.rs
@@ -74,7 +74,6 @@ impl DirEntry {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs;
@@ -100,7 +99,6 @@ impl DirEntry {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs;
@@ -154,7 +152,6 @@ impl DirEntry {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs;
@@ -206,7 +203,6 @@ impl DirEntry {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs;

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -33,7 +33,6 @@ use crate::task::{blocking, Context, Poll};
 /// Create a new file and write some bytes to it:
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs::File;
@@ -48,7 +47,6 @@ use crate::task::{blocking, Context, Poll};
 /// Read the contents of a file into a `Vec<u8>`:
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs::File;
@@ -124,7 +122,6 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -171,7 +168,6 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -218,7 +214,6 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -274,7 +269,6 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -334,7 +328,6 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -381,7 +374,6 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -433,7 +425,6 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;

--- a/src/fs/hard_link.rs
+++ b/src/fs/hard_link.rs
@@ -22,7 +22,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -22,7 +22,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -9,7 +9,6 @@
 //! Create a new file and write some bytes to it:
 //!
 //! ```no_run
-//! # #![feature(async_await)]
 //! # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 //! #
 //! use async_std::fs::File;

--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -32,7 +32,6 @@ use crate::task::blocking;
 /// Opening a file for reading:
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs::OpenOptions;
@@ -48,7 +47,6 @@ use crate::task::blocking;
 /// Opening a file for both reading and writing, creating it if it doesn't exist:
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs::OpenOptions;
@@ -73,7 +71,6 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::OpenOptions;
@@ -96,7 +93,6 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::OpenOptions;
@@ -123,7 +119,6 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::OpenOptions;
@@ -169,7 +164,6 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::OpenOptions;
@@ -196,7 +190,6 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::OpenOptions;
@@ -226,7 +219,6 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::OpenOptions;
@@ -263,7 +255,6 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::OpenOptions;
@@ -316,7 +307,6 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::OpenOptions;

--- a/src/fs/read.rs
+++ b/src/fs/read.rs
@@ -24,7 +24,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/read_dir.rs
+++ b/src/fs/read_dir.rs
@@ -30,7 +30,6 @@ use crate::task::{blocking, Context, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/read_link.rs
+++ b/src/fs/read_link.rs
@@ -20,7 +20,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/read_to_string.rs
+++ b/src/fs/read_to_string.rs
@@ -20,7 +20,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/remove_dir.rs
+++ b/src/fs/remove_dir.rs
@@ -20,7 +20,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/remove_dir_all.rs
+++ b/src/fs/remove_dir_all.rs
@@ -20,7 +20,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/remove_file.rs
+++ b/src/fs/remove_file.rs
@@ -20,7 +20,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/rename.rs
+++ b/src/fs/rename.rs
@@ -21,7 +21,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/set_permissions.rs
+++ b/src/fs/set_permissions.rs
@@ -20,7 +20,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/symlink_metadata.rs
+++ b/src/fs/symlink_metadata.rs
@@ -20,7 +20,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/fs/write.rs
+++ b/src/fs/write.rs
@@ -22,7 +22,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs;

--- a/src/future/pending.rs
+++ b/src/future/pending.rs
@@ -2,7 +2,6 @@
 ///
 /// # Examples
 /// ```
-/// # #![feature(async_await)]
 /// # fn main() { async_std::task::block_on(async {
 /// #
 /// use std::time::Duration;

--- a/src/future/ready.rs
+++ b/src/future/ready.rs
@@ -7,7 +7,6 @@
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// # fn main() { async_std::task::block_on(async {
 /// #
 /// use async_std::future;

--- a/src/io/buf_read.rs
+++ b/src/io/buf_read.rs
@@ -46,7 +46,6 @@ pub trait BufRead {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -97,7 +96,6 @@ pub trait BufRead {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -138,7 +136,6 @@ pub trait BufRead {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;

--- a/src/io/buf_reader.rs
+++ b/src/io/buf_reader.rs
@@ -31,7 +31,6 @@ const DEFAULT_CAPACITY: usize = 8 * 1024;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::fs::File;
@@ -60,7 +59,6 @@ impl<R: AsyncRead> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -79,7 +77,6 @@ impl<R: AsyncRead> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -117,7 +114,6 @@ impl<R> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -139,7 +135,6 @@ impl<R> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -161,7 +156,6 @@ impl<R> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -183,7 +177,6 @@ impl<R> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;

--- a/src/io/copy.rs
+++ b/src/io/copy.rs
@@ -28,7 +28,6 @@ use crate::io;
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::io;

--- a/src/io/empty.rs
+++ b/src/io/empty.rs
@@ -11,7 +11,6 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```rust
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::io;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -9,7 +9,6 @@
 //! Read a line from the standard input:
 //!
 //! ```no_run
-//! # #![feature(async_await)]
 //! # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 //! #
 //! use async_std::io;

--- a/src/io/read.rs
+++ b/src/io/read.rs
@@ -52,7 +52,6 @@ pub trait Read {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -102,7 +101,6 @@ pub trait Read {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -140,7 +138,6 @@ pub trait Read {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -193,7 +190,6 @@ pub trait Read {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;

--- a/src/io/seek.rs
+++ b/src/io/seek.rs
@@ -43,7 +43,6 @@ pub trait Seek {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;

--- a/src/io/sink.rs
+++ b/src/io/sink.rs
@@ -11,7 +11,6 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```rust
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::io;

--- a/src/io/stderr.rs
+++ b/src/io/stderr.rs
@@ -17,7 +17,6 @@ use crate::task::{blocking, Context, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::io;

--- a/src/io/stdin.rs
+++ b/src/io/stdin.rs
@@ -18,7 +18,6 @@ use crate::task::{blocking, Context, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::io;
@@ -92,7 +91,6 @@ impl Stdin {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::io;

--- a/src/io/stdout.rs
+++ b/src/io/stdout.rs
@@ -17,7 +17,6 @@ use crate::task::{blocking, Context, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::io;

--- a/src/io/timeout.rs
+++ b/src/io/timeout.rs
@@ -13,7 +13,6 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use std::time::Duration;

--- a/src/io/write.rs
+++ b/src/io/write.rs
@@ -47,7 +47,6 @@ pub trait Write {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -68,7 +67,6 @@ pub trait Write {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;
@@ -114,7 +112,6 @@ pub trait Write {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
 //! Spawn a task and block the current thread on its result:
 //!
 //! ```
-//! # #![feature(async_await)]
 //! use async_std::task;
 //!
 //! fn main() {
@@ -27,7 +26,6 @@
 //! See [here](https://github.com/async-rs/async-std/tree/master/examples)
 //! for more examples.
 
-#![feature(async_await)]
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -13,7 +13,6 @@
 //! A simple UDP echo server:
 //!
 //! ```no_run
-//! # #![feature(async_await)]
 //! # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 //! #
 //! use async_std::net::UdpSocket;

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -30,7 +30,6 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::io;
@@ -70,7 +69,6 @@ impl TcpListener {
     /// Create a TCP listener bound to 127.0.0.1:0:
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpListener;
@@ -119,7 +117,6 @@ impl TcpListener {
     /// ## Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpListener;
@@ -172,7 +169,6 @@ impl TcpListener {
     /// ## Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpListener;
@@ -200,7 +196,6 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpListener;

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -34,7 +34,6 @@ use crate::task::{Context, Poll};
 /// ## Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::net::TcpStream;
@@ -70,7 +69,6 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpStream;
@@ -155,7 +153,6 @@ impl TcpStream {
     /// ## Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpStream;
@@ -174,7 +171,6 @@ impl TcpStream {
     /// ## Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpStream;
@@ -197,7 +193,6 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpStream;
@@ -221,7 +216,6 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpStream;
@@ -248,7 +242,6 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpStream;
@@ -286,7 +279,6 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpStream;
@@ -313,7 +305,6 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::TcpStream;
@@ -339,7 +330,6 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use std::net::Shutdown;

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -29,7 +29,6 @@ use crate::task::Poll;
 /// ## Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::net::UdpSocket;
@@ -65,7 +64,6 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::UdpSocket;
@@ -114,7 +112,6 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     ///	use async_std::net::UdpSocket;
@@ -135,7 +132,6 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::UdpSocket;
@@ -188,7 +184,6 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::UdpSocket;
@@ -230,7 +225,6 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     ///	use async_std::net::UdpSocket;
@@ -265,7 +259,6 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::UdpSocket;
@@ -308,7 +301,6 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::net::UdpSocket;
@@ -442,7 +434,6 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use std::net::Ipv4Addr;
@@ -472,7 +463,6 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use std::net::{Ipv6Addr, SocketAddr};

--- a/src/os/unix/fs.rs
+++ b/src/os/unix/fs.rs
@@ -18,7 +18,6 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::os::unix::fs::symlink;

--- a/src/os/unix/net/datagram.rs
+++ b/src/os/unix/net/datagram.rs
@@ -29,7 +29,6 @@ use crate::task::{blocking, Poll};
 /// ## Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::os::unix::net::UnixDatagram;
@@ -63,7 +62,6 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
@@ -83,7 +81,6 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
@@ -104,7 +101,6 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
@@ -132,7 +128,6 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
@@ -153,7 +148,6 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
@@ -176,7 +170,6 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
@@ -198,7 +191,6 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
@@ -232,7 +224,6 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
@@ -266,7 +257,6 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
@@ -299,7 +289,6 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
@@ -336,7 +325,6 @@ impl UnixDatagram {
     /// ## Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;

--- a/src/os/unix/net/listener.rs
+++ b/src/os/unix/net/listener.rs
@@ -33,7 +33,6 @@ use crate::task::{blocking, Context, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::os::unix::net::UnixListener;
@@ -62,7 +61,6 @@ impl UnixListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixListener;
@@ -88,7 +86,6 @@ impl UnixListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixListener;
@@ -136,7 +133,6 @@ impl UnixListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixListener;
@@ -161,7 +157,6 @@ impl UnixListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixListener;

--- a/src/os/unix/net/stream.rs
+++ b/src/os/unix/net/stream.rs
@@ -26,7 +26,6 @@ use crate::task::{blocking, Context, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 /// #
 /// use async_std::os::unix::net::UnixStream;
@@ -53,7 +52,6 @@ impl UnixStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixStream;
@@ -115,7 +113,6 @@ impl UnixStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixStream;
@@ -142,7 +139,6 @@ impl UnixStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixStream;
@@ -161,7 +157,6 @@ impl UnixStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixStream;
@@ -183,7 +178,6 @@ impl UnixStream {
     /// [`Shutdown`]: https://doc.rust-lang.org/std/net/enum.Shutdown.html
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
     /// #
     /// use async_std::os::unix::net::UnixStream;

--- a/src/stream/empty.rs
+++ b/src/stream/empty.rs
@@ -8,7 +8,6 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// # fn main() { async_std::task::block_on(async {
 /// #
 /// use async_std::prelude::*;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -7,7 +7,6 @@
 //! # Examples
 //!
 //! ```
-//! # #![feature(async_await)]
 //! # fn main() { async_std::task::block_on(async {
 //! #
 //! use async_std::prelude::*;

--- a/src/stream/once.rs
+++ b/src/stream/once.rs
@@ -7,7 +7,6 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// # fn main() { async_std::task::block_on(async {
 /// #
 /// use async_std::prelude::*;

--- a/src/stream/repeat.rs
+++ b/src/stream/repeat.rs
@@ -7,7 +7,6 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// # fn main() { async_std::task::block_on(async {
 /// #
 /// use async_std::prelude::*;

--- a/src/stream/stream.rs
+++ b/src/stream/stream.rs
@@ -7,7 +7,6 @@
 //! # Examples
 //!
 //! ```
-//! # #![feature(async_await)]
 //! # fn main() { async_std::task::block_on(async {
 //! #
 //! use async_std::prelude::*;
@@ -69,7 +68,6 @@ pub trait Stream {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use async_std::prelude::*;
@@ -91,7 +89,6 @@ pub trait Stream {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use async_std::prelude::*;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -9,7 +9,6 @@
 //! Spawn a task that updates an integer protected by a mutex:
 //!
 //! ```
-//! # #![feature(async_await)]
 //! # fn main() { async_std::task::block_on(async {
 //! #
 //! use std::sync::Arc;

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -24,7 +24,6 @@ const BLOCKED: usize = 1 << 1;
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// # fn main() { async_std::task::block_on(async {
 /// #
 /// use std::sync::Arc;
@@ -83,7 +82,6 @@ impl<T> Mutex<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use std::sync::Arc;
@@ -198,7 +196,6 @@ impl<T> Mutex<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use std::sync::Arc;
@@ -252,7 +249,6 @@ impl<T> Mutex<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use async_std::sync::Mutex;

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -33,7 +33,6 @@ const READ_COUNT_MASK: usize = !(ONE_READ - 1);
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// # fn main() { async_std::task::block_on(async {
 /// #
 /// use async_std::sync::RwLock;
@@ -90,7 +89,6 @@ impl<T> RwLock<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use async_std::sync::RwLock;
@@ -213,7 +211,6 @@ impl<T> RwLock<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use async_std::sync::RwLock;
@@ -256,7 +253,6 @@ impl<T> RwLock<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use async_std::sync::RwLock;
@@ -378,7 +374,6 @@ impl<T> RwLock<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use async_std::sync::RwLock;
@@ -419,7 +414,6 @@ impl<T> RwLock<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// use async_std::sync::RwLock;
     ///
     /// let lock = RwLock::new(10);
@@ -437,7 +431,6 @@ impl<T> RwLock<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use async_std::sync::RwLock;

--- a/src/task/local.rs
+++ b/src/task/local.rs
@@ -20,7 +20,6 @@ use super::pool;
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// #
 /// use std::cell::Cell;
 ///
@@ -92,7 +91,6 @@ impl<T: Send + 'static> LocalKey<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// #
     /// use std::cell::Cell;
     ///
@@ -132,7 +130,6 @@ impl<T: Send + 'static> LocalKey<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// #
     /// use std::cell::Cell;
     ///

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -10,7 +10,6 @@
 //! Spawn a task and await its result:
 //!
 //! ```
-//! # #![feature(async_await)]
 //! # fn main() { async_std::task::block_on(async {
 //! #
 //! use async_std::task;

--- a/src/task/pool.rs
+++ b/src/task/pool.rs
@@ -29,7 +29,6 @@ use crate::io;
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// # fn main() { async_std::task::block_on(async {
 /// #
 /// use async_std::task;
@@ -51,7 +50,6 @@ pub fn current() -> Task {
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// # fn main() { async_std::task::block_on(async {
 /// #
 /// use async_std::task;
@@ -83,7 +81,6 @@ where
 /// # Examples
 ///
 /// ```no_run
-/// # #![feature(async_await)]
 /// use async_std::task;
 ///
 /// fn main() {

--- a/src/task/sleep.rs
+++ b/src/task/sleep.rs
@@ -14,7 +14,6 @@ use crate::io;
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// # fn main() { async_std::task::block_on(async {
 /// #
 /// use std::time::Duration;

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -65,7 +65,6 @@ impl<T> JoinHandle<T> {
     /// # Examples
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use async_std::task;
@@ -98,7 +97,6 @@ impl<T> Future for JoinHandle<T> {
 /// # Examples
 ///
 /// ```
-/// # #![feature(async_await)]
 /// #
 /// use async_std::task;
 ///

--- a/tests/block_on.rs
+++ b/tests/block_on.rs
@@ -1,5 +1,3 @@
-#![feature(async_await)]
-
 use async_std::task;
 
 #[test]

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -1,5 +1,3 @@
-#![feature(async_await)]
-
 use std::sync::Arc;
 
 use async_std::prelude::*;

--- a/tests/rwlock.rs
+++ b/tests/rwlock.rs
@@ -1,5 +1,3 @@
-#![feature(async_await)]
-
 use std::cell::Cell;
 use std::num::Wrapping;
 use std::pin::Pin;

--- a/tests/task_local.rs
+++ b/tests/task_local.rs
@@ -1,5 +1,3 @@
-#![feature(async_await)]
-
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_std::task;

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,5 +1,3 @@
-#![feature(async_await)]
-
 use async_std::io;
 use async_std::net::{TcpListener, TcpStream};
 use async_std::prelude::*;

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -1,5 +1,3 @@
-#![feature(async_await)]
-
 use async_std::io;
 use async_std::net::UdpSocket;
 use async_std::task;

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -1,5 +1,4 @@
 #![cfg(unix)]
-#![feature(async_await)]
 
 use async_std::io;
 use async_std::os::unix::net::UnixDatagram;


### PR DESCRIPTION
Removes the `async_await` feature gate, due to land in tomorrow's nightly (ref https://github.com/rust-lang/rust/pull/63209#issuecomment-523219271). Thanks!

## Code used to remove feature gate
```shell
#!/bin/sh

files="$(fd .rs)"

for f in $files; do
  sed -i '/async_await/d' "$f"
done

cargo fmt -- --edition 2018
```