### PR TITLE
Clean up the fs module and a few other places

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "async-std"
 version = "0.99.5"
 authors = [
   "Stjepan Glavina <stjepang@gmail.com>",
-  "The async-std Project Developers",
+  "Yoshua Wuyts <yoshuawuyts@gmail.com>",
+  "Contributors to async-std",
 ]
 edition = "2018"
 license = "Apache-2.0/MIT"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Async version of Rust's standard library
+# Async version of the Rust standard library
 
 [![Build Status](https://travis-ci.com/async-rs/async-std.svg?branch=master)](https://travis-ci.com/async-rs/async-std)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](https://github.com/async-rs/async-std)

--- a/examples/list-dir.rs
+++ b/examples/list-dir.rs
@@ -13,8 +13,9 @@ fn main() -> io::Result<()> {
     task::block_on(async {
         let mut dir = fs::read_dir(&path).await?;
 
-        while let Some(entry) = dir.next().await {
-            println!("{}", entry?.file_name().to_string_lossy());
+        while let Some(res) = dir.next().await {
+            let entry = res?;
+            println!("{}", entry.file_name().to_string_lossy());
         }
 
         Ok(())

--- a/src/fs/canonicalize.rs
+++ b/src/fs/canonicalize.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::io;
@@ -15,10 +14,11 @@ use crate::task::blocking;
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `path` does not exist.
-/// * A non-final component in path is not a directory.
+/// * `path` does not point to an existing file or directory.
+/// * A non-final component in `path` is not a directory.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -33,5 +33,5 @@ use crate::task::blocking;
 /// ```
 pub async fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::canonicalize(path) }).await
+    blocking::spawn(async move { std::fs::canonicalize(path) }).await
 }

--- a/src/fs/copy.rs
+++ b/src/fs/copy.rs
@@ -1,28 +1,32 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Copies the contents and permissions of one file to another.
+/// Copies the contents and permissions of a file to a new location.
 ///
-/// On success, the total number of bytes copied is returned and equals the length of the `from`
-/// file.
+/// On success, the total number of bytes copied is returned and equals the length of the `to` file
+/// after this operation.
 ///
 /// The old contents of `to` will be overwritten. If `from` and `to` both point to the same file,
-/// then the file will likely get truncated by this operation.
+/// then the file will likely get truncated as a result of this operation.
+///
+/// If you're working with open [`File`]s and want to copy contents through those types, use the
+/// [`io::copy`] function.
 ///
 /// This function is an async version of [`std::fs::copy`].
 ///
+/// [`File`]: struct.File.html
+/// [`io::copy`]: ../io/fn.copy.html
 /// [`std::fs::copy`]: https://doc.rust-lang.org/std/fs/fn.copy.html
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * The `from` path is not a file.
-/// * The `from` file does not exist.
-/// * The current process lacks permissions to access `from` or write `to`.
+/// * `from` does not point to an existing file.
+/// * The current process lacks permissions to read `from` or write `to`.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -31,12 +35,12 @@ use crate::task::blocking;
 /// #
 /// use async_std::fs;
 ///
-/// let bytes_copied = fs::copy("a.txt", "b.txt").await?;
+/// let num_bytes = fs::copy("a.txt", "b.txt").await?;
 /// #
 /// # Ok(()) }) }
 /// ```
 pub async fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
     let from = from.as_ref().to_owned();
     let to = to.as_ref().to_owned();
-    blocking::spawn(async move { fs::copy(&from, &to) }).await
+    blocking::spawn(async move { std::fs::copy(&from, &to) }).await
 }

--- a/src/fs/create_dir.rs
+++ b/src/fs/create_dir.rs
@@ -1,22 +1,26 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Creates a new, empty directory.
+/// Creates a new directory.
+///
+/// Note that this function will only create the final directory in `path`. If you want to create
+/// all of its missing parent directories too, use the [`create_dir_all`] function instead.
 ///
 /// This function is an async version of [`std::fs::create_dir`].
 ///
+/// [`create_dir_all`]: fn.create_dir_all.html
 /// [`std::fs::create_dir`]: https://doc.rust-lang.org/std/fs/fn.create_dir.html
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `path` already exists.
-/// * A parent of the given path does not exist.
-/// * The current process lacks permissions to create directory at `path`.
+/// * `path` already points to an existing file or directory.
+/// * A parent directory in `path` does not exist.
+/// * The current process lacks permissions to create the directory.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -25,11 +29,11 @@ use crate::task::blocking;
 /// #
 /// use async_std::fs;
 ///
-/// fs::create_dir("./some/dir").await?;
+/// fs::create_dir("./some/directory").await?;
 /// #
 /// # Ok(()) }) }
 /// ```
 pub async fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::create_dir(path) }).await
+    blocking::spawn(async move { std::fs::create_dir(path) }).await
 }

--- a/src/fs/create_dir_all.rs
+++ b/src/fs/create_dir_all.rs
@@ -1,10 +1,9 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Creates a new, empty directory and all of its parents if they are missing.
+/// Creates a new directory and all of its parents if they are missing.
 ///
 /// This function is an async version of [`std::fs::create_dir_all`].
 ///
@@ -12,10 +11,11 @@ use crate::task::blocking;
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * The parent directories do not exists and couldn't be created.
-/// * The current process lacks permissions to create directory at `path`.
+/// * `path` already points to an existing file or directory.
+/// * The current process lacks permissions to create the directory or its missing parents.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -24,11 +24,11 @@ use crate::task::blocking;
 /// #
 /// use async_std::fs;
 ///
