### PR TITLE
feat: implement sync::Barrier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ num_cpus = "1.10.1"
 pin-utils = "0.1.0-alpha.4"
 slab = "0.4.2"
 kv-log-macro = "1.0.4"
+broadcaster = "0.2.4"
 
 [dev-dependencies]
 femme = "1.2.0"

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -32,8 +32,10 @@
 #[doc(inline)]
 pub use std::sync::{Arc, Weak};
 
+pub use barrier::{Barrier, BarrierWaitResult};
 pub use mutex::{Mutex, MutexGuard};
 pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
+mod barrier;
 mod mutex;
 mod rwlock;

--- a/tests/barrier.rs
+++ b/tests/barrier.rs
@@ -1,0 +1,52 @@
+use std::sync::Arc;
+
+use futures_channel::mpsc::unbounded;
+use futures_util::sink::SinkExt;
+use futures_util::stream::StreamExt;
+
+use async_std::sync::Barrier;
+use async_std::task;
+
+#[test]
+fn test_barrier() {
+    // Based on the test in std, I was seeing some race conditions, so running it in a loop to make sure
+    // things are solid.
+
+    for _ in 0..1_000 {
+        task::block_on(async move {
+            const N: usize = 10;
+
+            let barrier = Arc::new(Barrier::new(N));
+            let (tx, mut rx) = unbounded();
+
+            for _ in 0..N - 1 {
+                let c = barrier.clone();
+                let mut tx = tx.clone();
+                task::spawn(async move {
+                    let res = c.wait().await;
+
+                    tx.send(res.is_leader()).await.unwrap();
+                });
+            }
+
+            // At this point, all spawned threads should be blocked,
+            // so we shouldn't get anything from the port
+            let res = rx.try_next();
+            assert!(match res {
+                Err(_err) => true,
+                _ => false,
+            });
+
+            let mut leader_found = barrier.wait().await.is_leader();
+
+            // Now, the barrier is cleared and we should get data.
+            for _ in 0..N - 1 {
+                if rx.next().await.unwrap() {
+                    assert!(!leader_found);
+                    leader_found = true;
+                }
+            }
+            assert!(leader_found);
+        });
+    }
+}


### PR DESCRIPTION
~~Based on the implementation in https://github.com/tokio-rs/tokio/pull/1571~~

Based on the implementation in the std lib 

Things to discuss

- `async` or `std` `Arc` in examples and tests
- ~~`async` or `std` `Mutex` in the implementation~~ can't use std, as it needs to be shared
- use of `broadcaster` dependency to implement, well broadcast

To fix
- [x] missing debug implementation, once broadcaster has it, or it is dropped

## Docs

![Screenshot 2019-09-25 at 21 07 25](https://user-images.githubusercontent.com/790842/65631833-a541e580-dfd8-11e9-970b-8a1df9155529.png)
