### PR TITLE
FromStream impl for Option<T> + Revised impl for Vec<T>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ cfg_if! {
 
         mod vec;
         mod result;
+        mod option;
     }
 }
 

--- a/src/option/from_stream.rs
+++ b/src/option/from_stream.rs
@@ -1,0 +1,49 @@
+use std::pin::Pin;
+
+use crate::prelude::*;
+use crate::stream::{FromStream, IntoStream};
+
+impl<T, V> FromStream<Option<T>> for Option<V>
+where
+    V: FromStream<T>,
+{
+    /// Takes each element in the stream: if it is `None`, no further
+    /// elements are taken, and `None` is returned. Should no `None`
+    /// occur, a container with the values of each `Option` is returned.
+    #[inline]
+    fn from_stream<'a, S: IntoStream<Item = Option<T>>>(
+        stream: S,
+    ) -> Pin<Box<dyn core::future::Future<Output = Self> + 'a>>
+    where
+        <S as IntoStream>::IntoStream: 'a,
+    {
+        let stream = stream.into_stream();
+
+        Pin::from(Box::new(async move {
+            pin_utils::pin_mut!(stream);
+
+            // Using `scan` here because it is able to stop the stream early
+            // if a failure occurs
+            let mut found_error = false;
+            let out: V = stream
+                .scan((), |_, elem| {
+                    match elem {
+                        Some(elem) => Some(elem),
+                        None => {
+                            found_error = true;
+                            // Stop processing the stream on error
+                            None
+                        }
+                    }
+                })
+                .collect()
+                .await;
+
+            if found_error {
+                None
+            } else {
+                Some(out)
+            }
+        }))
+    }
+}

--- a/src/option/from_stream.rs
+++ b/src/option/from_stream.rs
@@ -19,7 +19,7 @@ where
     {
         let stream = stream.into_stream();
 
-        Pin::from(Box::new(async move {
+        Box::pin(async move {
             pin_utils::pin_mut!(stream);
 
             // Using `scan` here because it is able to stop the stream early
@@ -44,6 +44,6 @@ where
             } else {
                 Some(out)
             }
-        }))
+        })
     }
 }

--- a/src/option/from_stream.rs
+++ b/src/option/from_stream.rs
@@ -39,11 +39,7 @@ where
                 .collect()
                 .await;
 
-            if found_error {
-                None
-            } else {
-                Some(out)
-            }
+            if found_error { None } else { Some(out) }
         })
     }
 }

--- a/src/option/mod.rs
+++ b/src/option/mod.rs
@@ -1,0 +1,9 @@
+//! The Rust core optional value type
+//!
+//! This module provides the `Option<T>` type for returning and
+//! propagating optional values.
+
+mod from_stream;
+
+#[doc(inline)]
+pub use std::option::Option;

--- a/src/result/from_stream.rs
+++ b/src/result/from_stream.rs
@@ -19,7 +19,7 @@ where
     {
         let stream = stream.into_stream();
 
-        Pin::from(Box::new(async move {
+        Box::pin(async move {
             pin_utils::pin_mut!(stream);
 
             // Using `scan` here because it is able to stop the stream early
@@ -43,6 +43,6 @@ where
                 Some(err) => Err(err),
                 None => Ok(out),
             }
-        }))
+        })
     }
 }

--- a/src/vec/from_stream.rs
+++ b/src/vec/from_stream.rs
@@ -1,7 +1,6 @@
 use std::pin::Pin;
 
-use crate::prelude::*;
-use crate::stream::{FromStream, IntoStream};
+use crate::stream::{FromStream, IntoStream, Extend};
 
 impl<T> FromStream<T> for Vec<T> {
     #[inline]
@@ -17,9 +16,7 @@ impl<T> FromStream<T> for Vec<T> {
             pin_utils::pin_mut!(stream);
 
             let mut out = vec![];
-            while let Some(item) = stream.next().await {
-                out.push(item);
-            }
+            out.stream_extend(stream).await;
             out
         }))
     }

--- a/src/vec/from_stream.rs
+++ b/src/vec/from_stream.rs
@@ -12,12 +12,12 @@ impl<T> FromStream<T> for Vec<T> {
     {
         let stream = stream.into_stream();
 
-        Pin::from(Box::new(async move {
+        Box::pin(async move {
             pin_utils::pin_mut!(stream);
 
             let mut out = vec![];
             out.stream_extend(stream).await;
             out
-        }))
+        })
     }
 }

--- a/src/vec/from_stream.rs
+++ b/src/vec/from_stream.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-use crate::stream::{FromStream, IntoStream, Extend};
+use crate::stream::{Extend, FromStream, IntoStream};
 
 impl<T> FromStream<T> for Vec<T> {
     #[inline]


### PR DESCRIPTION
cc #129 

The `FromStream` impl for `Option<T>` is almost identical to the one for `Result<T>` (and thus also almost identical to the one in the standard library). Just like with #207, this adds a new module for option and leaves it unstable with the other `FromStream` impls.

I've also re-implemented `FromStream` for `Vec<T>` in terms of the async `Extend` trait. This better matches the standard library and also gives us some code re-use as the previous impl was essentially the same as the implementation of `Extend`.

I'm waiting on a few more methods to be added to stream before I can add the rest of the `FromStream` impls. @montekki has started to work on that in #264. Thanks!