-/// fs::create_dir_all("./some/dir").await?;
+/// fs::create_dir_all("./some/directory").await?;
 /// #
 /// # Ok(()) }) }
 /// ```
 pub async fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::create_dir_all(path) }).await
+    blocking::spawn(async move { std::fs::create_dir_all(path) }).await
 }

--- a/src/fs/dir_entry.rs
+++ b/src/fs/dir_entry.rs
@@ -1,45 +1,28 @@
 use std::ffi::OsString;
-use std::fs;
+use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use cfg_if::cfg_if;
 
+use crate::fs::{FileType, Metadata};
 use crate::io;
 use crate::task::blocking;
 
-/// An entry inside a directory.
+/// An entry in a directory.
 ///
-/// An instance of `DirEntry` represents an entry inside a directory on the filesystem. Each entry
-/// carriers additional information like the full path or metadata.
+/// A stream of entries in a directory is returned by [`read_dir`].
 ///
 /// This type is an async version of [`std::fs::DirEntry`].
 ///
+/// [`read_dir`]: fn.read_dir.html
 /// [`std::fs::DirEntry`]: https://doc.rust-lang.org/std/fs/struct.DirEntry.html
-#[derive(Debug)]
-pub struct DirEntry {
-    /// The inner synchronous `DirEntry`.
-    inner: Arc<fs::DirEntry>,
-
-    #[cfg(unix)]
-    ino: u64,
-}
+pub struct DirEntry(Arc<std::fs::DirEntry>);
 
 impl DirEntry {
-    /// Creates an asynchronous `DirEntry` from a synchronous handle.
-    pub(crate) fn new(inner: fs::DirEntry) -> DirEntry {
-        #[cfg(unix)]
-        let dir_entry = DirEntry {
-            ino: inner.ino(),
-            inner: Arc::new(inner),
-        };
-
-        #[cfg(windows)]
-        let dir_entry = DirEntry {
-            inner: Arc::new(inner),
-        };
-
-        dir_entry
+    /// Creates an asynchronous `DirEntry` from a synchronous one.
+    pub(crate) fn new(inner: std::fs::DirEntry) -> DirEntry {
+        DirEntry(Arc::new(inner))
     }
 
     /// Returns the full path to this entry.
@@ -59,20 +42,33 @@ impl DirEntry {
     ///
     /// let mut dir = fs::read_dir(".").await?;
     ///
-    /// while let Some(entry) = dir.next().await {
-    ///     let entry = entry?;
+    /// while let Some(res) = dir.next().await {
+    ///     let entry = res?;
     ///     println!("{:?}", entry.path());
     /// }
     /// #
     /// # Ok(()) }) }
     /// ```
     pub fn path(&self) -> PathBuf {
-        self.inner.path()
+        self.0.path()
     }
 
-    /// Returns the metadata for this entry.
+    /// Reads the metadata for this entry.
     ///
-    /// This function will not traverse symlinks if this entry points at a symlink.
+    /// This function will traverse symbolic links to read the metadata.
+    ///
+    /// If you want to read metadata without following symbolic links, use [`symlink_metadata`]
+    /// instead.
+    ///
+    /// [`symlink_metadata`]: fn.symlink_metadata.html
+    ///
+    /// # Errors
+    ///
+    /// An error will be returned in the following situations:
+    ///
+    /// * This entry does not point to an existing file or directory anymore.
+    /// * The current process lacks permissions to read the metadata.
+    /// * Some other I/O error occurred.
     ///
     /// # Examples
     ///
@@ -84,21 +80,33 @@ impl DirEntry {
     ///
     /// let mut dir = fs::read_dir(".").await?;
     ///
-    /// while let Some(entry) = dir.next().await {
-    ///     let entry = entry?;
+    /// while let Some(res) = dir.next().await {
+    ///     let entry = res?;
     ///     println!("{:?}", entry.metadata().await?);
     /// }
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn metadata(&self) -> io::Result<fs::Metadata> {
-        let inner = self.inner.clone();
+    pub async fn metadata(&self) -> io::Result<Metadata> {
+        let inner = self.0.clone();
         blocking::spawn(async move { inner.metadata() }).await
     }
 
-    /// Returns the file type for this entry.
+    /// Reads the file type for this entry.
     ///
-    /// This function will not traverse symlinks if this entry points at a symlink.
+    /// This function will not traverse symbolic links if this entry points at one.
+    ///
+    /// If you want to read metadata with following symbolic links, use [`metadata`] instead.
+    ///
+    /// [`metadata`]: #method.metadata
+    ///
+    /// # Errors
+    ///
+    /// An error will be returned in the following situations:
+    ///
+    /// * This entry does not point to an existing file or directory anymore.
+    /// * The current process lacks permissions to read this entry's metadata.
+    /// * Some other I/O error occurred.
     ///
     /// # Examples
     ///
@@ -110,15 +118,15 @@ impl DirEntry {
     ///
     /// let mut dir = fs::read_dir(".").await?;
     ///
-    /// while let Some(entry) = dir.next().await {
-    ///     let entry = entry?;
+    /// while let Some(res) = dir.next().await {
+    ///     let entry = res?;
     ///     println!("{:?}", entry.file_type().await?);
     /// }
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn file_type(&self) -> io::Result<fs::FileType> {
-        let inner = self.inner.clone();
+    pub async fn file_type(&self) -> io::Result<FileType> {
+        let inner = self.0.clone();
         blocking::spawn(async move { inner.file_type() }).await
     }
 
@@ -134,15 +142,21 @@ impl DirEntry {
     ///
     /// let mut dir = fs::read_dir(".").await?;
     ///
-    /// while let Some(entry) = dir.next().await {
-    ///     let entry = entry?;
-    ///     println!("{:?}", entry.file_name());
+    /// while let Some(res) = dir.next().await {
+    ///     let entry = res?;
+    ///     println!("{}", entry.file_name().to_string_lossy());
     /// }
     /// #
     /// # Ok(()) }) }
     /// ```
     pub fn file_name(&self) -> OsString {
-        self.inner.file_name()
+        self.0.file_name()
+    }
+}
+
+impl fmt::Debug for DirEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("DirEntry").field(&self.path()).finish()
     }
 }
 
@@ -159,7 +173,7 @@ cfg_if! {
     if #[cfg(any(unix, feature = "docs"))] {
         impl DirEntryExt for DirEntry {
             fn ino(&self) -> u64 {
-                self.ino
+                self.0.ino()
             }
         }
     }

--- a/src/fs/file_type.rs
+++ b/src/fs/file_type.rs
@@ -1,0 +1,86 @@
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "docs")] {
+        /// The type of a file or directory.
+        ///
+        /// A file type is returned by [`Metadata::file_type`].
+        ///
+        /// Note that file types are mutually exclusive, i.e. at most one of methods [`is_dir`],
+        /// [`is_file`], and [`is_symlink`] can return `true`.
+        ///
+        /// This type is a re-export of [`std::fs::FileType`].
+        ///
+        /// [`Metadata::file_type`]: struct.Metadata.html#method.file_type
+        /// [`is_dir`]: #method.is_dir
+        /// [`is_file`]: #method.is_file
+        /// [`is_symlink`]: #method.is_symlink
+        /// [`std::fs::FileType`]: https://doc.rust-lang.org/std/fs/struct.FileType.html
+        #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+        pub struct FileType {
+            _private: (),
+        }
+
+        impl FileType {
+            /// Returns `true` if this file type represents a regular directory.
+            ///
+            /// If this file type represents a symbolic link, this method returns `false`.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use async_std::fs;
+            ///
+            /// let file_type = fs::metadata(".").await?.file_type();
+            /// println!("{:?}", file_type.is_dir());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn is_dir(&self) -> bool {
+                unimplemented!()
+            }
+
+            /// Returns `true` if this file type represents a regular file.
+            ///
+            /// If this file type represents a symbolic link, this method returns `false`.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use async_std::fs;
+            ///
+            /// let file_type = fs::metadata("a.txt").await?.file_type();
+            /// println!("{:?}", file_type.is_file());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn is_file(&self) -> bool {
+                unimplemented!()
+            }
+
+            /// Returns `true` if this file type represents a symbolic link.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use async_std::fs;
+            ///
+            /// let file_type = fs::metadata("a.txt").await?.file_type();
+            /// println!("{:?}", file_type.is_symlink());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn is_symlink(&self) -> bool {
+                unimplemented!()
+            }
+        }
+    } else {
+        pub use std::fs::FileType;
+    }
+}

