### PR TITLE
add io::prelude

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -20,6 +20,8 @@
 //! # Ok(()) }) }
 //! ```
 
+pub mod prelude;
+
 #[doc(inline)]
 pub use std::io::{Error, ErrorKind, Result, SeekFrom};
 

--- a/src/io/prelude.rs
+++ b/src/io/prelude.rs
@@ -1,4 +1,4 @@
-//! The I/O Prelude
+//! The async I/O Prelude
 //!
 //! The purpose of this module is to alleviate imports of many common I/O traits
 //! by adding a glob import to the top of I/O heavy modules:
@@ -8,4 +8,11 @@
 //! use async_std::io::prelude::*;
 //! ```
 
-pub use super::{BufRead, Read, Seek, Write};
+#[doc(no_inline)]
+pub use super::BufRead as _;
+#[doc(no_inline)]
+pub use super::Read as _;
+#[doc(no_inline)]
+pub use super::Seek as _;
+#[doc(no_inline)]
+pub use super::Write as _;

--- a/src/io/prelude.rs
+++ b/src/io/prelude.rs
@@ -1,0 +1,11 @@
+//! The I/O Prelude
+//!
+//! The purpose of this module is to alleviate imports of many common I/O traits
+//! by adding a glob import to the top of I/O heavy modules:
+//!
+//! ```
+//! # #![allow(unused_imports)]
+//! use async_std::io::prelude::*;
+//! ```
+
+pub use super::{BufRead, Read, Seek, Write};


### PR DESCRIPTION
I was working on some async io code earlier, and ended up writing:
```rust
    use async_std::io::{BufReader, BufRead, Read};
```

It took a bit of trial and error to get the right traits in scope, and I kind of wished I had `io::prelude` available so it would *just work*. Which is why this patch adds `io::prelude`. I guess I'm kind of circling back on the idea of only having a single prelude; but overall I think this feels more intuitive. Thanks!

## Screenshots
![Screenshot_2019-09-08 async_std io - Rust](https://user-images.githubusercontent.com/2467194/64481454-8e2f8500-d1dc-11e9-9299-7a82b7dbb031.png)
![Screenshot_2019-09-08 async_std io prelude - Rust](https://user-images.githubusercontent.com/2467194/64481455-8e2f8500-d1dc-11e9-9d20-1e90fabccaf4.png)
![Screenshot_2019-09-08 std io prelude - Rust](https://user-images.githubusercontent.com/2467194/64481509-bfa85080-d1dc-11e9-9965-be7d0d84b551.png)

