### PR TITLE
fixes to stream::min_by

### DIFF
--- a/src/stream/stream/min_by.rs
+++ b/src/stream/stream/min_by.rs
@@ -16,9 +16,7 @@ impl<S, F, T> MinByFuture<S, F, T> {
     pin_utils::unsafe_pinned!(stream: S);
     pin_utils::unsafe_unpinned!(compare: F);
     pin_utils::unsafe_unpinned!(min: Option<T>);
-}
 
-impl<S, F, T> MinByFuture<S, F, T> {
     pub(super) fn new(stream: S, compare: F) -> Self {
         MinByFuture {
             stream,

--- a/src/stream/stream/min_by.rs
+++ b/src/stream/stream/min_by.rs
@@ -4,8 +4,7 @@ use std::pin::Pin;
 use crate::future::Future;
 use crate::task::{Context, Poll};
 
-/// A future that yields the minimum item in a stream by a given comparison function.
-#[derive(Debug)]
+#[allow(missing_debug_implementations)]
 pub struct MinByFuture<S, F, T> {
     stream: S,
     compare: F,

--- a/src/stream/stream/min_by.rs
+++ b/src/stream/stream/min_by.rs
@@ -2,20 +2,23 @@ use std::cmp::Ordering;
 use std::pin::Pin;
 
 use crate::future::Future;
-use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
 /// A future that yields the minimum item in a stream by a given comparison function.
-#[derive(Clone, Debug)]
-pub struct MinByFuture<S: Stream, F> {
+#[derive(Debug)]
+pub struct MinByFuture<S, F, T> {
     stream: S,
     compare: F,
-    min: Option<S::Item>,
+    min: Option<T>,
 }
 
-impl<S: Stream + Unpin, F> Unpin for MinByFuture<S, F> {}
+impl<S, F, T> MinByFuture<S, F, T> {
+    pin_utils::unsafe_pinned!(stream: S);
+    pin_utils::unsafe_unpinned!(compare: F);
+    pin_utils::unsafe_unpinned!(min: Option<T>);
+}
 
-impl<S: Stream + Unpin, F> MinByFuture<S, F> {
+impl<S, F, T> MinByFuture<S, F, T> {
     pub(super) fn new(stream: S, compare: F) -> Self {
         MinByFuture {
             stream,
@@ -25,25 +28,25 @@ impl<S: Stream + Unpin, F> MinByFuture<S, F> {
     }
 }
 
-impl<S, F> Future for MinByFuture<S, F>
+impl<S, F> Future for MinByFuture<S, F, S::Item>
 where
-    S: futures_core::stream::Stream + Unpin,
+    S: futures_core::stream::Stream + Unpin + Sized,
     S::Item: Copy,
     F: FnMut(&S::Item, &S::Item) -> Ordering,
 {
     type Output = Option<S::Item>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let next = futures_core::ready!(Pin::new(&mut self.stream).poll_next(cx));
+        let next = futures_core::ready!(self.as_mut().stream().poll_next(cx));
 
         match next {
             Some(new) => {
                 cx.waker().wake_by_ref();
-                match self.as_mut().min.take() {
-                    None => self.as_mut().min = Some(new),
-                    Some(old) => match (&mut self.as_mut().compare)(&new, &old) {
-                        Ordering::Less => self.as_mut().min = Some(new),
-                        _ => self.as_mut().min = Some(old),
+                match self.as_mut().min().take() {
+                    None => *self.as_mut().min() = Some(new),
+                    Some(old) => match (&mut self.as_mut().compare())(&new, &old) {
+                        Ordering::Less => *self.as_mut().min() = Some(new),
+                        _ => *self.as_mut().min() = Some(old),
                     },
                 }
                 Poll::Pending

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -153,9 +153,9 @@ pub trait Stream {
     /// #
     /// # }) }
     /// ```
-    fn min_by<F>(self, compare: F) -> MinByFuture<Self, F>
+    fn min_by<F>(self, compare: F) -> MinByFuture<Self, F, Self::Item>
     where
-        Self: Sized + Unpin,
+        Self: Sized,
         F: FnMut(&Self::Item, &Self::Item) -> Ordering,
     {
         MinByFuture::new(self, compare)


### PR DESCRIPTION
1. `min_by` should not have a `Self: Unpin` bound.
2. uses `unsafe_pinned` instead of an `Unpin` bound in the `impl`s.
3. leaves `waker().wake_by_ref()` line in place since here we are returning `Poll::Pending` upon receiving new elements from the `inner` stream and need to re-schedule ourselves to receive new elements (as in `AllFuture`)
4. It's not clear at the moment how `ret!` macro should be used for returning types without explicit lifetimes. That's the case for `Take` and `MinByFuture`.
