### PR TITLE
Pin futures crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ async-task = "1.0.0"
 cfg-if = "0.1.9"
 crossbeam-channel = "0.3.9"
 crossbeam-deque = "0.7.1"
-futures-core-preview = "0.3.0-alpha.18"
-futures-io-preview = "0.3.0-alpha.18"
+futures-core-preview = "=0.3.0-alpha.18"
+futures-io-preview = "=0.3.0-alpha.18"
 futures-timer = "0.4.0"
 lazy_static = "1.4.0"
 log = { version = "0.4.8", features = ["kv_unstable"] }
@@ -50,9 +50,9 @@ surf = "1.0.2"
 tempdir = "0.3.7"
 
 # These are used by the book for examples
-futures-channel-preview = "0.3.0-alpha.18"
-futures-util-preview = "0.3.0-alpha.18"
+futures-channel-preview = "=0.3.0-alpha.18"
+futures-util-preview = "=0.3.0-alpha.18"
 
 [dev-dependencies.futures-preview]
-version = "0.3.0-alpha.18"
+version = "=0.3.0-alpha.18"
 features = ["std", "nightly", "async-await"]


### PR DESCRIPTION
The `futures-*` crates are rapidly changing and have recently caused the crate to not compile (https://github.com/async-rs/async-std/issues/249). This would pin the crates to the previous version