### PR TITLE
expose std::pin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod sync;
 pub mod task;
 
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+#[cfg(feature = "unstable")]
 pub mod pin;
 
 pub(crate) mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,5 +51,6 @@ pub mod prelude;
 pub mod stream;
 pub mod sync;
 pub mod task;
+pub mod pin;
 
 pub(crate) mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,10 +47,12 @@ pub mod future;
 pub mod io;
 pub mod net;
 pub mod os;
-pub mod pin;
 pub mod prelude;
 pub mod stream;
 pub mod sync;
 pub mod task;
+
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+pub mod pin;
 
 pub(crate) mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,10 +47,10 @@ pub mod future;
 pub mod io;
 pub mod net;
 pub mod os;
+pub mod pin;
 pub mod prelude;
 pub mod stream;
 pub mod sync;
 pub mod task;
-pub mod pin;
 
 pub(crate) mod utils;

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,0 +1,4 @@
+//! Types that pin data to its location in memory.
+
+#[doc(inline)]
+pub use std::pin::Pin;

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,4 +1,6 @@
 //! Types that pin data to its location in memory.
+//!
+//! For more documentation see [`std::pin`](https://doc.rust-lang.org/std/pin/index.html).
 
 #[doc(inline)]
 pub use std::pin::Pin;


### PR DESCRIPTION
This is important when defining / calling futures, so it makes sense for us to also export this.

But also given recent user feedback on the confusion on pinning, I'd like to open up the possibility to experiment with providing better pinning facilities  such as [`pin-project`](https://github.com/taiki-e/pin-project) or [`pin_mut`](https://docs.rs/pin-utils/0.1.0-alpha.4/pin_utils/macro.pin_mut.html) behind flags. I'm not sure if we could, or even should. But I want to allow us to have that conversation and test things out (even if it's just in floating patches.)

Thanks!