--- a/src/fs/hard_link.rs
+++ b/src/fs/hard_link.rs
@@ -1,13 +1,12 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Creates a new hard link on the filesystem.
+/// Creates a hard link on the filesystem.
 ///
-/// The `dst` path will be a link pointing to the `src` path. Note that systems often require these
-/// two paths to both be located on the same filesystem.
+/// The `dst` path will be a link pointing to the `src` path. Note that operating systems often
+/// require these two paths to be located on the same filesystem.
 ///
 /// This function is an async version of [`std::fs::hard_link`].
 ///
@@ -15,9 +14,10 @@ use crate::task::blocking;
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * The `src` path is not a file or doesn't exist.
+/// * `src` does not point to an existing file.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -33,5 +33,5 @@ use crate::task::blocking;
 pub async fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
     let from = from.as_ref().to_owned();
     let to = to.as_ref().to_owned();
-    blocking::spawn(async move { fs::hard_link(&from, &to) }).await
+    blocking::spawn(async move { std::fs::hard_link(&from, &to) }).await
 }

--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -1,23 +1,28 @@
-use std::fs::{self, Metadata};
 use std::path::Path;
+
+use cfg_if::cfg_if;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Queries the metadata for a path.
+/// Reads metadata for a path.
 ///
-/// This function will traverse symbolic links to query information about the file or directory.
+/// This function will traverse symbolic links to read metadata for the target file or directory.
+/// If you want to read metadata without following symbolic links, use [`symlink_metadata`]
+/// instead.
 ///
 /// This function is an async version of [`std::fs::metadata`].
 ///
+/// [`symlink_metadata`]: fn.symlink_metadata.html
 /// [`std::fs::metadata`]: https://doc.rust-lang.org/std/fs/fn.metadata.html
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `path` does not exist.
-/// * The current process lacks permissions to query metadata for `path`.
+/// * `path` does not point to an existing file or directory.
+/// * The current process lacks permissions to read metadata for the path.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -32,5 +37,196 @@ use crate::task::blocking;
 /// ```
 pub async fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::metadata(path) }).await
