### PR TITLE
Remove Unpin bound in `impl Stream for T`

### DIFF
--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -547,7 +547,7 @@ pub trait Stream {
     }
 }
 
-impl<T: futures_core::stream::Stream + Unpin + ?Sized> Stream for T {
+impl<T: futures_core::stream::Stream + ?Sized> Stream for T {
     type Item = <Self as futures_core::stream::Stream>::Item;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/src/stream/stream/scan.rs
+++ b/src/stream/stream/scan.rs
@@ -1,6 +1,7 @@
-use crate::task::{Context, Poll};
-
 use std::pin::Pin;
+
+use crate::stream::Stream;
+use crate::task::{Context, Poll};
 
 /// A stream to maintain state while polling another stream.
 #[derive(Debug)]
@@ -25,7 +26,7 @@ impl<S: Unpin, St, F> Unpin for Scan<S, St, F> {}
 
 impl<S, St, F, B> futures_core::stream::Stream for Scan<S, St, F>
 where
-    S: futures_core::stream::Stream,
+    S: Stream,
     F: FnMut(&mut St, S::Item) -> Option<B>,
 {
     type Item = B;


### PR DESCRIPTION
I guess this is not needed anymore since we have `poll_next` that receives `Pin` now. The original bound is moved to `Stream::next`.