### PR TITLE
Fix uds listener hanging on accept

### DIFF
--- a/src/os/unix/net/listener.rs
+++ b/src/os/unix/net/listener.rs
@@ -95,9 +95,9 @@ impl UnixListener {
         future::poll_fn(|cx| {
             let res = futures_core::ready!(self.watcher.poll_read_with(cx, |inner| {
                 match inner.accept_std() {
-                    // Converting to `would block` so that the watcher will
+                    // Converting to `WouldBlock` so that the watcher will
                     // add the waker of this task to a list of readers.
-                    Ok(None) => Err(std::io::ErrorKind::WouldBlock.into()),
+                    Ok(None) => Err(io::ErrorKind::WouldBlock.into()),
                     res => res,
                 }
             }));
@@ -110,7 +110,7 @@ impl UnixListener {
                     };
                     Poll::Ready(Ok((stream, addr)))
                 }
-                // This should never happen since None is converted to WouldBlock
+                // This should never happen since `None` is converted to `WouldBlock`
                 None => unreachable!(),
             }
         })

--- a/src/os/unix/net/listener.rs
+++ b/src/os/unix/net/listener.rs
@@ -93,11 +93,16 @@ impl UnixListener {
     /// ```
     pub async fn accept(&self) -> io::Result<(UnixStream, SocketAddr)> {
         future::poll_fn(|cx| {
-            let res =
-                futures_core::ready!(self.watcher.poll_read_with(cx, |inner| inner.accept_std()));
+            let res = futures_core::ready!(self.watcher.poll_read_with(cx, |inner| {
+                match inner.accept_std() {
+                    // Converting to `would block` so that the watcher will
+                    // add the waker of this task to a list of readers.
+                    Ok(None) => Err(std::io::ErrorKind::WouldBlock.into()),
+                    res => res,
+                }
+            }));
 
             match res? {
-                None => Poll::Pending,
                 Some((io, addr)) => {
                     let mio_stream = mio_uds::UnixStream::from_stream(io)?;
                     let stream = UnixStream {
@@ -105,6 +110,8 @@ impl UnixListener {
                     };
                     Poll::Ready(Ok((stream, addr)))
                 }
+                // This should never happen since None is converted to WouldBlock
+                None => unreachable!(),
             }
         })
         .await

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -47,7 +47,7 @@ fn into_raw_fd() -> io::Result<()> {
 
 const PING: &[u8] = b"ping";
 const PONG: &[u8] = b"pong";
-const TEST_TIMEOUT: std::time::Duration = Duration::from_secs(3);
+const TEST_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[test]
 fn socket_ping_pong() {


### PR DESCRIPTION
UDS listener was hanging because the accept method would return `Poll::Pending` without registering the task to be awoken in the case when underlying unix listener returns a `WouldBlock` that gets converted to `None`. This is a hacky fix for this case.

Should fix #248