### PR TITLE
Add Stream::scan

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -25,7 +25,7 @@ pub use double_ended_stream::DoubleEndedStream;
 pub use empty::{empty, Empty};
 pub use once::{once, Once};
 pub use repeat::{repeat, Repeat};
-pub use stream::{Stream, Take};
+pub use stream::{Scan, Stream, Take};
 
 mod double_ended_stream;
 mod empty;

--- a/src/stream/stream/scan.rs
+++ b/src/stream/stream/scan.rs
@@ -9,7 +9,7 @@ pub struct Scan<S, St, F> {
     state_f: (St, F),
 }
 
-impl<S, St: Unpin, F: Unpin> Scan<S, St, F> {
+impl<S, St, F> Scan<S, St, F> {
     pub(crate) fn new(stream: S, initial_state: St, f: F) -> Self {
         Self {
             stream,
@@ -21,11 +21,12 @@ impl<S, St: Unpin, F: Unpin> Scan<S, St, F> {
     pin_utils::unsafe_unpinned!(state_f: (St, F));
 }
 
+impl<S: Unpin, St, F> Unpin for Scan<S, St, F> {}
+
 impl<S, St, F, B> futures_core::stream::Stream for Scan<S, St, F>
 where
     S: futures_core::stream::Stream,
-    St: Unpin,
-    F: Unpin + FnMut(&mut St, S::Item) -> Option<B>,
+    F: FnMut(&mut St, S::Item) -> Option<B>,
 {
     type Item = B;
 

--- a/src/stream/stream/scan.rs
+++ b/src/stream/stream/scan.rs
@@ -1,0 +1,41 @@
+use crate::task::{Context, Poll};
+
+use std::pin::Pin;
+
+/// A stream to maintain state while polling another stream.
+#[derive(Debug)]
+pub struct Scan<S, St, F> {
+    stream: S,
+    state_f: (St, F),
+}
+
+impl<S, St: Unpin, F: Unpin> Scan<S, St, F> {
+    pub(crate) fn new(stream: S, initial_state: St, f: F) -> Self {
+        Self {
+            stream,
+            state_f: (initial_state, f),
+        }
+    }
+
+    pin_utils::unsafe_pinned!(stream: S);
+    pin_utils::unsafe_unpinned!(state_f: (St, F));
+}
+
+impl<S, St, F, B> futures_core::stream::Stream for Scan<S, St, F>
+where
+    S: futures_core::stream::Stream,
+    St: Unpin,
+    F: Unpin + FnMut(&mut St, S::Item) -> Option<B>,
+{
+    type Item = B;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<B>> {
+        let poll_result = self.as_mut().stream().poll_next(cx);
+        poll_result.map(|item| {
+            item.and_then(|item| {
+                let (state, f) = self.as_mut().state_f();
+                f(state, item)
+            })
+        })
+    }
+}


### PR DESCRIPTION
Ref #129. The mapper function `f` is synchronous and returns bare `Option<B>`.

Asynchronous `f` seems tricky to implement right. It requires the wrapper to be self-referential, as a reference to internal state may be captured by the returned future.