### PR TITLE
document feature flags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,25 @@
 //!
 //! See [here](https://github.com/async-rs/async-std/tree/master/examples)
 //! for more examples.
+//!
+//! # Features
+//!
+//! `async-std` is strongly commited to following semver. This means your code
+//! won't break unless _you_ decide to upgrade.
+//!
+//! However every now and then we come up with something that we think will
+//! work _great_ for `async-std`, and we want to provide a sneak-peek so you
+//! can try it out. This is what we call _"unstable"_ features. You can try out
+//! the unstable features by enabling the `unstable` feature in you `Cargo.toml`
+//! file:
+//!
+//! ```toml
+//! [dependencies]
+//! async-std = { version = "0.99.5", features = ["unstable"] }
+//! ```
+//!
+//! Just be careful when running these features, as they may change between
+//! versions.
 
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]


### PR DESCRIPTION
Documents how to enable the `unstable` feature flag, addressing user feedback we've had. Thanks!

## Screenshot

![Screenshot_2019-09-16 async_std - Rust](https://user-images.githubusercontent.com/2467194/64959106-c4ca6700-d890-11e9-9052-618ad9e25d85.png)
