### PR TITLE
[wip] switch bors integration to use GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 on: pull_request
 
 jobs:
-  build_and_test:
-    name: Build and test on ${{ matrix.os }}
+  check_src:
+    name: Nightly on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -35,8 +35,8 @@ jobs:
         command: test
         args: --all --doc --features unstable
 
-  check_fmt_and_docs:
-    name: Checking fmt and docs
+  check_docs:
+    name: Docs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -53,15 +53,12 @@ jobs:
 
     - name: setup
       run: |
-        rustup component add rustfmt
         test -x $HOME/.cargo/bin/mdbook || ./ci/install-mdbook.sh
         rustc --version
 
     - name: mdbook
       run: |
         mdbook build docs
-    - name: fmt
-      run: cargo fmt --all -- --check
 
     - name: Docs
       run: cargo doc --features docs,unstable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 on: pull_request
 
+name: test
 jobs:
   check_src:
-    name: Nightly on ${{ matrix.os }}
+    name: nightly on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -36,7 +37,7 @@ jobs:
         args: --all --doc --features unstable
 
   check_docs:
-    name: Docs
+    name: rustdoc
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,9 +1,9 @@
 on: pull_request
 
-name: Style
+name: style
 jobs:
   clippy:
-    name: Clippy
+    name: clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   fmt:
-    name: Rustfmt
+    name: rustfmt
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,8 +1,9 @@
 on: pull_request
 
-name: Clippy check
+name: Style
 jobs:
-  clippy_check:
+  clippy:
+    name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -18,3 +19,21 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - id: component
+      uses: actions-rs/components-nightly@v1
+      with:
+        component: rustfmt
+    - uses: actions-rs/toolchain@v1
+      with:
+          toolchain: ${{ steps.component.outputs.toolchain }}
+          override: true
+    - name: setup
+      run: rustup component add rustfmt
+    - name: fmt
+      run: cargo fmt --all -- --check

--- a/bors.toml
+++ b/bors.toml
@@ -1,1 +1,10 @@
-status = ["continuous-integration/travis-ci/push"]
+status = [
+    "test (stable)",
+    "test (beta)",
+    "test (nightly)",
+    "test (macos)",
+    "style (clippy)",
+    "style (rustfmt)",
+    "style (rustdoc)",
+]
+delete_merged_branches = true


### PR DESCRIPTION
Based on https://github.com/taiki-e/pin-project/pull/117/files#diff-3515bd2b4297af2de6456cf6df7c9f4cR1-R10 this is a WIP PR to move our bors checks over to GitHub actions. This is the final blocker to completely move to GitHub actions.

Additionally I've moved some files around, and named some steps that were previously unnamed.