### PR TITLE
add future::{join,try_join,select,try_select} macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ docs = []
 unstable = []
 
 [dependencies]
-async-macros = { path = "../async-macros" }
+async-macros = "1.0.0"
 async-task = "1.0.0"
 cfg-if = "0.1.9"
 crossbeam-channel = "0.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ docs = []
 unstable = []
 
 [dependencies]
+async-macros = { path = "../async-macros" }
 async-task = "1.0.0"
 cfg-if = "0.1.9"
 crossbeam-channel = "0.3.9"

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -3,6 +3,10 @@
 #[doc(inline)]
 pub use std::future::Future;
 
+#[doc(inline)]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+pub use async_macros::{join, try_join};
+
 use cfg_if::cfg_if;
 
 pub use pending::pending;

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -5,7 +5,7 @@ pub use std::future::Future;
 
 #[doc(inline)]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
-pub use async_macros::{join, try_join};
+pub use async_macros::{join, select, try_join, try_select};
 
 use cfg_if::cfg_if;
 


### PR DESCRIPTION
Adds the `future::{join,try_join}` macros. Depends on publishing a first release of https://github.com/async-rs/async-macros first (@stjepang could I get publish access to crates.io for `async-macros`?). Thanks!

Closes #14, #175.

## Screenshot

This is what the docs look like:

![Screenshot_2019-09-12 async_std future - Rust](https://user-images.githubusercontent.com/2467194/64800395-d0fbaf00-d586-11e9-9c6a-73bd86d2883e.png)
