### PR TITLE
expose IoSlice, IoSliceMut

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -23,7 +23,7 @@
 pub mod prelude;
 
 #[doc(inline)]
-pub use std::io::{Error, ErrorKind, Result, SeekFrom};
+pub use std::io::{Error, ErrorKind, IoSlice, IoSliceMut, Result, SeekFrom};
 
 pub use buf_read::{BufRead, Lines};
 pub use buf_reader::BufReader;


### PR DESCRIPTION
Exposes `io::IoSlice` and `io::IoSliceMut`. Given we're returning these from `read_vectored` and `write_vectored` it might make sense to just include them as part of our re-exports. Thanks!

Ref #131.