### PR TITLE
Add BufRead::consume

### DIFF
--- a/src/io/buf_read/mod.rs
+++ b/src/io/buf_read/mod.rs
@@ -43,6 +43,12 @@ cfg_if! {
 /// [`futures::io::AsyncBufRead`]:
 /// https://docs.rs/futures-preview/0.3.0-alpha.17/futures/io/trait.AsyncBufRead.html
 pub trait BufRead {
+    /// Tells this buffer that `amt` bytes have been consumed from the buffer, so they should no
+    /// longer be returned in calls to `read`.
+    fn consume(&mut self, amt: usize)
+    where
+        Self: Unpin;
+
     /// Returns the contents of the internal buffer, filling it with more data from the inner
     /// reader if it is empty.
     ///
@@ -61,15 +67,6 @@ pub trait BufRead {
         Self: Unpin,
     {
         FillBufFuture::new(self)
-    }
-
-    /// Tells this buffer that `amt` bytes have been consumed from the buffer, so they should no
-    /// longer be returned in calls to `read`.
-    fn consume(&mut self, amt: usize)
-    where
-        Self: AsyncBufRead + Unpin,
-    {
-        AsyncBufRead::consume(Pin::new(self), amt)
     }
 
     /// Reads all bytes into `buf` until the delimiter `byte` or EOF is reached.
@@ -226,7 +223,11 @@ pub trait BufRead {
     }
 }
 
-impl<T: AsyncBufRead + Unpin + ?Sized> BufRead for T {}
+impl<T: AsyncBufRead + Unpin + ?Sized> BufRead for T {
+    fn consume(&mut self, amt: usize) {
+        AsyncBufRead::consume(Pin::new(self), amt)
+    }
+}
 
 pub fn read_until_internal<R: AsyncBufRead + ?Sized>(
     mut reader: Pin<&mut R>,

--- a/src/io/buf_read/mod.rs
+++ b/src/io/buf_read/mod.rs
@@ -63,6 +63,15 @@ pub trait BufRead {
         FillBufFuture::new(self)
     }
 
+    /// Tells this buffer that `amt` bytes have been consumed from the buffer, so they should no
+    /// longer be returned in calls to `read`.
+    fn consume(&mut self, amt: usize)
+    where
+        Self: AsyncBufRead + Unpin,
+    {
+        AsyncBufRead::consume(Pin::new(self), amt)
+    }
+
     /// Reads all bytes into `buf` until the delimiter `byte` or EOF is reached.
     ///
     /// This function will read bytes from the underlying stream until the delimiter or EOF is


### PR DESCRIPTION
Ref #131. This implements `BufReader::consume`. Thanks!


Note on `fill_buf`: I couldn't get the `async fn fill_buf()` to work, but tracked progress for it here: https://gist.github.com/yoshuawuyts/09bbdc7823225ca96b5e35cd1da5d581. Got some lifetimes isssues. If anyone wants to give this a shot, please do!