### PR TITLE
Change task counter AtomicU64 to AtomicU32

### DIFF
--- a/src/task/blocking.rs
+++ b/src/task/blocking.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::thread;
 use std::time::Duration;
 
@@ -13,9 +13,9 @@ use crate::future::Future;
 use crate::task::{Context, Poll};
 use crate::utils::abort_on_panic;
 
-const MAX_THREADS: u64 = 10_000;
+const MAX_THREADS: u32 = 10_000;
 
-static DYNAMIC_THREAD_COUNT: AtomicU64 = AtomicU64::new(0);
+static DYNAMIC_THREAD_COUNT: AtomicU32 = AtomicU32::new(0);
 
 struct Pool {
     sender: Sender<async_task::Task<()>>,

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -1,9 +1,9 @@
 use std::fmt;
-use std::i64;
+use std::i32;
 use std::mem;
-use std::num::NonZeroU64;
+use std::num::NonZeroU32;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use super::local;
@@ -105,22 +105,22 @@ impl<T> Future for JoinHandle<T> {
 /// })
 /// ```
 #[derive(Eq, PartialEq, Clone, Copy, Hash, Debug)]
-pub struct TaskId(NonZeroU64);
+pub struct TaskId(NonZeroU32);
 
 impl TaskId {
     pub(crate) fn new() -> TaskId {
-        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        static COUNTER: AtomicU32 = AtomicU32::new(1);
 
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
 
-        if id > i64::MAX as u64 {
+        if id > i32::MAX as u32 {
             std::process::abort();
         }
-        unsafe { TaskId(NonZeroU64::new_unchecked(id)) }
+        unsafe { TaskId(NonZeroU32::new_unchecked(id)) }
     }
 
     pub(crate) fn as_u64(&self) -> u64 {
-        self.0.get()
+        self.0.get() as u64
     }
 }
 


### PR DESCRIPTION
cross compile with mipsel-unknown-linux-uclibc(32bit) error:
```shell
root@8bc5bd79cb06:/opt/liukai/rust/async-t# xargo build --target mipsel-unknown-linux-uclibc --release
   Compiling async-std v0.99.4
error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
 --> /root/.cargo/registry/src/mirrors.ustc.edu.cn-61ef6e0cd06fb9b8/async-std-0.99.4/src/task/task.rs:6:25
  |
6 | use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
  |                         ^^^^^^^^^
  |                         |
  |                         no `AtomicU64` in `sync::atomic`
  |                         help: a similar name exists in the module: `AtomicU16`

error[E0432]: unresolved import `std::sync::atomic::AtomicU64`
 --> /root/.cargo/registry/src/mirrors.ustc.edu.cn-61ef6e0cd06fb9b8/async-std-0.99.4/src/task/blocking.rs:5:25
  |
5 | use std::sync::atomic::{AtomicU64, Ordering};
  |                         ^^^^^^^^^
  |                         |
  |                         no `AtomicU64` in `sync::atomic`
  |                         help: a similar name exists in the module: `AtomicU16`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0432`.
error: Could not compile `async-std`.

To learn more, run the command again with --verbose.
```