### PR TITLE
[docs] clearer variable name for broker_handle

### DIFF
--- a/docs/src/tutorial/clean_shutdown.md
+++ b/docs/src/tutorial/clean_shutdown.md
@@ -25,7 +25,7 @@ async fn server(addr: impl ToSocketAddrs) -> Result<()> {
     let listener = TcpListener::bind(addr).await?;
 
     let (broker_sender, broker_receiver) = mpsc::unbounded();
-    let broker = task::spawn(broker(broker_receiver));
+    let broker_handle = task::spawn(broker(broker_receiver));
     let mut incoming = listener.incoming();
     while let Some(stream) = incoming.next().await {
         let stream = stream?;
@@ -33,7 +33,7 @@ async fn server(addr: impl ToSocketAddrs) -> Result<()> {
         spawn_and_log_error(client(broker_sender.clone(), stream));
     }
     drop(broker_sender); // 1
-    broker.await?; // 5
+    broker_handle.await?; // 5
     Ok(())
 }
 ```

--- a/docs/src/tutorial/handling_disconnection.md
+++ b/docs/src/tutorial/handling_disconnection.md
@@ -130,7 +130,7 @@ async fn server(addr: impl ToSocketAddrs) -> Result<()> {
     let listener = TcpListener::bind(addr).await?;
 
     let (broker_sender, broker_receiver) = mpsc::unbounded();
-    let broker = task::spawn(broker(broker_receiver));
+    let broker_handle = task::spawn(broker(broker_receiver));
     let mut incoming = listener.incoming();
     while let Some(stream) = incoming.next().await {
         let stream = stream?;
@@ -138,7 +138,7 @@ async fn server(addr: impl ToSocketAddrs) -> Result<()> {
         spawn_and_log_error(client(broker_sender.clone(), stream));
     }
     drop(broker_sender);
-    broker.await;
+    broker_handle.await;
     Ok(())
 }
 


### PR DESCRIPTION
- use `broker_handle` as a variable name to avoid overloading the `broker` function
- ~~keep the `Result` from `client_writer` in `writers` (makes the loop with `writer.await?;` work correctly)~~
- ~~return `Result` from `brokers` in the final code example~~