+    blocking::spawn(async move { std::fs::metadata(path) }).await
+}
+
+cfg_if! {
+    if #[cfg(feature = "docs")] {
+        use std::time::SystemTime;
+
+        use crate::fs::{FileType, Permissions};
+
+        /// Metadata for a file or directory.
+        ///
+        /// Metadata is returned by [`metadata`] and [`symlink_metadata`].
+        ///
+        /// This type is a re-export of [`std::fs::Metadata`].
+        ///
+        /// [`metadata`]: fn.metadata.html
+        /// [`symlink_metadata`]: fn.symlink_metadata.html
+        /// [`is_dir`]: #method.is_dir
+        /// [`is_file`]: #method.is_file
+        /// [`std::fs::Metadata`]: https://doc.rust-lang.org/std/fs/struct.Metadata.html
+        #[derive(Clone, Debug)]
+        pub struct Metadata {
+            _private: (),
+        }
+
+        impl Metadata {
+            /// Returns the file type from this metadata.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use std::fs;
+            ///
+            /// let metadata = fs::metadata("a.txt").await?;
+            /// println!("{:?}", metadata.file_type());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn file_type(&self) -> FileType {
+                unimplemented!()
+            }
+
+            /// Returns `true` if this metadata is for a regular directory.
+            ///
+            /// If this metadata is for a symbolic link, this method returns `false`.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use std::fs;
+            ///
+            /// let metadata = fs::metadata(".").await?;
+            /// println!("{:?}", metadata.is_dir());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn is_dir(&self) -> bool {
+                unimplemented!()
+            }
+
+            /// Returns `true` if this metadata is for a regular file.
+            ///
+            /// If this metadata is for a symbolic link, this method returns `false`.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use std::fs;
+            ///
+            /// let metadata = fs::metadata("a.txt").await?;
+            /// println!("{:?}", metadata.is_file());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn is_file(&self) -> bool {
+                unimplemented!()
+            }
+
+            /// Returns the file size in bytes.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use std::fs;
+            ///
+            /// let metadata = fs::metadata("a.txt").await?;
+            /// println!("{}", metadata.len());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn len(&self) -> u64 {
+                unimplemented!()
+            }
+
+            /// Returns the permissions from this metadata.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use std::fs;
+            ///
+            /// let metadata = fs::metadata("a.txt").await?;
+            /// println!("{:?}", metadata.permissions());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn permissions(&self) -> Permissions {
+                unimplemented!()
+            }
+
+            /// Returns the last modification time.
+            ///
+            /// # Errors
+            ///
+            /// This data may not be available on all platforms, in which case an error will be
+            /// returned.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use std::fs;
+            ///
+            /// let metadata = fs::metadata("a.txt").await?;
+            /// println!("{:?}", metadata.modified());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn modified(&self) -> io::Result<SystemTime> {
+                unimplemented!()
+            }
+
+            /// Returns the last access time.
+            ///
+            /// # Errors
+            ///
+            /// This data may not be available on all platforms, in which case an error will be
+            /// returned.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use std::fs;
+            ///
+            /// let metadata = fs::metadata("a.txt").await?;
+            /// println!("{:?}", metadata.accessed());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn accessed(&self) -> io::Result<SystemTime> {
+                unimplemented!()
+            }
+
+            /// Returns the creation time.
+            ///
+            /// # Errors
+            ///
+            /// This data may not be available on all platforms, in which case an error will be
+            /// returned.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use std::fs;
+            ///
+            /// let metadata = fs::metadata("a.txt").await?;
+            /// println!("{:?}", metadata.created());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn created(&self) -> io::Result<SystemTime> {
+                unimplemented!()
+            }
+        }
+    } else {
+        pub use std::fs::Metadata;
+    }
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -2,7 +2,12 @@
 //!
 //! This module is an async version of [`std::fs`].
 //!
+//! [`os::unix::fs`]: ../os/unix/fs/index.html
 //! [`std::fs`]: https://doc.rust-lang.org/std/fs/index.html
+//!
+//! # Platform-specific extensions
+//!
+//! * Unix: use the [`os::unix::fs`] module.
 //!
 //! # Examples
 //!
@@ -23,11 +28,11 @@
 pub use dir_builder::DirBuilder;
 pub use dir_entry::DirEntry;
 pub use file::File;
+pub use file_type::FileType;
 pub use open_options::OpenOptions;
+pub use metadata::Metadata;
+pub use permissions::Permissions;
 pub use read_dir::ReadDir;
-
-#[doc(inline)]
-pub use std::fs::{FileType, Metadata, Permissions};
 
 pub use canonicalize::canonicalize;
 pub use copy::copy;
@@ -54,9 +59,11 @@ mod create_dir_all;
 mod dir_builder;
 mod dir_entry;
 mod file;
+mod file_type;
 mod hard_link;
 mod metadata;
 mod open_options;
+mod permissions;
 mod read;
 mod read_dir;
 mod read_link;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -29,8 +29,8 @@ pub use dir_builder::DirBuilder;
 pub use dir_entry::DirEntry;
 pub use file::File;
 pub use file_type::FileType;
-pub use open_options::OpenOptions;
 pub use metadata::Metadata;
+pub use open_options::OpenOptions;
 pub use permissions::Permissions;
 pub use read_dir::ReadDir;
 

--- a/src/fs/permissions.rs
+++ b/src/fs/permissions.rs
@@ -1,0 +1,58 @@
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "docs")] {
+        /// A set of permissions on a file or directory.
+        ///
+        /// This type is a re-export of [`std::fs::Permissions`].
+        ///
+        /// [`std::fs::Permissions`]: https://doc.rust-lang.org/std/fs/struct.Permissions.html
+        #[derive(Clone, PartialEq, Eq, Debug)]
+        pub struct Permissions {
+            _private: (),
+        }
+
+        impl Permissions {
+            /// Returns the read-only flag.
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use async_std::fs;
+            ///
+            /// let perm = fs::metadata("a.txt").await?.permissions();
+            /// println!("{:?}", perm.readonly());
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn readonly(&self) -> bool {
+                unimplemented!()
+            }
+
+            /// Configures the read-only flag.
+            ///
+            /// [`fs::set_permissions`]: fn.set_permissions.html
+            ///
+            /// # Examples
+            ///
+            /// ```no_run
+            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// #
+            /// use async_std::fs;
+            ///
+            /// let mut perm = fs::metadata("a.txt").await?.permissions();
+            /// perm.set_readonly(true);
+            /// fs::set_permissions("a.txt", perm).await?;
+            /// #
+            /// # Ok(()) }) }
+            /// ```
+            pub fn set_readonly(&mut self, readonly: bool) {
+                unimplemented!()
+            }
+        }
+    } else {
+        pub use std::fs::Permissions;
+    }
+}

