### PR TITLE
from/into stream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod prelude;
 pub mod stream;
 pub mod sync;
 pub mod task;
+mod vec;
 
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[cfg(feature = "unstable")]

--- a/src/stream/from_stream.rs
+++ b/src/stream/from_stream.rs
@@ -10,6 +10,7 @@ use std::pin::Pin;
 /// See also: [`IntoStream`].
 ///
 /// [`IntoStream`]: trait.IntoStream.html
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 pub trait FromStream<T: Send> {
     /// Creates a value from a stream.
     ///

--- a/src/stream/from_stream.rs
+++ b/src/stream/from_stream.rs
@@ -10,7 +10,7 @@ use std::pin::Pin;
 /// See also: [`IntoStream`].
 ///
 /// [`IntoStream`]: trait.IntoStream.html
-pub trait FromStream<T> {
+pub trait FromStream<T: Send> {
     /// Creates a value from a stream.
     ///
     /// # Examples
@@ -22,7 +22,7 @@ pub trait FromStream<T> {
     ///
     /// // let _five_fives = async_std::stream::repeat(5).take(5);
     /// ```
-    fn from_stream<'a, S: IntoStream<Item = T> + 'a>(
+    fn from_stream<'a, S: IntoStream<Item = T> + Send + 'a>(
         stream: S,
-    ) -> Pin<Box<dyn core::future::Future<Output = Self> + 'a>>;
+    ) -> Pin<Box<dyn core::future::Future<Output = Self> + Send + 'a>>;
 }

--- a/src/stream/from_stream.rs
+++ b/src/stream/from_stream.rs
@@ -1,0 +1,28 @@
+use super::IntoStream;
+
+use std::pin::Pin;
+
+/// Conversion from a `Stream`.
+///
+/// By implementing `FromStream` for a type, you define how it will be created from a stream.
+/// This is common for types which describe a collection of some kind.
+///
+/// See also: [`IntoStream`].
+///
+/// [`IntoStream`]: trait.IntoStream.html
+pub trait FromStream<T> {
+    /// Creates a value from a stream.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// // use async_std::stream::FromStream;
+    ///
+    /// // let _five_fives = async_std::stream::repeat(5).take(5);
+    /// ```
+    fn from_stream<'a, S: IntoStream<Item = T> + 'a>(
+        stream: S,
+    ) -> Pin<Box<dyn core::future::Future<Output = Self> + 'a>>;
+}

--- a/src/stream/into_stream.rs
+++ b/src/stream/into_stream.rs
@@ -18,13 +18,13 @@ pub trait IntoStream {
     type Item;
 
     /// Which kind of stream are we turning this into?
-    type IntoStream: Stream<Item = Self::Item>;
+    type IntoStream: Stream<Item = Self::Item> + Send;
 
     /// Creates a stream from a value.
     fn into_stream(self) -> Self::IntoStream;
 }
 
-impl<I: Stream> IntoStream for I {
+impl<I: Stream + Send> IntoStream for I {
     type Item = I::Item;
     type IntoStream = I;
 

--- a/src/stream/into_stream.rs
+++ b/src/stream/into_stream.rs
@@ -1,0 +1,35 @@
+use futures_core::stream::Stream;
+
+/// Conversion into a `Stream`.
+///
+/// By implementing `IntoIterator` for a type, you define how it will be
+/// converted to an iterator. This is common for types which describe a
+/// collection of some kind.
+///
+/// [`from_stream`]: #tymethod.from_stream
+/// [`Stream`]: trait.Stream.html
+/// [`collect`]: trait.Stream.html#method.collect
+///
+/// See also: [`FromStream`].
+///
+/// [`FromStream`]: trait.FromStream.html
+pub trait IntoStream {
+    /// The type of the elements being iterated over.
+    type Item;
+
+    /// Which kind of stream are we turning this into?
+    type IntoStream: Stream<Item = Self::Item>;
+
+    /// Creates a stream from a value.
+    fn into_stream(self) -> Self::IntoStream;
+}
+
+impl<I: Stream> IntoStream for I {
+    type Item = I::Item;
+    type IntoStream = I;
+
+    #[inline]
+    fn into_stream(self) -> I {
+        self
+    }
+}

--- a/src/stream/into_stream.rs
+++ b/src/stream/into_stream.rs
@@ -13,6 +13,7 @@ use futures_core::stream::Stream;
 /// See also: [`FromStream`].
 ///
 /// [`FromStream`]: trait.FromStream.html
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 pub trait IntoStream {
     /// The type of the elements being iterated over.
     type Item;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -23,12 +23,16 @@
 
 pub use double_ended_stream::DoubleEndedStream;
 pub use empty::{empty, Empty};
+pub use from_stream::FromStream;
+pub use into_stream::IntoStream;
 pub use once::{once, Once};
 pub use repeat::{repeat, Repeat};
 pub use stream::{Scan, Stream, Take, Zip};
 
 mod double_ended_stream;
 mod empty;
+mod from_stream;
+mod into_stream;
 mod once;
 mod repeat;
 mod stream;

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -91,7 +91,7 @@ cfg_if! {
         }
     } else {
         macro_rules! dyn_ret {
-            ($a:lifetime, $o:ty) => (Pin<Box<dyn core::future::Future<Output = $o> + 'a>>)
+            ($a:lifetime, $o:ty) => (Pin<Box<dyn core::future::Future<Output = $o> + Send + 'a>>)
         }
     }
 }
@@ -544,6 +544,7 @@ pub trait Stream {
     ///
     /// Basic usage:
     ///
+    /// ```
     /// # fn main() { async_std::task::block_on(async {
     /// #
     /// use async_std::prelude::*;
@@ -551,7 +552,6 @@ pub trait Stream {
     ///
     /// let mut s = stream::repeat::<u32>(42).take(3);
     /// assert!(s.any(|x| x ==  42).await);
-    ///
     /// #
     /// # }) }
     /// ```
@@ -704,7 +704,8 @@ pub trait Stream {
     #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead (TODO)"]
     fn collect<'a, B>(self) -> dyn_ret!('a, B)
     where
-        Self: futures_core::stream::Stream + Sized + 'a,
+        Self: futures_core::stream::Stream + Sized + Send + 'a,
+        <Self as futures_core::stream::Stream>::Item: Send,
         B: FromStream<<Self as futures_core::stream::Stream>::Item>,
     {
         FromStream::from_stream(self)

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -54,6 +54,7 @@ use super::from_stream::FromStream;
 use std::cmp::Ordering;
 use std::marker::PhantomData;
 use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use cfg_if::cfg_if;
 

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -51,8 +51,6 @@ use next::NextFuture;
 use nth::NthFuture;
 
 use super::from_stream::FromStream;
-use crate::future::Future;
-use crate::task::{Context, Poll};
 use std::cmp::Ordering;
 use std::marker::PhantomData;
 use std::pin::Pin;

--- a/src/vec/from_stream.rs
+++ b/src/vec/from_stream.rs
@@ -1,0 +1,25 @@
+use crate::stream::{FromStream, IntoStream, Stream};
+
+use std::pin::Pin;
+
+impl<T> FromStream<T> for Vec<T> {
+    #[inline]
+    fn from_stream<'a, S: IntoStream<Item = T>>(
+        stream: S,
+    ) -> Pin<Box<dyn core::future::Future<Output = Self> + 'a>>
+    where
+        <S as IntoStream>::IntoStream: 'a,
+    {
+        let stream = stream.into_stream();
+
+        Pin::from(Box::new(async move {
+            pin_utils::pin_mut!(stream);
+
+            let mut out = vec![];
+            while let Some(item) = stream.next().await {
+                out.push(item);
+            }
+            out
+        }))
+    }
+}

--- a/src/vec/from_stream.rs
+++ b/src/vec/from_stream.rs
@@ -2,13 +2,13 @@ use crate::stream::{FromStream, IntoStream, Stream};
 
 use std::pin::Pin;
 
-impl<T> FromStream<T> for Vec<T> {
+impl<T: Send> FromStream<T> for Vec<T> {
     #[inline]
     fn from_stream<'a, S: IntoStream<Item = T>>(
         stream: S,
-    ) -> Pin<Box<dyn core::future::Future<Output = Self> + 'a>>
+    ) -> Pin<Box<dyn core::future::Future<Output = Self> + Send + 'a>>
     where
-        <S as IntoStream>::IntoStream: 'a,
+        <S as IntoStream>::IntoStream: Send + 'a,
     {
         let stream = stream.into_stream();
 

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -1,0 +1,9 @@
+//! The Rust core allocation and collections library
+//!
+//! This library provides smart pointers and collections for managing
+//! heap-allocated values.
+
+mod from_stream;
+
+#[doc(inline)]
+pub use std::vec::Vec;


### PR DESCRIPTION
This adds `Stream` counterparts to `FromIterator`, `IntoIterator` and `Iterator::collect`, allowing to use the same patterns that are common in streams. Thanks!

## Tasks
- [x]  `FromStream`
- [x] `IntoStream`
- [x] `Stream::collect`

## Screenshot
![Screenshot_2019-08-29 async_std stream - Rust](https://user-images.githubusercontent.com/2467194/63928985-ec2bd200-ca50-11e9-868c-9899800e5b83.png)