### PR TITLE
IntoStream for vec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ mod result;
 pub mod stream;
 pub mod sync;
 pub mod task;
-mod vec;
+pub mod vec;
 
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[cfg(feature = "unstable")]

--- a/src/stream/into_stream.rs
+++ b/src/stream/into_stream.rs
@@ -25,12 +25,12 @@ pub trait IntoStream {
     fn into_stream(self) -> Self::IntoStream;
 }
 
-// impl<I: Stream + Send> IntoStream for I {
-//     type Item = I::Item;
-//     type IntoStream = I;
+impl<I: Stream + Send> IntoStream for I {
+    type Item = I::Item;
+    type IntoStream = I;
 
-//     #[inline]
-//     fn into_stream(self) -> I {
-//         self
-//     }
-// }
+    #[inline]
+    fn into_stream(self) -> I {
+        self
+    }
+}

--- a/src/stream/into_stream.rs
+++ b/src/stream/into_stream.rs
@@ -25,12 +25,12 @@ pub trait IntoStream {
     fn into_stream(self) -> Self::IntoStream;
 }
 
-impl<I: Stream + Send> IntoStream for I {
-    type Item = I::Item;
-    type IntoStream = I;
+// impl<I: Stream + Send> IntoStream for I {
+//     type Item = I::Item;
+//     type IntoStream = I;
 
-    #[inline]
-    fn into_stream(self) -> I {
-        self
-    }
-}
+//     #[inline]
+//     fn into_stream(self) -> I {
+//         self
+//     }
+// }

--- a/src/vec/into_stream.rs
+++ b/src/vec/into_stream.rs
@@ -1,0 +1,89 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// A stream that moves out of a vector.
+#[derive(Debug)]
+pub struct IntoStream<T> {
+    iter: std::vec::IntoIter<T>,
+}
+
+impl<T: Send> crate::stream::IntoStream for Vec<T> {
+    type Item = T;
+    type IntoStream = IntoStream<T>;
+
+    /// Creates a consuming iterator, that is, one that moves each value out of
+    /// the vector (from start to end). The vector cannot be used after calling
+    /// this.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let v = vec!["a".to_string(), "b".to_string()];
+    /// for s in v.into_stream() {
+    ///     // s has type String, not &String
+    ///     println!("{}", s);
+    /// }
+    /// ```
+    #[inline]
+    fn into_stream(mut self) -> IntoStream<T> {
+        let iter = self.into_iter();
+        IntoStream { iter }
+    }
+}
+
+impl<T: Send> futures_core::stream::Stream for IntoStream<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.iter.next())
+    }
+}
+
+/// Slice stream.
+#[derive(Debug)]
+pub struct Stream<'a, T: 'a> {
+    iter: std::slice::Iter<'a, T>,
+}
+
+impl<'a, T: Sync> futures_core::stream::Stream for Stream<'a, T> {
+    type Item = &'a T;
+
+    fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.iter.next())
+    }
+}
+
+impl<'a, T: Sync> crate::stream::IntoStream for &'a Vec<T> {
+    type Item = &'a T;
+    type IntoStream = Stream<'a, T>;
+
+    fn into_stream(self) -> Stream<'a, T> {
+        let iter = self.iter();
+        Stream { iter }
+    }
+}
+
+/// Mutable slice stream.
+#[derive(Debug)]
+pub struct StreamMut<'a, T: 'a> {
+    iter: std::slice::IterMut<'a, T>,
+}
+
+impl<'a, T: Sync> futures_core::stream::Stream for StreamMut<'a, T> {
+    type Item = &'a mut T;
+
+    fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.iter.next())
+    }
+}
+
+impl<'a, T: Send + Sync> crate::stream::IntoStream for &'a mut Vec<T> {
+    type Item = &'a mut T;
+
+    type IntoStream = StreamMut<'a, T>;
+
+    fn into_stream(self) -> StreamMut<'a, T> {
+        let iter = self.iter_mut();
+        StreamMut { iter }
+    }
+}

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -1,9 +1,11 @@
-//! The Rust core allocation and collections library
+//! Core allocation and collections library.
 //!
-//! This library provides smart pointers and collections for managing
-//! heap-allocated values.
+//! This library contains stream types for `std::vec::Vec`.
 
 mod from_stream;
+mod into_stream;
 
-#[doc(inline)]
-pub use std::vec::Vec;
+// #[doc(inline)]
+// pub use std::vec::Vec;
+
+pub use into_stream::{IntoStream, Stream, StreamMut};


### PR DESCRIPTION
This WIP PR implements `IntoStream` for `Vec`, adding three new stream types for vec: `vec::Stream`, `vec::IntoStream`, `vec::StreamMut`. We may want to extend this patch to also cover `slice`, because if we'd follow std, vec should use `Stream` and `StreamMut` types from `slice::*`.

Ref #129.

cc/ @stjepang @sunjay 

## Error
I'm currently blocked on a problem with our bounds. Namely we do:

```rust
impl<I: Stream + Send> IntoStream for I {
    type Item = I::Item;
    type IntoStream = I;

    #[inline]
    fn into_stream(self) -> I {
        self
    }
}
```

Which is causing the following error to show up:

![2019-09-18-234517_1920x1080](https://user-images.githubusercontent.com/2467194/65188369-8db1ac80-da6e-11e9-8916-6d0ab93aca96.png)

I'm confused why this is happening, as `std::iter` has [a similar impl](https://doc.rust-lang.org/src/core/iter/traits/collect.rs.html#241-248). I'm worried this is some kind of orphan rule thing, but I don't quite get it. Getting help with this would be greatly appreciated!