--- a/src/fs/read.rs
+++ b/src/fs/read.rs
@@ -1,25 +1,28 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Read the entire contents of a file into a bytes vector.
+/// Reads the entire contents of a file as raw bytes.
 ///
 /// This is a convenience function for reading entire files. It pre-allocates a buffer based on the
-/// file size when available, so it is generally faster than manually opening a file and reading
-/// into a `Vec`.
+/// file size when available, so it is typically faster than manually opening a file and reading
+/// from it.
+///
+/// If you want to read the contents as a string, use [`read_to_string`] instead.
 ///
 /// This function is an async version of [`std::fs::read`].
 ///
+/// [`read_to_string`]: fn.read_to_string.html
 /// [`std::fs::read`]: https://doc.rust-lang.org/std/fs/fn.read.html
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `path` does not exist.
-/// * The current process lacks permissions to read `path`.
+/// * `path` does not point to an existing file.
+/// * The current process lacks permissions to read the file.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -34,5 +37,5 @@ use crate::task::blocking;
 /// ```
 pub async fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::read(path) }).await
+    blocking::spawn(async move { std::fs::read(path) }).await
 }

--- a/src/fs/read_link.rs
+++ b/src/fs/read_link.rs
@@ -1,10 +1,9 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::io;
 use crate::task::blocking;
 
-/// Reads a symbolic link, returning the path it points to.
+/// Reads a symbolic link and returns the path it points to.
 ///
 /// This function is an async version of [`std::fs::read_link`].
 ///
@@ -12,10 +11,10 @@ use crate::task::blocking;
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `path` is not a symbolic link.
-/// * `path` does not exist.
+/// * `path` does not point to an existing link.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -30,5 +29,5 @@ use crate::task::blocking;
 /// ```
 pub async fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::read_link(path) }).await
+    blocking::spawn(async move { std::fs::read_link(path) }).await
 }

--- a/src/fs/read_to_string.rs
+++ b/src/fs/read_to_string.rs
@@ -1,21 +1,29 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Read the entire contents of a file into a string.
+/// Reads the entire contents of a file as a string.
+///
+/// This is a convenience function for reading entire files. It pre-allocates a string based on the
+/// file size when available, so it is typically faster than manually opening a file and reading
+/// from it.
+///
+/// If you want to read the contents as raw bytes, use [`read`] instead.
 ///
 /// This function is an async version of [`std::fs::read_to_string`].
 ///
+/// [`read`]: fn.read.html
 /// [`std::fs::read_to_string`]: https://doc.rust-lang.org/std/fs/fn.read_to_string.html
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `path` is not a file.
-/// * The current process lacks permissions to read `path`.
+/// * `path` does not point to an existing file.
+/// * The current process lacks permissions to read the file.
+/// * The contents of the file cannot be read as a UTF-8 string.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -30,5 +38,5 @@ use crate::task::blocking;
 /// ```
 pub async fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::read_to_string(path) }).await
+    blocking::spawn(async move { std::fs::read_to_string(path) }).await
 }

--- a/src/fs/remove_dir.rs
+++ b/src/fs/remove_dir.rs
@@ -1,10 +1,9 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Removes an existing, empty directory.
+/// Removes an empty directory.
 ///
 /// This function is an async version of [`std::fs::remove_dir`].
 ///
@@ -12,10 +11,11 @@ use crate::task::blocking;
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `path` is not an empty directory.
-/// * The current process lacks permissions to remove directory at `path`.
+/// * `path` is not an existing and empty directory.
+/// * The current process lacks permissions to remove the directory.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -24,11 +24,11 @@ use crate::task::blocking;
 /// #
 /// use async_std::fs;
 ///
-/// fs::remove_dir("./some/dir").await?;
+/// fs::remove_dir("./some/directory").await?;
 /// #
 /// # Ok(()) }) }
 /// ```
 pub async fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::remove_dir(path) }).await
+    blocking::spawn(async move { std::fs::remove_dir(path) }).await
 }

--- a/src/fs/remove_dir_all.rs
+++ b/src/fs/remove_dir_all.rs
@@ -1,10 +1,9 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Removes an directory and all of its contents.
+/// Removes a directory and all of its contents.
 ///
 /// This function is an async version of [`std::fs::remove_dir_all`].
 ///
@@ -12,10 +11,11 @@ use crate::task::blocking;
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `path` is not a directory.
-/// * The current process lacks permissions to remove directory at `path`.
+/// * `path` is not an existing and empty directory.
+/// * The current process lacks permissions to remove the directory.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -24,11 +24,11 @@ use crate::task::blocking;
 /// #
 /// use async_std::fs;
 ///
-/// fs::remove_dir_all("./some/dir").await?;
+/// fs::remove_dir_all("./some/directory").await?;
 /// #
 /// # Ok(()) }) }
 /// ```
 pub async fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::remove_dir_all(path) }).await
+    blocking::spawn(async move { std::fs::remove_dir_all(path) }).await
 }

