### PR TITLE
Fix error[E0008]: cannot bind by-move into a pattern guard

### DIFF
--- a/src/net/driver/mod.rs
+++ b/src/net/driver/mod.rs
@@ -204,7 +204,7 @@ impl<T: Evented> Watcher<T> {
     {
         // If the operation isn't blocked, return its result.
         match f(self.source.as_ref().unwrap()) {
-            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => {}
             res => return Poll::Ready(res),
         }
 
@@ -213,7 +213,7 @@ impl<T: Evented> Watcher<T> {
 
         // Try running the operation again.
         match f(self.source.as_ref().unwrap()) {
-            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => {}
             res => return Poll::Ready(res),
         }
 
@@ -239,7 +239,7 @@ impl<T: Evented> Watcher<T> {
     {
         // If the operation isn't blocked, return its result.
         match f(self.source.as_ref().unwrap()) {
-            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => {}
             res => return Poll::Ready(res),
         }
 
@@ -248,7 +248,7 @@ impl<T: Evented> Watcher<T> {
 
         // Try running the operation again.
         match f(self.source.as_ref().unwrap()) {
-            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => {}
             res => return Poll::Ready(res),
         }
 


### PR DESCRIPTION
Fixes the following error:

Error: error[E0008]: cannot bind by-move into a pattern guard
   --> src/net/driver/mod.rs:207:17
    |
207 |             Err(err) if err.kind() == io::ErrorKind::WouldBlock => {}
    |                 ^^^ moves value into pattern guard
    |
    = help: add `#![feature(bind_by_move_pattern_guards)]` to the crate attributes to enable