### PR TITLE
Fixes feature flag used in generating the docs in the README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Docs
-      run: cargo doc --features docs,unstable
+      run: cargo doc --features docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       rust: nightly
       os: linux
       script:
-        - cargo doc --features docs,unstable
+        - cargo doc --features docs
 
     - name: book
       rust: nightly

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ git clone git@github.com:async-rs/async-std.git && cd async-std
 Generate docs:
 
 ```
-cargo doc --features docs.rs --open
+cargo doc --features docs --open
 ```
 
 Check out the [examples](examples). To run an example:

--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ git clone git@github.com:async-rs/async-std.git && cd async-std
 Generate docs:
 
 ```
-cargo doc --features docs --open
+cargo +nightly doc --features docs --open
 ```
 
 Check out the [examples](examples). To run an example:
 
 ```
-cargo run --example hello-world
+cargo +nightly run --example hello-world
 ```
 
 ## Contributing

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -25,7 +25,7 @@
 #[doc(inline)]
 pub use std::task::{Context, Poll, Waker};
 
-#[cfg(feature = "unstable")]
+#[cfg(any(feature = "unstable", feature = "docs"))]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[doc(inline)]
 pub use async_macros::ready;


### PR DESCRIPTION
I thought I'd take a stab at fixing at this https://github.com/async-rs/async-std/issues/82, but I ran into a few errors following the instruction in the README.md

The first error and one that is addressed in this pull request is that the feature flag used to generate the docs is incorrect- it should be `docs` and not `docs.rs`
```
$ cargo doc --features docs.rs --open

error: Package `async-std v0.99.8 (/home/mike/workspace/async-std)` does not have these features: `docs.rs`
```

Perhaps additionally, it should be `--features docs,unstable` as it is in `.travis.yml` . Should I add that to the README? https://github.com/async-rs/async-std/blob/master/.travis.yml#L53

Lastly, I had to use the `+nightly` flag to get it to the docs and example to run. Should I add this or is it assumed that the user would have this configured somewhere?

Thanks!