### PR TITLE
add stream::interval

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ crossbeam-channel = "0.3.9"
 crossbeam-deque = "0.7.1"
 futures-core-preview = "=0.3.0-alpha.19"
 futures-io-preview = "=0.3.0-alpha.19"
-futures-timer = "1.0.1"
+futures-timer = "1.0.2"
 lazy_static = "1.4.0"
 log = { version = "0.4.8", features = ["kv_unstable"] }
 memchr = "2.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ crossbeam-channel = "0.3.9"
 crossbeam-deque = "0.7.1"
 futures-core-preview = "=0.3.0-alpha.19"
 futures-io-preview = "=0.3.0-alpha.19"
-futures-timer = "0.4.0"
+futures-timer = "1.0.0"
 lazy_static = "1.4.0"
 log = { version = "0.4.8", features = ["kv_unstable"] }
 memchr = "2.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ crossbeam-channel = "0.3.9"
 crossbeam-deque = "0.7.1"
 futures-core-preview = "=0.3.0-alpha.19"
 futures-io-preview = "=0.3.0-alpha.19"
-futures-timer = "1.0.0"
+futures-timer = "1.0.1"
 lazy_static = "1.4.0"
 log = { version = "0.4.8", features = ["kv_unstable"] }
 memchr = "2.2.1"

--- a/src/io/timeout.rs
+++ b/src/io/timeout.rs
@@ -1,8 +1,6 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
-use std::task::{Context, Poll};
-use std::pin::Pin;
 
 use futures_timer::Delay;
 use pin_utils::unsafe_pinned;
@@ -41,7 +39,8 @@ where
     Timeout {
         timeout: Delay::new(dur),
         future: f,
-    }.await
+    }
+    .await
 }
 
 /// Future returned by the `FutureExt::timeout` method.
@@ -63,7 +62,6 @@ where
 }
 
 impl<F, T> Future for Timeout<F, T>
->>>>>>> 01f8584... add stream::interval
 where
     F: Future<Output = io::Result<T>>,
 {

--- a/src/stream/interval.rs
+++ b/src/stream/interval.rs
@@ -1,0 +1,186 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+use futures_core::future::Future;
+use futures_core::stream::Stream;
+use pin_utils::unsafe_pinned;
+
+use futures_timer::Delay;
+
+/// Creates a new stream that yields at a set interval.
+///
+/// The first stream first yields after `dur`, and continues to yield every
+/// `dur` after that. The stream accounts for time elapsed between calls, and
+/// will adjust accordingly to prevent time skews.
+///
+/// Note that intervals are not intended for high resolution timers, but rather
+/// they will likely fire some granularity after the exact instant that they're
+/// otherwise indicated to fire at.
+///
+/// # Examples
+///
+/// Basic example:
+///
+/// ```no_run
+/// use std::time::Duration;
+/// use futures::prelude::*;
+///
+/// let interval = Interval::new(Duration::from_secs(4));
+/// while let Some(_) = interval.next().await {
+///     println!("prints every four seconds"));
+/// }
+/// ```
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+#[doc(inline)]
+pub fn interval(dur: Duration) -> Interval {
+    Interval {
+        delay: Delay::new(dur),
+        interval: dur,
+    }
+}
+
+/// A stream representing notifications at fixed interval
+///
+#[derive(Debug)]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+#[doc(inline)]
+pub struct Interval {
+    delay: Delay,
+    interval: Duration,
+}
+
+impl Interval {
+    unsafe_pinned!(delay: Delay);
+}
+
+impl Stream for Interval {
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if Pin::new(&mut *self).delay().poll(cx).is_pending() {
+            return Poll::Pending;
+        }
+        let when = Instant::now();
+        let next = next_interval(when, Instant::now(), self.interval);
+        self.delay.reset_at(next);
+        Poll::Ready(Some(()))
+    }
+}
+
+/// Converts Duration object to raw nanoseconds if possible
+///
+/// This is useful to divide intervals.
+///
+/// While technically for large duration it's impossible to represent any
+/// duration as nanoseconds, the largest duration we can represent is about
+/// 427_000 years. Large enough for any interval we would use or calculate in
+/// tokio.
+fn duration_to_nanos(dur: Duration) -> Option<u64> {
+    dur.as_secs()
+        .checked_mul(1_000_000_000)
+        .and_then(|v| v.checked_add(u64::from(dur.subsec_nanos())))
+}
+
+fn next_interval(prev: Instant, now: Instant, interval: Duration) -> Instant {
+    let new = prev + interval;
+    if new > now {
+        return new;
+    }
+
+    let spent_ns = duration_to_nanos(now.duration_since(prev)).expect("interval should be expired");
+    let interval_ns =
+        duration_to_nanos(interval).expect("interval is less that 427 thousand years");
+    let mult = spent_ns / interval_ns + 1;
+    assert!(
+        mult < (1 << 32),
+        "can't skip more than 4 billion intervals of {:?} \
+         (trying to skip {})",
+        interval,
+        mult
+    );
+    prev + interval * (mult as u32)
+}
+
+#[cfg(test)]
+mod test {
+    use super::next_interval;
+    use std::time::{Duration, Instant};
+
+    struct Timeline(Instant);
+
+    impl Timeline {
+        fn new() -> Timeline {
+            Timeline(Instant::now())
+        }
+        fn at(&self, millis: u64) -> Instant {
+            self.0 + Duration::from_millis(millis)
+        }
+        fn at_ns(&self, sec: u64, nanos: u32) -> Instant {
+            self.0 + Duration::new(sec, nanos)
+        }
+    }
+
+    fn dur(millis: u64) -> Duration {
+        Duration::from_millis(millis)
+    }
+
+    // The math around Instant/Duration isn't 100% precise due to rounding
+    // errors, see #249 for more info
+    fn almost_eq(a: Instant, b: Instant) -> bool {
+        if a == b {
+            true
+        } else if a > b {
+            a - b < Duration::from_millis(1)
+        } else {
+            b - a < Duration::from_millis(1)
+        }
+    }
+
+    #[test]
+    fn norm_next() {
+        let tm = Timeline::new();
+        assert!(almost_eq(
+            next_interval(tm.at(1), tm.at(2), dur(10)),
+            tm.at(11)
+        ));
+        assert!(almost_eq(
+            next_interval(tm.at(7777), tm.at(7788), dur(100)),
+            tm.at(7877)
+        ));
+        assert!(almost_eq(
+            next_interval(tm.at(1), tm.at(1000), dur(2100)),
+            tm.at(2101)
+        ));
+    }
+
+    #[test]
+    fn fast_forward() {
+        let tm = Timeline::new();
+        assert!(almost_eq(
+            next_interval(tm.at(1), tm.at(1000), dur(10)),
+            tm.at(1001)
+        ));
+        assert!(almost_eq(
+            next_interval(tm.at(7777), tm.at(8888), dur(100)),
+            tm.at(8977)
+        ));
+        assert!(almost_eq(
+            next_interval(tm.at(1), tm.at(10000), dur(2100)),
+            tm.at(10501)
+        ));
+    }
+
+    /// TODO: this test actually should be successful, but since we can't
+    ///       multiply Duration on anything larger than u32 easily we decided
+    ///       to allow it to fail for now
+    #[test]
+    #[should_panic(expected = "can't skip more than 4 billion intervals")]
+    fn large_skip() {
+        let tm = Timeline::new();
+        assert_eq!(
+            next_interval(tm.at_ns(0, 1), tm.at_ns(25, 0), Duration::new(0, 2)),
+            tm.at_ns(25, 1)
+        );
+    }
+}

