### PR TITLE
Restore Version Sort

### DIFF
--- a/ci/install-mdbook.sh
+++ b/ci/install-mdbook.sh
@@ -9,7 +9,7 @@ main() {
                     https://github.com/rust-lang-nursery/mdbook \
                         | cut -d/ -f3 \
                         | grep -E '^v0\.3\.[0-9]+$' \
-                        | sort \
+                        | sort --version-sort \
                         | tail -n1)
 
     curl -LSfs https://japaric.github.io/trust/install.sh | \


### PR DESCRIPTION
Since we only build the book on Linux for now, restore the `--version-sort` flag for gnu sort. This makes me feel better that when sorting numbering oddities (e.g. multiple digits) will be handled correctly.

This was removed when I was trying to get this script to work on Windows and OSX, which is no longer relevant.