### PR TITLE
links the timeout docs to each other

### DIFF
--- a/src/future/timeout.rs
+++ b/src/future/timeout.rs
@@ -10,6 +10,9 @@ use crate::task::{Context, Poll};
 
 /// Awaits a future or times out after a duration of time.
 ///
+/// If you want to await an I/O future consider using
+/// [`io::timeout`](../io/fn.timeout.html) instead.
+///
 /// # Examples
 ///
 /// ```

--- a/src/io/timeout.rs
+++ b/src/io/timeout.rs
@@ -7,6 +7,9 @@ use crate::io;
 
 /// Awaits an I/O future or times out after a duration of time.
 ///
+/// If you want to await a non I/O future consider using
+/// [`future::timeout`](../future/fn.timeout.html) instead.
+///
 /// # Examples
 ///
 /// ```no_run


### PR DESCRIPTION
Was talking in chat about futures timeouts, and apparently folks missed we had two different timeout functions. This links them to each other so if you find one, you also become aware of the other. Thanks!