--- a/src/fs/remove_file.rs
+++ b/src/fs/remove_file.rs
@@ -1,10 +1,9 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Removes a file from the filesystem.
+/// Removes a file.
 ///
 /// This function is an async version of [`std::fs::remove_file`].
 ///
@@ -12,10 +11,11 @@ use crate::task::blocking;
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `path` is not a file.
-/// * The current process lacks permissions to remove file at `path`.
+/// * `path` does not point to an existing file.
+/// * The current process lacks permissions to remove the file.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -30,5 +30,5 @@ use crate::task::blocking;
 /// ```
 pub async fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::remove_file(path) }).await
+    blocking::spawn(async move { std::fs::remove_file(path) }).await
 }

--- a/src/fs/rename.rs
+++ b/src/fs/rename.rs
@@ -1,10 +1,12 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Renames a file or directory to a new name, replacing the original if it already exists.
+/// Renames a file or directory to a new location.
+///
+/// If a file or directory already exists at the target location, it will be overwritten by this
+/// operation.
 ///
 /// This function is an async version of [`std::fs::rename`].
 ///
@@ -12,11 +14,12 @@ use crate::task::blocking;
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `from` does not exist.
+/// * `from` does not point to an existing file or directory.
 /// * `from` and `to` are on different filesystems.
-/// * The current process lacks permissions to rename `from` to `to`.
+/// * The current process lacks permissions to do the rename operation.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -32,5 +35,5 @@ use crate::task::blocking;
 pub async fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
     let from = from.as_ref().to_owned();
     let to = to.as_ref().to_owned();
-    blocking::spawn(async move { fs::rename(&from, &to) }).await
+    blocking::spawn(async move { std::fs::rename(&from, &to) }).await
 }

--- a/src/fs/set_permissions.rs
+++ b/src/fs/set_permissions.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use crate::io;
 use crate::fs::Permissions;
+use crate::io;
 use crate::task::blocking;
 
 /// Changes the permissions of a file or directory.

--- a/src/fs/set_permissions.rs
+++ b/src/fs/set_permissions.rs
@@ -1,10 +1,10 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
+use crate::fs::Permissions;
 use crate::task::blocking;
 
-/// Changes the permissions on a file or directory.
+/// Changes the permissions of a file or directory.
 ///
 /// This function is an async version of [`std::fs::set_permissions`].
 ///
@@ -12,10 +12,11 @@ use crate::task::blocking;
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `path` does not exist.
-/// * The current process lacks permissions to change attributes of `path`.
+/// * `path` does not point to an existing file or directory.
+/// * The current process lacks permissions to change attributes on the file or directory.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -30,7 +31,7 @@ use crate::task::blocking;
 /// #
 /// # Ok(()) }) }
 /// ```
-pub async fn set_permissions<P: AsRef<Path>>(path: P, perm: fs::Permissions) -> io::Result<()> {
+pub async fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::set_permissions(path, perm) }).await
+    blocking::spawn(async move { std::fs::set_permissions(path, perm) }).await
 }

--- a/src/fs/symlink_metadata.rs
+++ b/src/fs/symlink_metadata.rs
@@ -1,21 +1,26 @@
-use std::fs::{self, Metadata};
 use std::path::Path;
 
+use crate::fs::Metadata;
 use crate::io;
 use crate::task::blocking;
 
-/// Queries the metadata for a path without following symlinks.
+/// Reads metadata for a path without following symbolic links.
+///
+/// If you want to follow symbolic links before reading metadata of the target file or directory,
+/// use [`metadata`] instead.
 ///
 /// This function is an async version of [`std::fs::symlink_metadata`].
 ///
+/// [`metadata`]: fn.metadata.html
 /// [`std::fs::symlink_metadata`]: https://doc.rust-lang.org/std/fs/fn.symlink_metadata.html
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * `path` does not exist.
-/// * The current process lacks permissions to query metadata for `path`.
+/// * `path` does not point to an existing file or directory.
+/// * The current process lacks permissions to read metadata for the path.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -30,5 +35,5 @@ use crate::task::blocking;
 /// ```
 pub async fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
     let path = path.as_ref().to_owned();
-    blocking::spawn(async move { fs::symlink_metadata(path) }).await
+    blocking::spawn(async move { std::fs::symlink_metadata(path) }).await
 }

--- a/src/fs/write.rs
+++ b/src/fs/write.rs
@@ -1,10 +1,9 @@
-use std::fs;
 use std::path::Path;
 
 use crate::io;
 use crate::task::blocking;
 
-/// Writes a slice of bytes as the entire contents of a file.
+/// Writes a slice of bytes as the new contents of a file.
 ///
 /// This function will create a file if it does not exist, and will entirely replace its contents
 /// if it does.
@@ -15,9 +14,11 @@ use crate::task::blocking;
 ///
 /// # Errors
 ///
-/// An error will be returned in the following situations (not an exhaustive list):
+/// An error will be returned in the following situations:
 ///
-/// * The current process lacks permissions to write into `path`.
+/// * The file's parent directory does not exist.
+/// * The current process lacks permissions to write to the file.
+/// * Some other I/O error occurred.
 ///
 /// # Examples
 ///
@@ -26,12 +27,12 @@ use crate::task::blocking;
 /// #
 /// use async_std::fs;
 ///
-/// fs::write("a.txt", b"Lorem ipsum").await?;
+/// fs::write("a.txt", b"Hello world!").await?;
 /// #
 /// # Ok(()) }) }
 /// ```
 pub async fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     let contents = contents.as_ref().to_owned();
-    blocking::spawn(async move { fs::write(path, contents) }).await
+    blocking::spawn(async move { std::fs::write(path, contents) }).await
 }

