### PR TITLE
adds stream::chain combinator

### DIFF
--- a/src/stream/stream/chain.rs
+++ b/src/stream/stream/chain.rs
@@ -1,0 +1,50 @@
+use std::pin::Pin;
+
+use super::fuse::Fuse;
+use crate::stream::Stream;
+use crate::task::{Context, Poll};
+
+/// Chains two streams one after another.
+#[derive(Debug)]
+pub struct Chain<S, U> {
+    first: Fuse<S>,
+    second: Fuse<U>,
+}
+
+impl<S: Stream, U: Stream> Chain<S, U> {
+    pin_utils::unsafe_pinned!(first: Fuse<S>);
+    pin_utils::unsafe_pinned!(second: Fuse<U>);
+
+    pub(super) fn new(first: S, second: U) -> Self {
+        Chain {
+            first: first.fuse(),
+            second: second.fuse(),
+        }
+    }
+}
+
+impl<S: Stream, U: Stream<Item = S::Item>> Stream for Chain<S, U> {
+    type Item = S::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if !self.first.done {
+            let next = futures_core::ready!(self.as_mut().first().poll_next(cx));
+            if let Some(next) = next {
+                return Poll::Ready(Some(next));
+            }
+        }
+
+        if !self.second.done {
+            let next = futures_core::ready!(self.as_mut().second().poll_next(cx));
+            if let Some(next) = next {
+                return Poll::Ready(Some(next));
+            }
+        }
+
+        if self.first.done && self.second.done {
+            return Poll::Ready(None);
+        }
+
+        Poll::Pending
+    }
+}

--- a/src/stream/stream/fuse.rs
+++ b/src/stream/stream/fuse.rs
@@ -1,5 +1,7 @@
 use std::pin::Pin;
-use std::task::{Context, Poll};
+
+use crate::stream::Stream;
+use crate::task::{Context, Poll};
 
 /// A `Stream` that is permanently closed once a single call to `poll` results in
 /// `Poll::Ready(None)`, returning `Poll::Ready(None)` for all future calls to `poll`.
@@ -11,12 +13,12 @@ pub struct Fuse<S> {
 
 impl<S: Unpin> Unpin for Fuse<S> {}
 
-impl<S: futures_core::Stream> Fuse<S> {
+impl<S: Stream> Fuse<S> {
     pin_utils::unsafe_pinned!(stream: S);
     pin_utils::unsafe_unpinned!(done: bool);
 }
 
-impl<S: futures_core::Stream> futures_core::Stream for Fuse<S> {
+impl<S: Stream> Stream for Fuse<S> {
     type Item = S::Item;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<S::Item>> {


### PR DESCRIPTION
Adds a `Chain` combinator and Introduces some changes to `Fuse` so it's usable in this case, but those need a closer look. 

---
Ref: #129 
Stdlib: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.chain