--- a/src/stream/interval.rs
+++ b/src/stream/interval.rs
@@ -14,9 +14,16 @@ use futures_timer::Delay;
 /// `dur` after that. The stream accounts for time elapsed between calls, and
 /// will adjust accordingly to prevent time skews.
 ///
+/// Each interval may be slightly longer than the specified duration, but never
+/// less.
+///
 /// Note that intervals are not intended for high resolution timers, but rather
 /// they will likely fire some granularity after the exact instant that they're
 /// otherwise indicated to fire at.
+///
+/// See also: [`task::sleep`].
+///
+/// [`task::sleep`]: ../task/fn.sleep.html
 ///
 /// # Examples
 ///

--- a/src/stream/interval.rs
+++ b/src/stream/interval.rs
@@ -23,13 +23,18 @@ use futures_timer::Delay;
 /// Basic example:
 ///
 /// ```no_run
+/// use async_std::prelude::*;
+/// use async_std::stream;
 /// use std::time::Duration;
-/// use futures::prelude::*;
 ///
-/// let interval = Interval::new(Duration::from_secs(4));
+/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// #
+/// let mut interval = stream::interval(Duration::from_secs(4));
 /// while let Some(_) = interval.next().await {
-///     println!("prints every four seconds"));
+///     println!("prints every four seconds");
 /// }
+/// #
+/// # Ok(()) }) }
 /// ```
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[doc(inline)]
@@ -63,7 +68,7 @@ impl Stream for Interval {
         }
         let when = Instant::now();
         let next = next_interval(when, Instant::now(), self.interval);
-        self.delay.reset_at(next);
+        self.delay.reset(next);
         Poll::Ready(Some(()))
     }
 }

--- a/src/stream/interval.rs
+++ b/src/stream/interval.rs
@@ -10,7 +10,7 @@ use futures_timer::Delay;
 
 /// Creates a new stream that yields at a set interval.
 ///
-/// The first stream first yields after `dur`, and continues to yield every
+/// The stream first yields after `dur`, and continues to yield every
 /// `dur` after that. The stream accounts for time elapsed between calls, and
 /// will adjust accordingly to prevent time skews.
 ///

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -44,13 +44,15 @@ cfg_if! {
         mod extend;
         mod from_stream;
         mod into_stream;
+        mod interval;
 
         pub use double_ended_stream::DoubleEndedStream;
         pub use exact_size_stream::ExactSizeStream;
         pub use extend::Extend;
         pub use from_stream::FromStream;
-        pub use into_stream::IntoStream;
         pub use fused_stream::FusedStream;
+        pub use into_stream::IntoStream;
+        pub use interval::{interval, Interval};
 
         pub use stream::Merge;
     }

--- a/src/task/sleep.rs
+++ b/src/task/sleep.rs
@@ -11,6 +11,10 @@ use crate::io;
 ///
 /// [`std::thread::sleep`]: https://doc.rust-lang.org/std/thread/fn.sleep.html
 ///
+/// See also: [`stream::interval`].
+///
+/// [`stream::interval`]: ../stream/fn.interval.html
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
Adds `stream::interval` as "unstable", implementing https://github.com/async-rs/async-std/issues/18#issuecomment-521220974. Had to incorporate #275 for this unfortunately also. This integrates the now defunct `futures_timer::Interval` code into `async_std`, building only on the `Delay` primitive. Thanks!

Closes #275. 

cc/ @shaikh-raj 

## Example
```rust
use std::time::Duration;
use futures::prelude::*;

let interval = Interval::new(Duration::from_secs(4));
while let Some(_) = interval.next().await {
    println!("prints every four seconds"));
}
```

## Screenshot

![Screenshot_2019-10-09 async_std stream interval - Rust](https://user-images.githubusercontent.com/2467194/66502353-578fa780-eac5-11e9-865b-9591a20e5666.png)
