### PR TITLE
Add Stream::poll_next

### DIFF
--- a/src/stream/stream/all.rs
+++ b/src/stream/stream/all.rs
@@ -1,43 +1,36 @@
-use crate::future::Future;
-use crate::task::{Context, Poll};
-
 use std::marker::PhantomData;
 use std::pin::Pin;
 
-#[derive(Debug)]
-pub struct AllFuture<'a, S, F, T>
-where
-    F: FnMut(T) -> bool,
-{
+use crate::future::Future;
+use crate::stream::Stream;
+use crate::task::{Context, Poll};
+
+#[doc(hidden)]
+#[allow(missing_debug_implementations)]
+pub struct AllFuture<'a, S, F, T> {
     pub(crate) stream: &'a mut S,
     pub(crate) f: F,
     pub(crate) result: bool,
-    pub(crate) __item: PhantomData<T>,
+    pub(crate) _marker: PhantomData<T>,
 }
 
-impl<'a, S, F, T> AllFuture<'a, S, F, T>
-where
-    F: FnMut(T) -> bool,
-{
-    pin_utils::unsafe_pinned!(stream: &'a mut S);
-    pin_utils::unsafe_unpinned!(result: bool);
-    pin_utils::unsafe_unpinned!(f: F);
-}
+impl<S: Unpin, F, T> Unpin for AllFuture<'_, S, F, T> {}
 
 impl<S, F> Future for AllFuture<'_, S, F, S::Item>
 where
-    S: futures_core::stream::Stream + Unpin + Sized,
+    S: Stream + Unpin + Sized,
     F: FnMut(S::Item) -> bool,
 {
     type Output = bool;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        use futures_core::stream::Stream;
-        let next = futures_core::ready!(self.as_mut().stream().poll_next(cx));
+        let next = futures_core::ready!(Pin::new(&mut *self.stream).poll_next(cx));
+
         match next {
             Some(v) => {
-                let result = (self.as_mut().f())(v);
-                *self.as_mut().result() = result;
+                let result = (&mut self.f)(v);
+                self.result = result;
+
                 if result {
                     // don't forget to wake this task again to pull the next item from stream
                     cx.waker().wake_by_ref();

--- a/src/stream/stream/min_by.rs
+++ b/src/stream/stream/min_by.rs
@@ -6,7 +6,8 @@ use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
 /// A future that yields the minimum item in a stream by a given comparison function.
-#[derive(Clone, Debug)]
+#[doc(hidden)]
+#[allow(missing_debug_implementations)]
 pub struct MinByFuture<S: Stream, F> {
     stream: S,
     compare: F,
@@ -27,7 +28,7 @@ impl<S: Stream + Unpin, F> MinByFuture<S, F> {
 
 impl<S, F> Future for MinByFuture<S, F>
 where
-    S: futures_core::stream::Stream + Unpin,
+    S: Stream + Unpin,
     S::Item: Copy,
     F: FnMut(&S::Item, &S::Item) -> Ordering,
 {

--- a/src/stream/stream/next.rs
+++ b/src/stream/stream/next.rs
@@ -1,6 +1,8 @@
-use crate::future::Future;
-use crate::task::{Context, Poll};
 use std::pin::Pin;
+
+use crate::future::Future;
+use crate::stream::Stream;
+use crate::task::{Context, Poll};
 
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]
@@ -8,7 +10,7 @@ pub struct NextFuture<'a, T: Unpin + ?Sized> {
     pub(crate) stream: &'a mut T,
 }
 
-impl<T: futures_core::stream::Stream + Unpin + ?Sized> Future for NextFuture<'_, T> {
+impl<T: Stream + Unpin + ?Sized> Future for NextFuture<'_, T> {
     type Output = Option<T::Item>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/stream/stream/take.rs
+++ b/src/stream/stream/take.rs
@@ -1,6 +1,7 @@
-use crate::task::{Context, Poll};
-
 use std::pin::Pin;
+
+use crate::stream::Stream;
+use crate::task::{Context, Poll};
 
 /// A stream that yields the first `n` items of another stream.
 #[derive(Clone, Debug)]
@@ -11,12 +12,12 @@ pub struct Take<S> {
 
 impl<S: Unpin> Unpin for Take<S> {}
 
-impl<S: futures_core::stream::Stream> Take<S> {
+impl<S: Stream> Take<S> {
     pin_utils::unsafe_pinned!(stream: S);
     pin_utils::unsafe_unpinned!(remaining: usize);
 }
 
-impl<S: futures_core::stream::Stream> futures_core::stream::Stream for Take<S> {
+impl<S: Stream> futures_core::stream::Stream for Take<S> {
     type Item = S::Item;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<S::Item>> {


### PR DESCRIPTION
Adding `poll_next` to the `Stream` trait will simplify #125.

After a discussion with @yoshuawuyts and @withoutboats, we became confident that the `Stream` trait of the future will never solely rely on `async fn next()` and will always have to rely on `fn poll_next()`.

This PR now makes our `Stream` trait implementable by end users.

I also made a few adjustments around pinning to `all()` and `any()` combinators since they take a `&mut self`, which implies `Self: Unpin`. A rule of thumb is that if a method takes a `&mut self` and then pins `self`, we *have to* require `Self: Unpin`.