### PR TITLE
add stream::join

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ docs = []
 unstable = []
 
 [dependencies]
+async-macros = "1.0.0"
 async-task = "1.0.0"
 cfg-if = "0.1.9"
 crossbeam-channel = "0.3.9"

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -42,5 +42,9 @@ cfg_if! {
         pub use double_ended_stream::DoubleEndedStream;
         pub use from_stream::FromStream;
         pub use into_stream::IntoStream;
+
+        #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+        #[doc(inline)]
+        pub use async_macros::{join_stream as join, JoinStream as Join};
     }
 }


### PR DESCRIPTION
Ref #129 #187. This adds the `stream::join` which can join multiple streams into a single stream. Thanks!

## Example
```rust
let a = stream::once(1u8);
let b = stream::once(2u8);
let c = stream::once(3u8);

let mut s = stream::join!(a, b, c);

assert_eq!(s.collect().await, vec![1u8, 2u8, 3u8]);
```

## Screenshot

![Screenshot_2019-09-17 async_std stream - Rust](https://user-images.githubusercontent.com/2467194/65080099-cedb8b00-d9a0-11e9-984f-edd7d6bad5cc.png)
