### PR TITLE
Expose pin project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 
+## Added
+
+- Added `pin::pin_project` attribute macro as unstable.
+- Added `pin::pinned_drop` attribute macro as unstable.
+- Added `pin::project` attribute macro as unstable.
+- Added `pin::project_ref` attribute macro as unstable.
+- Added `pin::UnsafeUnpin` trait as unstable.
+
 # [0.99.8] - 2019-09-28
 
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
-docs = ["broadcaster"]
-unstable = ["broadcaster"]
+docs = ["broadcaster", "pin-project"]
+unstable = ["broadcaster", "pin-project"]
 
 [dependencies]
 async-macros = "1.0.0"
@@ -43,6 +43,7 @@ pin-utils = "0.1.0-alpha.4"
 slab = "0.4.2"
 kv-log-macro = "1.0.4"
 broadcaster = { version = "0.2.6", optional = true, default-features = false, features = ["default-channels"] }
+pin-project = { version = "0.4.1", optional = true }
 
 [dev-dependencies]
 femme = "1.2.0"

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -4,3 +4,18 @@
 
 #[doc(inline)]
 pub use std::pin::Pin;
+
+#[doc(inline)]
+pub use pin_project::pin_project;
+
+#[doc(inline)]
+pub use pin_project::pinned_drop;
+
+#[doc(inline)]
+pub use pin_project::project;
+
+#[doc(inline)]
+pub use pin_project::project_ref;
+
+#[doc(inline)]
+pub use pin_project::UnsafeUnpin;


### PR DESCRIPTION
re-exports [`pin-project`](https://docs.rs/pin-project/0.4.1/pin_project/) traits from our unstable `pin` submodule. We should eventually pair this up with some good docs on what pinning is, why pin projection is useful, and how to do it using these attributes.

From internal discussions we've been considering adopting `pin-project` to remove our use of `unsafe` from our pin projections. It'd be great if we could write down our experiences porting from unsafe projections to pin-project, and use that to guide others to do the same. Thanks!

Related #203 

cc/ @taiki-e 

## Screenshot

![Screenshot_2019-09-28 async_std pin - Rust](https://user-images.githubusercontent.com/2467194/65819565-7f0d8700-e21e-11e9-86e1-0c2f425ee2f1.png)
