### PR TITLE
add future::poll_fn

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -4,7 +4,9 @@
 pub use std::future::Future;
 
 pub use pending::pending;
+pub use poll_fn::poll_fn;
 pub use ready::ready;
 
 mod pending;
+mod poll_fn;
 mod ready;

--- a/src/future/poll_fn.rs
+++ b/src/future/poll_fn.rs
@@ -1,6 +1,5 @@
 //! Definition of the `PollFn` adapter combinator
 
-use core::fmt;
 use core::pin::Pin;
 use std::future::Future;
 use std::task::{Context, Poll};
@@ -30,19 +29,13 @@ impl<F> Unpin for PollFn<F> {}
 /// }
 ///
 /// let read_future = poll_fn(read_line);
-/// assert_eq!(read_future.await, "Hello, World!".to_owned());
+/// assert_eq!(read_future.await, "Hello, World!");
 /// #
 /// # }) }
 /// ```
 pub async fn poll_fn<T>(f: impl FnMut(&mut Context<'_>) -> Poll<T>) -> T {
     let fut = PollFn { f };
     fut.await
-}
-
-impl<F> fmt::Debug for PollFn<F> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PollFn").finish()
-    }
 }
 
 impl<T, F> Future for PollFn<F>

--- a/src/future/poll_fn.rs
+++ b/src/future/poll_fn.rs
@@ -1,0 +1,57 @@
+//! Definition of the `PollFn` adapter combinator
+
+use core::fmt;
+use core::pin::Pin;
+use std::future::Future;
+use std::task::{Context, Poll};
+
+/// Future for the [`poll_fn`] function.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+struct PollFn<F> {
+    f: F,
+}
+
+impl<F> Unpin for PollFn<F> {}
+
+/// Creates a new future wrapping around a function returning `Poll`.
+///
+/// Polling the returned future delegates to the wrapped function.
+///
+/// # Examples
+///
+/// ```
+/// # fn main() { async_std::task::block_on(async {
+/// #
+/// use async_std::future::poll_fn;
+/// use async_std::task::{Context, Poll};
+///
+/// fn read_line(_cx: &mut Context<'_>) -> Poll<String> {
+///     Poll::Ready("Hello, World!".into())
+/// }
+///
+/// let read_future = poll_fn(read_line);
+/// assert_eq!(read_future.await, "Hello, World!".to_owned());
+/// #
+/// # }) }
+/// ```
+pub async fn poll_fn<T>(f: impl FnMut(&mut Context<'_>) -> Poll<T>) -> T {
+    let fut = PollFn { f };
+    fut.await
+}
+
+impl<F> fmt::Debug for PollFn<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PollFn").finish()
+    }
+}
+
+impl<T, F> Future for PollFn<F>
+where
+    F: FnMut(&mut Context<'_>) -> Poll<T>,
+{
+    type Output = T;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
+        (&mut self.f)(cx)
+    }
+}


### PR DESCRIPTION
This adds `futures::poll_fn`, which is fairly common and useful when defining custom futures. This seems like a generally useful, and easy addition to the futures submodule. Thanks!

## Ref
- https://docs.rs/futures-preview/0.3.0-alpha.18/futures/future/fn.poll_fn.html