### PR TITLE
add IntoFuture

### DIFF
--- a/src/future/into_future.rs
+++ b/src/future/into_future.rs
@@ -11,3 +11,13 @@ pub trait IntoFuture {
     /// Create a future from a value
     fn into_future(self) -> Self::Future;
 }
+
+impl<T: Future> IntoFuture for T {
+    type Output = T::Output;
+
+    type Future = T;
+
+    fn into_future(self) -> Self::Future {
+        self
+    }
+}

--- a/src/future/into_future.rs
+++ b/src/future/into_future.rs
@@ -1,6 +1,35 @@
 use crate::future::Future;
 
 /// Convert a type into a `Future`.
+///
+/// # Examples
+///
+/// ```
+/// use async_std::future::{Future, IntoFuture};
+/// use async_std::io;
+/// use async_std::pin::Pin;
+///
+/// struct Client;
+///
+/// impl Client {
+///     pub async fn send(self) -> io::Result<()> {
+///         // Send a request
+///         Ok(())
+///     }
+/// }
+///
+/// impl IntoFuture for Client {
+///     type Output = io::Result<()>;
+///
+///     type Future = Pin<Box<dyn Future<Output = Self::Output>>>;
+///
+///     fn into_future(self) -> Self::Future {
+///         Box::pin(async {
+///             self.send().await
+///         })
+///     }
+/// }
+/// ```
 pub trait IntoFuture {
     /// The type of value produced on completion.
     type Output;

--- a/src/future/into_future.rs
+++ b/src/future/into_future.rs
@@ -1,0 +1,13 @@
+use crate::future::Future;
+
+/// Convert a type into a `Future`.
+pub trait IntoFuture {
+    /// The type of value produced on completion.
+    type Output;
+
+    /// Which kind of future are we turning this into?
+    type Future: Future<Output = Self::Output>;
+
+    /// Create a future from a value
+    fn into_future(self) -> Self::Future;
+}

--- a/src/future/into_future.rs
+++ b/src/future/into_future.rs
@@ -30,6 +30,8 @@ use crate::future::Future;
 ///     }
 /// }
 /// ```
+#[cfg(any(feature = "unstable", feature = "docs"))]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 pub trait IntoFuture {
     /// The type of value produced on completion.
     type Output;

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -50,19 +50,20 @@ pub use async_macros::{join, select, try_join, try_select};
 
 use cfg_if::cfg_if;
 
-pub use into_future::IntoFuture;
 pub use pending::pending;
 pub use poll_fn::poll_fn;
 pub use ready::ready;
 
-mod into_future;
 mod pending;
 mod poll_fn;
 mod ready;
 
 cfg_if! {
     if #[cfg(any(feature = "unstable", feature = "docs"))] {
+        mod into_future;
         mod timeout;
+
+        pub use into_future::IntoFuture;
         pub use timeout::{timeout, TimeoutError};
     }
 }

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -50,10 +50,10 @@ pub use async_macros::{join, select, try_join, try_select};
 
 use cfg_if::cfg_if;
 
+pub use into_future::IntoFuture;
 pub use pending::pending;
 pub use poll_fn::poll_fn;
 pub use ready::ready;
-pub use into_future::IntoFuture;
 
 mod into_future;
 mod pending;

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -53,7 +53,9 @@ use cfg_if::cfg_if;
 pub use pending::pending;
 pub use poll_fn::poll_fn;
 pub use ready::ready;
+pub use into_future::IntoFuture;
 
+mod into_future;
 mod pending;
 mod poll_fn;
 mod ready;


### PR DESCRIPTION
Adds the `IntoFuture` trait, wihch @nemo157 [pointed out](https://www.reddit.com/r/rust/comments/d7acl0/async_finalizers/f0ytyyj/) would be useful for implementing the "async builder" pattern we used when building Surf.

In the [RFC2394 async_await](https://github.com/rust-lang/rfcs/blob/master/text/2394-async_await.md#the-await-compiler-built-in) it's also stated that `await` should call `IntoFuture` under the hood.

> A builtin called await! is added to the compiler. `await!` can be used to "pause" the computation of the future, yielding control back to the caller. __`await!` takes any expression which implements IntoFuture__, and evaluates to a value of the item type that that future has.

This PR doesn't add that functionality to `await`, but does have the right shape it should take, which allows people to start implementing `IntoFuture` so that later it will "just work".

---

cc/ @withoutboats, is what I've said so far about `IntoFuture` still accurate? I didn't see any mentions that this had been changed in [the stabilization report](https://github.com/rust-lang/rust/issues/62149), so does that mean that it means this simply has not been implemented yet?

## Screenshot

![Screenshot_2019-09-28 async_std future - Rust](https://user-images.githubusercontent.com/2467194/65820417-db75a400-e228-11e9-99cf-f6c65ebeb980.png)
