### PR TITLE
Stabilize io::Cursor

### DIFF
--- a/src/io/cursor.rs
+++ b/src/io/cursor.rs
@@ -21,7 +21,6 @@ use crate::task::{Context, Poll};
 /// [`Vec`]: https://doc.rust-lang.org/std/vec/struct.Vec.html
 /// [bytes]: https://doc.rust-lang.org/std/primitive.slice.html
 /// [`File`]: struct.File.html
-#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[derive(Clone, Debug, Default)]
 pub struct Cursor<T> {
     inner: std::io::Cursor<T>,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,7 +21,7 @@ pub use crate::io::Read as _;
 pub use crate::io::Seek as _;
 #[doc(no_inline)]
 pub use crate::io::Write as _;
-#[doc(hidden)]
+#[doc(no_inline)]
 pub use crate::stream::Stream;
 #[doc(no_inline)]
 pub use crate::task_local;

--- a/src/sync/barrier.rs
+++ b/src/sync/barrier.rs
@@ -157,7 +157,7 @@ impl Barrier {
             drop(lock);
 
             while local_gen == generation_id && count < self.n {
-                let (g, c) = wait.recv().await.expect("sender hasn not been closed");
+                let (g, c) = wait.recv().await.expect("sender has not been closed");
                 generation_id = g;
                 count = c;
             }


### PR DESCRIPTION
Our `Cursor` is really simple and matches the API of `std::io::Cursor`. There's not much reason to keep it unstable. :)