### PR TITLE
fix unstable display for pin docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ pub mod task;
 
 cfg_if! {
     if #[cfg(any(feature = "unstable", feature = "docs"))] {
+        #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
         pub mod pin;
         mod vec;
         mod result;


### PR DESCRIPTION
On https://docs.rs/async-std/0.99.6/async_std/ `pin` is not properly showing up as "unstable" despite being guarded as such. This fixes that. Thanks!