### PR TITLE
async_std::fmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 
+## Changed
+
+- Added the `fmt` submodule as unstable, with re-exports from `std`.
+
 # [0.99.8] - 2019-09-28
 
 ## Changed

--- a/src/fmt/mod.rs
+++ b/src/fmt/mod.rs
@@ -1,0 +1,24 @@
+//! Utilities for formatting and printing `String`s.
+//!
+//! This library is an asynchronous version of [`std::fmt`].
+//!
+//! [`std::fmt`]: https://doc.rust-lang.org/std/fmt/index.html
+
+// Structs re-export
+pub use std::fmt::{
+    Arguments, DebugList, DebugMap, DebugSet, DebugStruct, DebugTuple, Error, Formatter,
+};
+
+// Enums re-export
+pub use std::fmt::Alignment;
+
+// Traits re-export
+pub use std::fmt::{
+    Binary, Debug, Display, LowerExp, LowerHex, Octal, Pointer, UpperExp, UpperHex,
+};
+
+// Functions re-export
+pub use std::fmt::format;
+
+// Type defs re-export
+pub use std::fmt::Result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,9 @@ cfg_if! {
         #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
         pub mod pin;
 
+        #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+        pub mod fmt;
+
         mod vec;
         mod result;
     }


### PR DESCRIPTION
Exposes `async_std::fmt` as unstable. Ref #247. Thanks!

## Screenshot

![Screenshot_2019-09-28 async_std fmt - Rust](https://user-images.githubusercontent.com/2467194/65819475-4e791d80-e21d-11e9-9f62-1ce4c61793d5.png)