--- a/src/future/timeout.rs
+++ b/src/future/timeout.rs
@@ -60,7 +60,7 @@ impl<F: Future> Future for TimeoutFuture<F> {
         match self.as_mut().future().poll(cx) {
             Poll::Ready(v) => Poll::Ready(Ok(v)),
             Poll::Pending => match self.delay().poll(cx) {
-                Poll::Ready(_) => Poll::Ready(Err(TimeoutError { _priv: () })),
+                Poll::Ready(_) => Poll::Ready(Err(TimeoutError { _private: () })),
                 Poll::Pending => Poll::Pending,
             },
         }
@@ -71,7 +71,7 @@ impl<F: Future> Future for TimeoutFuture<F> {
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TimeoutError {
-    _priv: (),
+    _private: (),
 }
 
 impl Error for TimeoutError {}

--- a/src/io/buf_read/lines.rs
+++ b/src/io/buf_read/lines.rs
@@ -16,7 +16,7 @@ use crate::task::{Context, Poll};
 ///
 /// [`lines`]: trait.BufRead.html#method.lines
 /// [`BufRead`]: trait.BufRead.html
-/// [`std::io::Lines`]: https://doc.rust-lang.org/nightly/std/io/struct.Lines.html
+/// [`std::io::Lines`]: https://doc.rust-lang.org/std/io/struct.Lines.html
 #[derive(Debug)]
 pub struct Lines<R> {
     pub(crate) reader: R,

--- a/src/io/buf_reader.rs
+++ b/src/io/buf_reader.rs
@@ -37,10 +37,10 @@ const DEFAULT_CAPACITY: usize = 8 * 1024;
 /// use async_std::io::BufReader;
 /// use async_std::prelude::*;
 ///
-/// let mut f = BufReader::new(File::open("a.txt").await?);
+/// let mut file = BufReader::new(File::open("a.txt").await?);
 ///
 /// let mut line = String::new();
-/// f.read_line(&mut line).await?;
+/// file.read_line(&mut line).await?;
 /// #
 /// # Ok(()) }) }
 /// ```
@@ -134,8 +134,8 @@ impl<R> BufReader<R> {
     /// use async_std::fs::File;
     /// use async_std::io::BufReader;
     ///
-    /// let mut f = BufReader::new(File::open("a.txt").await?);
-    /// let inner = f.get_mut();
+    /// let mut file = BufReader::new(File::open("a.txt").await?);
+    /// let inner = file.get_mut();
     /// #
     /// # Ok(()) }) }
     /// ```

--- a/src/io/empty.rs
+++ b/src/io/empty.rs
@@ -25,7 +25,7 @@ use crate::task::{Context, Poll};
 /// # Ok(()) }) }
 /// ```
 pub fn empty() -> Empty {
-    Empty { _priv: () }
+    Empty { _private: () }
 }
 
 /// A reader that contains no data.
@@ -34,7 +34,7 @@ pub fn empty() -> Empty {
 ///
 /// [`sink`]: fn.sink.html
 pub struct Empty {
-    _priv: (),
+    _private: (),
 }
 
 impl fmt::Debug for Empty {

--- a/src/io/read/mod.rs
+++ b/src/io/read/mod.rs
@@ -63,10 +63,10 @@ pub trait Read {
     /// use async_std::fs::File;
     /// use async_std::prelude::*;
     ///
-    /// let mut f = File::open("a.txt").await?;
+    /// let mut file = File::open("a.txt").await?;
     ///
     /// let mut buf = vec![0; 1024];
-    /// let n = f.read(&mut buf).await?;
+    /// let n = file.read(&mut buf).await?;
     /// #
     /// # Ok(()) }) }
     /// ```
@@ -112,10 +112,10 @@ pub trait Read {
     /// use async_std::fs::File;
     /// use async_std::prelude::*;
     ///
-    /// let mut f = File::open("a.txt").await?;
+    /// let mut file = File::open("a.txt").await?;
     ///
     /// let mut buf = Vec::new();
-    /// f.read_to_end(&mut buf).await?;
+    /// file.read_to_end(&mut buf).await?;
     /// #
     /// # Ok(()) }) }
     /// ```
@@ -149,10 +149,10 @@ pub trait Read {
     /// use async_std::fs::File;
     /// use async_std::prelude::*;
     ///
-    /// let mut f = File::open("a.txt").await?;
+    /// let mut file = File::open("a.txt").await?;
     ///
     /// let mut buf = String::new();
-    /// f.read_to_string(&mut buf).await?;
+    /// file.read_to_string(&mut buf).await?;
     /// #
     /// # Ok(()) }) }
     /// ```
@@ -201,10 +201,10 @@ pub trait Read {
     /// use async_std::fs::File;
     /// use async_std::prelude::*;
     ///
-    /// let mut f = File::open("a.txt").await?;
+    /// let mut file = File::open("a.txt").await?;
     ///
     /// let mut buf = vec![0; 10];
-    /// f.read_exact(&mut buf).await?;
+    /// file.read_exact(&mut buf).await?;
     /// #
     /// # Ok(()) }) }
     /// ```

--- a/src/io/seek.rs
+++ b/src/io/seek.rs
@@ -49,9 +49,9 @@ pub trait Seek {
     /// use async_std::io::SeekFrom;
     /// use async_std::prelude::*;
     ///
-    /// let mut f = File::open("a.txt").await?;
+    /// let mut file = File::open("a.txt").await?;
     ///
-    /// let file_len = f.seek(SeekFrom::End(0)).await?;
+    /// let file_len = file.seek(SeekFrom::End(0)).await?;
     /// #
     /// # Ok(()) }) }
     /// ```

--- a/src/io/sink.rs
+++ b/src/io/sink.rs
@@ -22,7 +22,7 @@ use crate::task::{Context, Poll};
 /// # Ok(()) }) }
 /// ```
 pub fn sink() -> Sink {
-    Sink { _priv: () }
+    Sink { _private: () }
 }
 
 /// A writer that consumes and drops all data.
@@ -31,7 +31,7 @@ pub fn sink() -> Sink {
 ///
 /// [`sink`]: fn.sink.html
 pub struct Sink {
-    _priv: (),
+    _private: (),
 }
 
 impl fmt::Debug for Sink {

--- a/src/io/write/mod.rs
+++ b/src/io/write/mod.rs
@@ -56,9 +56,9 @@ pub trait Write {
     /// use async_std::fs::File;
     /// use async_std::prelude::*;
     ///
-    /// let mut f = File::create("a.txt").await?;
+    /// let mut file = File::create("a.txt").await?;
     ///
-    /// let n = f.write(b"hello world").await?;
+    /// let n = file.write(b"hello world").await?;
     /// #
     /// # Ok(()) }) }
     /// ```
@@ -76,10 +76,10 @@ pub trait Write {
     /// use async_std::fs::File;
     /// use async_std::prelude::*;
     ///
-    /// let mut f = File::create("a.txt").await?;
+    /// let mut file = File::create("a.txt").await?;
     ///
-    /// f.write_all(b"hello world").await?;
-    /// f.flush().await?;
+    /// file.write_all(b"hello world").await?;
+    /// file.flush().await?;
     /// #
     /// # Ok(()) }) }
     /// ```
@@ -113,6 +113,8 @@ pub trait Write {
     /// an error is returned. This method will not return until the entire buffer has been
     /// successfully written or such an error occurs.
     ///
+    /// [`write`]: #tymethod.write
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -121,9 +123,9 @@ pub trait Write {
     /// use async_std::fs::File;
     /// use async_std::prelude::*;
     ///
-    /// let mut f = File::create("a.txt").await?;
+    /// let mut file = File::create("a.txt").await?;
     ///
-    /// f.write_all(b"hello world").await?;
+    /// file.write_all(b"hello world").await?;
     /// #
     /// # Ok(()) }) }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,16 @@
 //! Async version of the Rust standard library.
 //!
-//! This crate is an async version of [`std`].
+//! Modules in this crate are organized in the same way as in the standard library, except blocking
+//! functions have been replaced with async functions and threads have been replaced with
+//! lightweight tasks.
 //!
-//! Higher-level documentation in the form of the book
-//! ["Async programming in Rust with async-std"][book]
-//! is available.
+//! More information, reading materials, and other resources:
 //!
-//! [`std`]: https://doc.rust-lang.org/std/index.html
-//! [book]: https://book.async.rs
+//! * [🌐 The async-std website](https://async.rs/)
+//! * [📖 The async-std book](https://book.async.rs)
+//! * [🐙 GitHub repository](https://github.com/async-rs/async-std)
+//! * [📒 List of code examples](https://github.com/async-rs/async-std/tree/master/examples)
+//! * [💬 Discord chat](https://discord.gg/JvZeVNe)
 //!
 //! # Examples
 //!
@@ -23,8 +26,15 @@
 //! }
 //! ```
 //!
-//! See [here](https://github.com/async-rs/async-std/tree/master/examples)
-//! for more examples.
+//! # Features
+//!
+//! Unstable APIs in this crate are available when the `unstable` Cargo feature is enabled:
+//!
+//! ```toml
+//! [dependencies.async-std]
+//! version = "0.99"
+//! features = ["unstable"]
+//! ```
 
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]

--- a/src/os/unix/fs.rs
+++ b/src/os/unix/fs.rs
@@ -69,7 +69,6 @@ cfg_if! {
             fn custom_flags(&mut self, flags: i32) -> &mut Self;
         }
     } else {
-        #[doc(inline)]
         pub use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
     }
 }

--- a/src/os/unix/io.rs
+++ b/src/os/unix/io.rs
@@ -51,7 +51,6 @@ cfg_if! {
             fn into_raw_fd(self) -> RawFd;
         }
     } else {
-        #[doc(inline)]
         pub use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
     }
 }

--- a/src/os/unix/net/mod.rs
+++ b/src/os/unix/net/mod.rs
@@ -94,7 +94,6 @@ cfg_if! {
             }
         }
     } else {
-        #[doc(inline)]
         pub use std::os::unix::net::SocketAddr;
     }
 }

--- a/src/os/windows/io.rs
+++ b/src/os/windows/io.rs
@@ -43,7 +43,6 @@ cfg_if! {
             fn into_raw_handle(self) -> RawHandle;
         }
     } else {
-        #[doc(inline)]
         pub use std::os::windows::io::{
             AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle, RawSocket,
         };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,15 @@
 //! The async prelude.
 //!
-//! The prelude re-exports the most commonly used traits in this crate.
+//! The prelude re-exports most commonly used traits and macros from this crate.
+//!
+//! # Examples
+//!
+//! Import the prelude with:
+//!
+//! ```
+//! # #[allow(unused_imports)]
+//! use async_std::prelude::*;
+//! ```
 
 #[doc(no_inline)]
 pub use crate::future::Future;


### PR DESCRIPTION
Just a cleanup for various pieces of documentation, mainly around the `lib.rs` docs, the prelude, and the `fs` module. Some small bugs are also fixed along the way.

This PR is the first one in a series of review PRs that I will be submitting before the upcoming 1.0 release.