### PR TITLE
expose `task::ready!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ docs = []
 unstable = []
 
 [dependencies]
+async-macros = "1.0.0"
 async-task = "1.0.0"
 cfg-if = "0.1.9"
 crossbeam-channel = "0.3.9"

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -5,6 +5,10 @@ pub use std::future::Future;
 
 use cfg_if::cfg_if;
 
+// Re-export the `ready!` definition from an external crate to expose it from
+// this submodule.
+pub use futures::ready;
+
 pub use pending::pending;
 pub use poll_fn::poll_fn;
 pub use ready::ready;

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -5,10 +5,6 @@ pub use std::future::Future;
 
 use cfg_if::cfg_if;
 
-// Re-export the `ready!` definition from an external crate to expose it from
-// this submodule.
-pub use futures::ready;
-
 pub use pending::pending;
 pub use poll_fn::poll_fn;
 pub use ready::ready;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -24,6 +24,8 @@
 #[doc(inline)]
 pub use std::task::{Context, Poll, Waker};
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[doc(inline)]
 pub use async_macros::ready;
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -24,11 +24,10 @@
 #[doc(inline)]
 pub use std::task::{Context, Poll, Waker};
 
-pub use block_on::block_on;
-// Re-export the `ready!` definition from an external crate to expose it from
-// this submodule.
-pub use futures_core::ready;
+#[doc(inline)]
+pub use async_macros::ready;
 
+pub use block_on::block_on;
 pub use local::{AccessError, LocalKey};
 pub use pool::{current, spawn, Builder};
 pub use sleep::sleep;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -25,6 +25,10 @@
 pub use std::task::{Context, Poll, Waker};
 
 pub use block_on::block_on;
+// Re-export the `ready!` definition from an external crate to expose it from
+// this submodule.
+pub use futures_core::ready;
+
 pub use local::{AccessError, LocalKey};
 pub use pool::{current, spawn, Builder};
 pub use sleep::sleep;


### PR DESCRIPTION
Export `async_std::task::ready!`. Thanks!

![Screenshot_2019-08-30 async_std task - Rust](https://user-images.githubusercontent.com/2467194/64046886-694c6980-cb6d-11e9-8602-443213436eef.png)

