### PR TITLE
expose sync::{Arc,Weak}

### DIFF
--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -29,6 +29,9 @@
 //! # }) }
 //! ```
 
+#[doc(inline)]
+pub use std::sync::{Arc, Weak};
+
 pub use mutex::{Mutex, MutexGuard};
 pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 


### PR DESCRIPTION
Ref #217. Exposes `std::sync::Arc` and `std::sync::Weak`. Thanks!