### PR TITLE
install rustfmt with fallback for gh-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,22 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
+    - id: component
+      uses: actions-rs/components-nightly@v1
+      with:
+        component: rustfmt
+
+    - uses: actions-rs/toolchain@v1
+      with:
+          toolchain: ${{ steps.component.outputs.toolchain }}
+          override: true
+
     - name: setup
       run: |
-        rustup default nightly
         rustup component add rustfmt
         test -x $HOME/.cargo/bin/mdbook || ./ci/install-mdbook.sh
         rustc --version
+
     - name: mdbook
       run: |
         mdbook build docs


### PR DESCRIPTION
This uses https://github.com/actions-rs/components-nightly to fall back to an older version of the rust toolchain if installation of a component fails. This fixes a bug that's currently happening on nightly where `rustfmt` isn't available. Thanks!