### PR TITLE
task::block_on -> thread::spawn_task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ task::blocking(async {
 
 - Refactored the scheduling algorithm of our executor to use work stealing
 - Refactored the network driver, removing 400 lines of code
-- Removed the `Send` bound from `task::block_on`
+- Removed the `Send` bound from `thread::spawn_task`
 - Removed `Unpin` bound from `impl<T: futures::stream::Stream> Stream for T`
 
 # [0.99.5] - 2019-09-12

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ cargo add async-std
 use async_std::task;
 
 fn main() {
-    task::block_on(async {
+    thread::spawn_task(async {
         println!("Hello, world!");
     })
 }
@@ -72,7 +72,7 @@ async fn get() -> io::Result<Vec<u8>> {
 }
 
 fn main() {
-    task::block_on(async {
+    thread::spawn_task(async {
         let raw_response = get().await.expect("request");
         let response = String::from_utf8(raw_response)
             .expect("utf8 conversion");

--- a/benches/task_local.rs
+++ b/benches/task_local.rs
@@ -13,7 +13,7 @@ fn get(b: &mut Bencher) {
     }
 
     let mut sum = 0;
-    task::block_on(async {
+    thread::spawn_task(async {
         b.iter(|| VAL.with(|v| sum += v));
     });
     black_box(sum);

--- a/docs/src/concepts/tasks.md
+++ b/docs/src/concepts/tasks.md
@@ -24,7 +24,7 @@ fn main() {
         }
     });
     println!("Started task!");
-    task::block_on(reader_task);
+    thread::spawn_task(reader_task);
     println!("Stopped task!");
 }
 ```
@@ -86,7 +86,7 @@ Tasks in `async_std` are one of the core abstractions. Much like Rust's `thread`
 # extern crate async_std;
 # use async_std::task;
 fn main() {
-    task::block_on(async {
+    thread::spawn_task(async {
         // this is std::fs, which blocks
         std::fs::read_to_string("test_file");
     })
@@ -107,7 +107,7 @@ In practice, that means that `block_on` propagates panics to the blocking compon
 # extern crate async_std;
 # use async_std::task;
 fn main() {
-    task::block_on(async {
+    thread::spawn_task(async {
         panic!("test");
     });
 }
@@ -128,7 +128,7 @@ task::spawn(async {
     panic!("test");
 });
 
-task::block_on(async {
+thread::spawn_task(async {
     task::sleep(Duration::from_millis(10000)).await;
 })
 ```

--- a/docs/src/tutorial/accept_loop.md
+++ b/docs/src/tutorial/accept_loop.md
@@ -85,7 +85,7 @@ Finally, let's add main:
 // main
 fn run() -> Result<()> {
     let fut = accept_loop("127.0.0.1:8080");
-    task::block_on(fut)
+    thread::spawn_task(fut)
 }
 ```
 
@@ -93,4 +93,4 @@ The crucial thing to realise that is in Rust, unlike other languages, calling an
 Async functions only construct futures, which are inert state machines.
 To start stepping through the future state-machine in an async function, you should use `.await`.
 In a non-async function, a way to execute a future is to hand it to the executor.
-In this case, we use `task::block_on` to execute a future on the current thread and block until it's done.
+In this case, we use `thread::spawn_task` to execute a future on the current thread and block until it's done.

--- a/docs/src/tutorial/all_together.md
+++ b/docs/src/tutorial/all_together.md
@@ -25,7 +25,7 @@ type Receiver<T> = mpsc::UnboundedReceiver<T>;
 
 // main
 fn run() -> Result<()> {
-    task::block_on(accept_loop("127.0.0.1:8080"))
+    thread::spawn_task(accept_loop("127.0.0.1:8080"))
 }
 
 fn spawn_and_log_error<F>(fut: F) -> task::JoinHandle<()>

--- a/docs/src/tutorial/handling_disconnection.md
+++ b/docs/src/tutorial/handling_disconnection.md
@@ -147,7 +147,7 @@ enum Void {}
 
 // main
 fn run() -> Result<()> {
-    task::block_on(accept_loop("127.0.0.1:8080"))
+    thread::spawn_task(accept_loop("127.0.0.1:8080"))
 }
 
 async fn accept_loop(addr: impl ToSocketAddrs) -> Result<()> {

--- a/docs/src/tutorial/implementing_a_client.md
+++ b/docs/src/tutorial/implementing_a_client.md
@@ -29,7 +29,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>
 
 // main
 fn run() -> Result<()> {
-    task::block_on(try_run("127.0.0.1:8080"))
+    thread::spawn_task(try_run("127.0.0.1:8080"))
 }
 
 async fn try_run(addr: impl ToSocketAddrs) -> Result<()> {

--- a/examples/a-chat/client.rs
+++ b/examples/a-chat/client.rs
@@ -5,7 +5,7 @@ use async_std::{
     io::{stdin, BufReader},
     net::{TcpStream, ToSocketAddrs},
     prelude::*,
-    task,
+    thread,
 };
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;

--- a/examples/a-chat/client.rs
+++ b/examples/a-chat/client.rs
@@ -11,7 +11,7 @@ use async_std::{
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 pub(crate) fn main() -> Result<()> {
-    task::block_on(try_main("127.0.0.1:8080"))
+    thread::spawn_task(try_main("127.0.0.1:8080"))
 }
 
 async fn try_main(addr: impl ToSocketAddrs) -> Result<()> {

--- a/examples/a-chat/server.rs
+++ b/examples/a-chat/server.rs
@@ -20,7 +20,7 @@ type Receiver<T> = mpsc::UnboundedReceiver<T>;
 enum Void {}
 
 pub(crate) fn main() -> Result<()> {
-    task::block_on(accept_loop("127.0.0.1:8080"))
+    thread::spawn_task(accept_loop("127.0.0.1:8080"))
 }
 
 async fn accept_loop(addr: impl ToSocketAddrs) -> Result<()> {

--- a/examples/a-chat/server.rs
+++ b/examples/a-chat/server.rs
@@ -10,6 +10,7 @@ use async_std::{
     net::{TcpListener, TcpStream, ToSocketAddrs},
     prelude::*,
     task,
+    thread,
 };
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -7,5 +7,5 @@ async fn say_hi() {
 }
 
 fn main() {
-    task::block_on(say_hi())
+    thread::spawn_task(say_hi())
 }

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,6 +1,6 @@
 //! Spawns a task that says hello.
 
-use async_std::task;
+use async_std::thread;
 
 async fn say_hi() {
     println!("Hello, world!");

--- a/examples/line-count.rs
+++ b/examples/line-count.rs
@@ -10,7 +10,7 @@ use async_std::task;
 fn main() -> io::Result<()> {
     let path = args().nth(1).expect("missing path argument");
 
-    task::block_on(async {
+    thread::spawn_task(async {
         let file = File::open(&path).await?;
         let mut lines = BufReader::new(file).lines();
         let mut count = 0u64;

--- a/examples/line-count.rs
+++ b/examples/line-count.rs
@@ -5,7 +5,7 @@ use std::env::args;
 use async_std::fs::File;
 use async_std::io::{self, BufReader};
 use async_std::prelude::*;
-use async_std::task;
+use async_std::thread;
 
 fn main() -> io::Result<()> {
     let path = args().nth(1).expect("missing path argument");

--- a/examples/list-dir.rs
+++ b/examples/list-dir.rs
@@ -10,7 +10,7 @@ use async_std::task;
 fn main() -> io::Result<()> {
     let path = args().nth(1).expect("missing path argument");
 
-    task::block_on(async {
+    thread::spawn_task(async {
         let mut dir = fs::read_dir(&path).await?;
 
         while let Some(res) = dir.next().await {

--- a/examples/list-dir.rs
+++ b/examples/list-dir.rs
@@ -5,7 +5,7 @@ use std::env::args;
 use async_std::fs;
 use async_std::io;
 use async_std::prelude::*;
-use async_std::task;
+use async_std::thread;
 
 fn main() -> io::Result<()> {
     let path = args().nth(1).expect("missing path argument");

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -5,7 +5,7 @@ use async_std::task;
 fn main() {
     femme::start(log::LevelFilter::Trace).unwrap();
 
-    task::block_on(async {
+    thread::spawn_task(async {
         let handle = task::spawn(async {
             log::info!("Hello world!");
         });

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,6 +1,6 @@
 //! Prints the runtime's execution log on the standard output.
 
-use async_std::task;
+use async_std::thread;
 
 fn main() {
     femme::start(log::LevelFilter::Trace).unwrap();

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,6 +1,7 @@
 //! Prints the runtime's execution log on the standard output.
 
 use async_std::thread;
+use async_std::task;
 
 fn main() {
     femme::start(log::LevelFilter::Trace).unwrap();

--- a/examples/print-file.rs
+++ b/examples/print-file.rs
@@ -12,7 +12,7 @@ const LEN: usize = 16 * 1024; // 16 Kb
 fn main() -> io::Result<()> {
     let path = args().nth(1).expect("missing path argument");
 
-    task::block_on(async {
+    thread::spawn_task(async {
         let mut file = File::open(&path).await?;
         let mut stdout = io::stdout();
         let mut buf = vec![0u8; LEN];

--- a/examples/print-file.rs
+++ b/examples/print-file.rs
@@ -5,7 +5,7 @@ use std::env::args;
 use async_std::fs::File;
 use async_std::io;
 use async_std::prelude::*;
-use async_std::task;
+use async_std::thread;
 
 const LEN: usize = 16 * 1024; // 16 Kb
 

--- a/examples/socket-timeouts.rs
+++ b/examples/socket-timeouts.rs
@@ -2,7 +2,8 @@
 
 use std::time::Duration;
 
-use async_std::{io, net::TcpStream, prelude::*, task};
+use async_std::{io, net::TcpStream, prelude::*};
+use async_std::thread;
 
 async fn get() -> io::Result<Vec<u8>> {
     let mut stream = TcpStream::connect("example.com:80").await?;

--- a/examples/socket-timeouts.rs
+++ b/examples/socket-timeouts.rs
@@ -20,7 +20,7 @@ async fn get() -> io::Result<Vec<u8>> {
 }
 
 fn main() {
-    task::block_on(async {
+    thread::spawn_task(async {
         let raw_response = get().await.expect("request");
         let response = String::from_utf8(raw_response).expect("utf8 conversion");
         println!("received: {}", response);

--- a/examples/stdin-echo.rs
+++ b/examples/stdin-echo.rs
@@ -5,7 +5,7 @@ use async_std::prelude::*;
 use async_std::task;
 
 fn main() -> io::Result<()> {
-    task::block_on(async {
+    thread::spawn_task(async {
         let stdin = io::stdin();
         let mut stdout = io::stdout();
         let mut line = String::new();

--- a/examples/stdin-echo.rs
+++ b/examples/stdin-echo.rs
@@ -2,7 +2,8 @@
 
 use async_std::io;
 use async_std::prelude::*;
-use async_std::task;
+use async_std::thread;
+use async_std::thread;
 
 fn main() -> io::Result<()> {
     thread::spawn_task(async {

--- a/examples/stdin-echo.rs
+++ b/examples/stdin-echo.rs
@@ -3,7 +3,6 @@
 use async_std::io;
 use async_std::prelude::*;
 use async_std::thread;
-use async_std::thread;
 
 fn main() -> io::Result<()> {
     thread::spawn_task(async {

--- a/examples/stdin-timeout.rs
+++ b/examples/stdin-timeout.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use async_std::io;
-use async_std::task;
+use async_std::thread;
 
 fn main() -> io::Result<()> {
     // This async scope times out after 5 seconds.

--- a/examples/stdin-timeout.rs
+++ b/examples/stdin-timeout.rs
@@ -7,7 +7,7 @@ use async_std::task;
 
 fn main() -> io::Result<()> {
     // This async scope times out after 5 seconds.
-    task::block_on(io::timeout(Duration::from_secs(5), async {
+    thread::spawn_task(io::timeout(Duration::from_secs(5), async {
         let stdin = io::stdin();
 
         // Read a line from the standard input and display it.

--- a/examples/surf-web.rs
+++ b/examples/surf-web.rs
@@ -1,7 +1,7 @@
 /* TODO: Once the next version of surf released, re-enable this example.
 //! Sends an HTTP request to the Rust website.
 
-use async_std::task;
+use async_std::thread;
 
 fn main() -> Result<(), surf::Exception> {
     thread::spawn_task(async {

--- a/examples/surf-web.rs
+++ b/examples/surf-web.rs
@@ -4,7 +4,7 @@
 use async_std::task;
 
 fn main() -> Result<(), surf::Exception> {
-    task::block_on(async {
+    thread::spawn_task(async {
         let url = "https://www.rust-lang.org";
         let mut response = surf::get(url).await?;
         let body = response.body_string().await?;

--- a/examples/task-local.rs
+++ b/examples/task-local.rs
@@ -10,7 +10,7 @@ task_local! {
 }
 
 fn main() {
-    task::block_on(async {
+    thread::spawn_task(async {
         println!("var = {}", VAR.with(|v| v.get()));
         VAR.with(|v| v.set(2));
         println!("var = {}", VAR.with(|v| v.get()));

--- a/examples/task-local.rs
+++ b/examples/task-local.rs
@@ -3,7 +3,7 @@
 use std::cell::Cell;
 
 use async_std::prelude::*;
-use async_std::task;
+use async_std::thread;
 
 task_local! {
     static VAR: Cell<i32> = Cell::new(1);

--- a/examples/task-name.rs
+++ b/examples/task-name.rs
@@ -1,5 +1,6 @@
 //! Spawns a named task that prints its name.
 
+use async_std::task;
 use async_std::thread;
 
 async fn print_name() {

--- a/examples/task-name.rs
+++ b/examples/task-name.rs
@@ -1,6 +1,6 @@
 //! Spawns a named task that prints its name.
 
-use async_std::task;
+use async_std::thread;
 
 async fn print_name() {
     println!("My name is {:?}", task::current().name());

--- a/examples/task-name.rs
+++ b/examples/task-name.rs
@@ -7,7 +7,7 @@ async fn print_name() {
 }
 
 fn main() {
-    task::block_on(async {
+    thread::spawn_task(async {
         task::Builder::new()
             .name("my-task".to_string())
             .spawn(print_name())

--- a/examples/tcp-client.rs
+++ b/examples/tcp-client.rs
@@ -18,7 +18,7 @@ use async_std::prelude::*;
 use async_std::task;
 
 fn main() -> io::Result<()> {
-    task::block_on(async {
+    thread::spawn_task(async {
         let mut stream = TcpStream::connect("127.0.0.1:8080").await?;
         println!("Connected to {}", &stream.peer_addr()?);
 

--- a/examples/tcp-client.rs
+++ b/examples/tcp-client.rs
@@ -15,7 +15,7 @@
 use async_std::io;
 use async_std::net::TcpStream;
 use async_std::prelude::*;
-use async_std::task;
+use async_std::thread;
 
 fn main() -> io::Result<()> {
     thread::spawn_task(async {

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -10,6 +10,7 @@ use async_std::io;
 use async_std::net::{TcpListener, TcpStream};
 use async_std::prelude::*;
 use async_std::thread;
+use async_std::task;
 
 async fn process(stream: TcpStream) -> io::Result<()> {
     println!("Accepted from: {}", stream.peer_addr()?);

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -21,7 +21,7 @@ async fn process(stream: TcpStream) -> io::Result<()> {
 }
 
 fn main() -> io::Result<()> {
-    task::block_on(async {
+    thread::spawn_task(async {
         let listener = TcpListener::bind("127.0.0.1:8080").await?;
         println!("Listening on {}", listener.local_addr()?);
 

--- a/examples/tcp-echo.rs
+++ b/examples/tcp-echo.rs
@@ -9,7 +9,7 @@
 use async_std::io;
 use async_std::net::{TcpListener, TcpStream};
 use async_std::prelude::*;
-use async_std::task;
+use async_std::thread;
 
 async fn process(stream: TcpStream) -> io::Result<()> {
     println!("Accepted from: {}", stream.peer_addr()?);

--- a/examples/udp-client.rs
+++ b/examples/udp-client.rs
@@ -17,7 +17,7 @@ use async_std::net::UdpSocket;
 use async_std::task;
 
 fn main() -> io::Result<()> {
-    task::block_on(async {
+    thread::spawn_task(async {
         let socket = UdpSocket::bind("127.0.0.1:8081").await?;
         println!("Listening on {}", socket.local_addr()?);
 

--- a/examples/udp-client.rs
+++ b/examples/udp-client.rs
@@ -14,7 +14,7 @@
 
 use async_std::io;
 use async_std::net::UdpSocket;
-use async_std::task;
+use async_std::thread;
 
 fn main() -> io::Result<()> {
     thread::spawn_task(async {

--- a/examples/udp-echo.rs
+++ b/examples/udp-echo.rs
@@ -8,7 +8,7 @@
 
 use async_std::io;
 use async_std::net::UdpSocket;
-use async_std::task;
+use async_std::thread;
 
 fn main() -> io::Result<()> {
     thread::spawn_task(async {

--- a/examples/udp-echo.rs
+++ b/examples/udp-echo.rs
@@ -11,7 +11,7 @@ use async_std::net::UdpSocket;
 use async_std::task;
 
 fn main() -> io::Result<()> {
-    task::block_on(async {
+    thread::spawn_task(async {
         let socket = UdpSocket::bind("127.0.0.1:8080").await?;
         let mut buf = vec![0u8; 1024];
 

--- a/src/fs/canonicalize.rs
+++ b/src/fs/canonicalize.rs
@@ -23,7 +23,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/copy.rs
+++ b/src/fs/copy.rs
@@ -31,7 +31,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/create_dir.rs
+++ b/src/fs/create_dir.rs
@@ -25,7 +25,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/create_dir_all.rs
+++ b/src/fs/create_dir_all.rs
@@ -20,7 +20,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/dir_builder.rs
+++ b/src/fs/dir_builder.rs
@@ -86,7 +86,7 @@ impl DirBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::DirBuilder;
     ///

--- a/src/fs/dir_entry.rs
+++ b/src/fs/dir_entry.rs
@@ -35,7 +35,7 @@ impl DirEntry {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs;
     /// use async_std::prelude::*;
@@ -73,7 +73,7 @@ impl DirEntry {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs;
     /// use async_std::prelude::*;
@@ -111,7 +111,7 @@ impl DirEntry {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs;
     /// use async_std::prelude::*;
@@ -135,7 +135,7 @@ impl DirEntry {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs;
     /// use async_std::prelude::*;

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -15,6 +15,7 @@ use crate::future;
 use crate::io::{self, Read, Seek, SeekFrom, Write};
 use crate::prelude::*;
 use crate::task::{self, blocking, Context, Poll, Waker};
+use crate::thread;
 
 /// An open file on the filesystem.
 ///
@@ -34,7 +35,7 @@ use crate::task::{self, blocking, Context, Poll, Waker};
 /// Create a new file and write some bytes to it:
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs::File;
 /// use async_std::prelude::*;
@@ -48,7 +49,7 @@ use crate::task::{self, blocking, Context, Poll, Waker};
 /// Read the contents of a file into a vector of bytes:
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs::File;
 /// use async_std::prelude::*;
@@ -87,7 +88,7 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     ///
@@ -122,7 +123,7 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     ///
@@ -146,7 +147,7 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     /// use async_std::prelude::*;
@@ -182,7 +183,7 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     /// use async_std::prelude::*;
@@ -216,7 +217,7 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     ///
@@ -242,7 +243,7 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     ///
@@ -268,7 +269,7 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     ///
@@ -292,7 +293,7 @@ impl Drop for File {
         // non-blocking fashion, but our only other option here is losing data remaining in the
         // write cache. Good task schedulers should be resilient to occasional blocking hiccups in
         // file destructors so we don't expect this to be a common problem in practice.
-        let _ = task::block_on(self.flush());
+        let _ = thread::spawn_task(self.flush());
     }
 }
 

--- a/src/fs/file_type.rs
+++ b/src/fs/file_type.rs
@@ -29,7 +29,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///
@@ -49,7 +49,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///
@@ -67,7 +67,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///

--- a/src/fs/hard_link.rs
+++ b/src/fs/hard_link.rs
@@ -22,7 +22,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -27,7 +27,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///
@@ -68,7 +68,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///
@@ -88,7 +88,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///
@@ -108,7 +108,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///
@@ -126,7 +126,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///
@@ -144,7 +144,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///
@@ -167,7 +167,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///
@@ -190,7 +190,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///
@@ -213,7 +213,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -14,7 +14,7 @@
 //! Create a new file and write some bytes to it:
 //!
 //! ```no_run
-//! # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+//! # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 //! #
 //! use async_std::fs::File;
 //! use async_std::prelude::*;

--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -32,7 +32,7 @@ use crate::task::blocking;
 /// Open a file for reading:
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs::OpenOptions;
 ///
@@ -47,7 +47,7 @@ use crate::task::blocking;
 /// Open a file for both reading and writing, and create it if it doesn't exist yet:
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs::OpenOptions;
 ///
@@ -71,7 +71,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::OpenOptions;
     ///
@@ -93,7 +93,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::OpenOptions;
     ///
@@ -119,7 +119,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::OpenOptions;
     ///
@@ -143,7 +143,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::OpenOptions;
     ///
@@ -171,7 +171,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::OpenOptions;
     ///
@@ -200,7 +200,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::OpenOptions;
     ///
@@ -230,7 +230,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::OpenOptions;
     ///
@@ -272,7 +272,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::OpenOptions;
     ///

--- a/src/fs/permissions.rs
+++ b/src/fs/permissions.rs
@@ -18,7 +18,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///
@@ -38,7 +38,7 @@ cfg_if! {
             /// # Examples
             ///
             /// ```no_run
-            /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             /// #
             /// use async_std::fs;
             ///

--- a/src/fs/read.rs
+++ b/src/fs/read.rs
@@ -27,7 +27,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/read_dir.rs
+++ b/src/fs/read_dir.rs
@@ -29,7 +29,7 @@ use crate::task::{blocking, Context, JoinHandle, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 /// use async_std::prelude::*;

--- a/src/fs/read_link.rs
+++ b/src/fs/read_link.rs
@@ -19,7 +19,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/read_to_string.rs
+++ b/src/fs/read_to_string.rs
@@ -28,7 +28,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/remove_dir.rs
+++ b/src/fs/remove_dir.rs
@@ -20,7 +20,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/remove_dir_all.rs
+++ b/src/fs/remove_dir_all.rs
@@ -20,7 +20,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/remove_file.rs
+++ b/src/fs/remove_file.rs
@@ -20,7 +20,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/rename.rs
+++ b/src/fs/rename.rs
@@ -24,7 +24,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/set_permissions.rs
+++ b/src/fs/set_permissions.rs
@@ -21,7 +21,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/symlink_metadata.rs
+++ b/src/fs/symlink_metadata.rs
@@ -25,7 +25,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/fs/write.rs
+++ b/src/fs/write.rs
@@ -23,7 +23,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs;
 ///

--- a/src/future/pending.rs
+++ b/src/future/pending.rs
@@ -9,7 +9,7 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
 /// use std::time::Duration;
 ///

--- a/src/future/poll_fn.rs
+++ b/src/future/poll_fn.rs
@@ -10,7 +10,7 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::future;
 /// use async_std::task::{Context, Poll};

--- a/src/future/ready.rs
+++ b/src/future/ready.rs
@@ -7,7 +7,7 @@
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::future;
 ///

--- a/src/future/timeout.rs
+++ b/src/future/timeout.rs
@@ -16,7 +16,7 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use std::time::Duration;
 ///

--- a/src/io/buf_read/mod.rs
+++ b/src/io/buf_read/mod.rs
@@ -77,7 +77,7 @@ extension_trait! {
             # Examples
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::fs::File;
             use async_std::io::BufReader;
@@ -94,7 +94,7 @@ extension_trait! {
             Multiple successful calls to `read_until` append all bytes up to and including to
             `buf`:
             ```
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::io::BufReader;
             use async_std::prelude::*;
@@ -155,7 +155,7 @@ extension_trait! {
             # Examples
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::fs::File;
             use async_std::io::BufReader;
@@ -197,7 +197,7 @@ extension_trait! {
             # Examples
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::fs::File;
             use async_std::io::BufReader;

--- a/src/io/buf_reader.rs
+++ b/src/io/buf_reader.rs
@@ -29,7 +29,7 @@ const DEFAULT_CAPACITY: usize = 8 * 1024;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::fs::File;
 /// use async_std::io::BufReader;
@@ -57,7 +57,7 @@ impl<R: io::Read> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     /// use async_std::io::BufReader;
@@ -75,7 +75,7 @@ impl<R: io::Read> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     /// use async_std::io::BufReader;
@@ -106,7 +106,7 @@ impl<R> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     /// use async_std::io::BufReader;
@@ -127,7 +127,7 @@ impl<R> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     /// use async_std::io::BufReader;
@@ -148,7 +148,7 @@ impl<R> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     /// use async_std::io::BufReader;
@@ -169,7 +169,7 @@ impl<R> BufReader<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::fs::File;
     /// use async_std::io::BufReader;

--- a/src/io/buf_writer.rs
+++ b/src/io/buf_writer.rs
@@ -308,7 +308,7 @@ mod tests {
     use super::BufWriter;
     use crate::io::{self, SeekFrom};
     use crate::prelude::*;
-    use crate::task;
+    use crate::thread;
 
     #[test]
     fn test_buffered_writer() {

--- a/src/io/buf_writer.rs
+++ b/src/io/buf_writer.rs
@@ -35,7 +35,7 @@ const DEFAULT_CAPACITY: usize = 8 * 1024;
 /// Let's write the numbers one through ten to a [`TcpStream`]:
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// use async_std::net::TcpStream;
 /// use async_std::prelude::*;
 ///
@@ -54,7 +54,7 @@ const DEFAULT_CAPACITY: usize = 8 * 1024;
 /// `BufWriter`:
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// use async_std::io::BufWriter;
 /// use async_std::net::TcpStream;
 /// use async_std::prelude::*;
@@ -93,7 +93,7 @@ impl<W: AsyncWrite> BufWriter<W> {
     ///
     /// ```no_run
     /// # #![allow(unused_mut)]
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// use async_std::io::BufWriter;
     /// use async_std::net::TcpStream;
     ///
@@ -113,7 +113,7 @@ impl<W: AsyncWrite> BufWriter<W> {
     ///
     /// ```no_run
     /// # #![allow(unused_mut)]
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// use async_std::io::BufWriter;
     /// use async_std::net::TcpStream;
     ///
@@ -136,7 +136,7 @@ impl<W: AsyncWrite> BufWriter<W> {
     ///
     /// ```no_run
     /// # #![allow(unused_mut)]
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// use async_std::io::BufWriter;
     /// use async_std::net::TcpStream;
     ///
@@ -158,7 +158,7 @@ impl<W: AsyncWrite> BufWriter<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// use async_std::io::BufWriter;
     /// use async_std::net::TcpStream;
     ///
@@ -196,7 +196,7 @@ impl<W: AsyncWrite> BufWriter<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// use async_std::io::BufWriter;
     /// use async_std::net::TcpStream;
     ///
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     fn test_buffered_writer() {
-        task::block_on(async {
+        thread::spawn_task(async {
             let inner = Vec::new();
             let mut writer = BufWriter::with_capacity(2, inner);
 
@@ -357,7 +357,7 @@ mod tests {
 
     #[test]
     fn test_buffered_writer_inner_into_inner_does_not_flush() {
-        task::block_on(async {
+        thread::spawn_task(async {
             let mut w = BufWriter::with_capacity(3, Vec::new());
             w.write(&[0, 1]).await.unwrap();
             assert_eq!(*w.get_ref(), []);
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     fn test_buffered_writer_seek() {
-        task::block_on(async {
+        thread::spawn_task(async {
             let mut w = BufWriter::with_capacity(3, io::Cursor::new(Vec::new()));
             w.write_all(&[0, 1, 2, 3, 4, 5]).await.unwrap();
             w.write_all(&[6, 7]).await.unwrap();

--- a/src/io/copy.rs
+++ b/src/io/copy.rs
@@ -30,7 +30,7 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::io;
 ///

--- a/src/io/cursor.rs
+++ b/src/io/cursor.rs
@@ -107,7 +107,7 @@ impl<T> Cursor<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::io::Cursor;
     /// use async_std::io::prelude::*;

--- a/src/io/empty.rs
+++ b/src/io/empty.rs
@@ -9,7 +9,7 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```rust
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::io;
 /// use async_std::prelude::*;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -9,7 +9,7 @@
 //! Read a line from the standard input:
 //!
 //! ```no_run
-//! # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+//! # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 //! #
 //! use async_std::io;
 //!

--- a/src/io/read/bytes.rs
+++ b/src/io/read/bytes.rs
@@ -36,6 +36,7 @@ impl<T: Read + Unpin> Stream for Bytes<T> {
 mod tests {
     use crate::io;
     use crate::prelude::*;
+    use crate::thread;
     use crate::task;
 
     #[test]

--- a/src/io/read/bytes.rs
+++ b/src/io/read/bytes.rs
@@ -40,7 +40,7 @@ mod tests {
 
     #[test]
     fn test_bytes_basics() -> std::io::Result<()> {
-        task::block_on(async move {
+        thread::spawn_task(async move {
             let raw: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
             let source: io::Cursor<Vec<u8>> = io::Cursor::new(raw.clone());
 

--- a/src/io/read/bytes.rs
+++ b/src/io/read/bytes.rs
@@ -37,7 +37,6 @@ mod tests {
     use crate::io;
     use crate::prelude::*;
     use crate::thread;
-    use crate::task;
 
     #[test]
     fn test_bytes_basics() -> std::io::Result<()> {

--- a/src/io/read/chain.rs
+++ b/src/io/read/chain.rs
@@ -23,7 +23,7 @@ impl<T, U> Chain<T, U> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> async_std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> async_std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::prelude::*;
     /// use async_std::fs::File;
@@ -45,7 +45,7 @@ impl<T, U> Chain<T, U> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> async_std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> async_std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::prelude::*;
     /// use async_std::fs::File;
@@ -71,7 +71,7 @@ impl<T, U> Chain<T, U> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> async_std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> async_std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::prelude::*;
     /// use async_std::fs::File;
@@ -183,7 +183,7 @@ mod tests {
         let source1: io::Cursor<Vec<u8>> = io::Cursor::new(vec![0, 1, 2]);
         let source2: io::Cursor<Vec<u8>> = io::Cursor::new(vec![3, 4, 5]);
 
-        task::block_on(async move {
+        thread::spawn_task(async move {
             let mut buffer = Vec::new();
 
             let mut source = source1.chain(source2);

--- a/src/io/read/chain.rs
+++ b/src/io/read/chain.rs
@@ -176,7 +176,7 @@ impl<T: BufRead + Unpin, U: BufRead + Unpin> BufRead for Chain<T, U> {
 mod tests {
     use crate::io;
     use crate::prelude::*;
-    use crate::task;
+    use crate::thread;
 
     #[test]
     fn test_chain_basics() -> std::io::Result<()> {

--- a/src/io/read/mod.rs
+++ b/src/io/read/mod.rs
@@ -89,7 +89,7 @@ extension_trait! {
             # Examples
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::fs::File;
             use async_std::prelude::*;
@@ -148,7 +148,7 @@ extension_trait! {
             # Examples
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::fs::File;
             use async_std::prelude::*;
@@ -187,7 +187,7 @@ extension_trait! {
             # Examples
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::fs::File;
             use async_std::prelude::*;
@@ -242,7 +242,7 @@ extension_trait! {
             # Examples
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::fs::File;
             use async_std::prelude::*;
@@ -282,7 +282,7 @@ extension_trait! {
             [`read()`]: tymethod.read
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::io::prelude::*;
             use async_std::fs::File;
@@ -318,7 +318,7 @@ extension_trait! {
             [file]: ../fs/struct.File.html
            
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use async_std::fs::File;
@@ -359,7 +359,7 @@ extension_trait! {
             [file]: ../fs/struct.File.html
            
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use async_std::fs::File;
@@ -392,7 +392,7 @@ extension_trait! {
             [file]: ../fs/struct.File.html
            
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use async_std::fs::File;
@@ -477,7 +477,7 @@ mod tests {
 
     #[test]
     fn test_read_by_ref() -> io::Result<()> {
-        crate::task::block_on(async {
+        crate::thread::spawn_task(async {
             let mut f = io::Cursor::new(vec![0u8, 1, 2, 3, 4, 5, 6, 7, 8]);
             let mut buffer = Vec::new();
             let mut other_buffer = Vec::new();

--- a/src/io/read/take.rs
+++ b/src/io/read/take.rs
@@ -218,7 +218,7 @@ impl<T: BufRead + Unpin> BufRead for Take<T> {
 mod tests {
     use crate::io;
     use crate::prelude::*;
-    use crate::task;
+    use crate::thread;
 
     #[test]
     fn test_take_basics() -> std::io::Result<()> {

--- a/src/io/read/take.rs
+++ b/src/io/read/take.rs
@@ -30,7 +30,7 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> async_std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> async_std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::prelude::*;
     /// use async_std::fs::File;
@@ -56,7 +56,7 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> async_std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> async_std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::prelude::*;
     /// use async_std::fs::File;
@@ -80,7 +80,7 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> async_std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> async_std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::prelude::*;
     /// use async_std::fs::File;
@@ -104,7 +104,7 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> async_std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> async_std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::prelude::*;
     /// use async_std::fs::File;
@@ -132,7 +132,7 @@ impl<T> Take<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> async_std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> async_std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::prelude::*;
     /// use async_std::fs::File;
@@ -224,7 +224,7 @@ mod tests {
     fn test_take_basics() -> std::io::Result<()> {
         let source: io::Cursor<Vec<u8>> = io::Cursor::new(vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
 
-        task::block_on(async move {
+        thread::spawn_task(async move {
             let mut buffer = [0u8; 5];
 
             // read at most five bytes

--- a/src/io/repeat.rs
+++ b/src/io/repeat.rs
@@ -11,7 +11,7 @@ use crate::task::{Context, Poll};
 /// ## Examples
 ///
 /// ```rust
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::io;
 /// use async_std::prelude::*;

--- a/src/io/seek.rs
+++ b/src/io/seek.rs
@@ -54,7 +54,7 @@ extension_trait! {
             # Examples
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::fs::File;
             use async_std::io::SeekFrom;

--- a/src/io/sink.rs
+++ b/src/io/sink.rs
@@ -9,7 +9,7 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```rust
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::io;
 /// use async_std::prelude::*;

--- a/src/io/stderr.rs
+++ b/src/io/stderr.rs
@@ -16,7 +16,7 @@ use crate::task::{blocking, Context, JoinHandle, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::io;
 /// use async_std::prelude::*;

--- a/src/io/stdin.rs
+++ b/src/io/stdin.rs
@@ -16,7 +16,7 @@ use crate::task::{blocking, Context, JoinHandle, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::io;
 ///
@@ -89,7 +89,7 @@ impl Stdin {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::io;
     ///

--- a/src/io/stdout.rs
+++ b/src/io/stdout.rs
@@ -16,7 +16,7 @@ use crate::task::{blocking, Context, JoinHandle, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::io;
 /// use async_std::prelude::*;

--- a/src/io/timeout.rs
+++ b/src/io/timeout.rs
@@ -13,7 +13,7 @@ use crate::io;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use std::time::Duration;
 ///

--- a/src/io/write/mod.rs
+++ b/src/io/write/mod.rs
@@ -92,7 +92,7 @@ extension_trait! {
             # Examples
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::fs::File;
             use async_std::prelude::*;
@@ -120,7 +120,7 @@ extension_trait! {
             # Examples
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::fs::File;
             use async_std::prelude::*;
@@ -174,7 +174,7 @@ extension_trait! {
             # Examples
 
             ```no_run
-            # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+            # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
             #
             use async_std::fs::File;
             use async_std::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! fn main() {
 //!     thread::spawn_task(async {
 //!         println!("Hello, world!");
-//!     }).join()
+//!     })
 //! }
 //! ```
 //!
@@ -58,8 +58,8 @@ pub mod os;
 pub mod prelude;
 pub mod stream;
 pub mod sync;
-pub mod thread;
 pub mod task;
+pub mod thread;
 
 cfg_if! {
     if #[cfg(any(feature = "unstable", feature = "docs"))] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,12 @@
 //! Spawn a task and block the current thread on its result:
 //!
 //! ```
-//! use async_std::task;
+//! use async_std::thread;
 //!
 //! fn main() {
-//!     task::block_on(async {
+//!     thread::spawn_task(async {
 //!         println!("Hello, world!");
-//!     })
+//!     }).join()
 //! }
 //! ```
 //!
@@ -58,6 +58,7 @@ pub mod os;
 pub mod prelude;
 pub mod stream;
 pub mod sync;
+pub mod thread;
 pub mod task;
 
 cfg_if! {

--- a/src/net/addr.rs
+++ b/src/net/addr.rs
@@ -34,7 +34,7 @@ cfg_if! {
 /// # Examples
 ///
 /// ```
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::net::ToSocketAddrs;
 ///

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -13,7 +13,7 @@
 //! A simple UDP echo server:
 //!
 //! ```no_run
-//! # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+//! # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 //! #
 //! use async_std::net::UdpSocket;
 //!

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -31,7 +31,7 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::io;
 /// use async_std::net::TcpListener;
@@ -65,7 +65,7 @@ impl TcpListener {
     /// Create a TCP listener bound to 127.0.0.1:0:
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpListener;
     ///
@@ -104,7 +104,7 @@ impl TcpListener {
     /// ## Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpListener;
     ///
@@ -136,7 +136,7 @@ impl TcpListener {
     /// ## Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpListener;
     /// use async_std::prelude::*;
@@ -163,7 +163,7 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpListener;
     ///

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -34,7 +34,7 @@ use crate::task::{Context, Poll};
 /// ## Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::net::TcpStream;
 /// use async_std::prelude::*;
@@ -64,7 +64,7 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpStream;
     ///
@@ -104,7 +104,7 @@ impl TcpStream {
     /// ## Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpStream;
     ///
@@ -122,7 +122,7 @@ impl TcpStream {
     /// ## Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpStream;
     ///
@@ -144,7 +144,7 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpStream;
     ///
@@ -167,7 +167,7 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpStream;
     ///
@@ -193,7 +193,7 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpStream;
     ///
@@ -217,7 +217,7 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpStream;
     ///
@@ -243,7 +243,7 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::TcpStream;
     ///
@@ -268,7 +268,7 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use std::net::Shutdown;
     ///

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -30,7 +30,7 @@ use crate::net::ToSocketAddrs;
 /// ## Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::net::UdpSocket;
 ///
@@ -60,7 +60,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::UdpSocket;
     ///
@@ -98,7 +98,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     ///	use async_std::net::UdpSocket;
     ///
@@ -118,7 +118,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::UdpSocket;
     ///
@@ -162,7 +162,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::UdpSocket;
     ///
@@ -195,7 +195,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     ///	use async_std::net::UdpSocket;
     ///
@@ -230,7 +230,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::UdpSocket;
     ///
@@ -260,7 +260,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::net::UdpSocket;
     ///
@@ -381,7 +381,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use std::net::Ipv4Addr;
     ///
@@ -410,7 +410,7 @@ impl UdpSocket {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use std::net::{Ipv6Addr, SocketAddr};
     ///

--- a/src/os/unix/fs.rs
+++ b/src/os/unix/fs.rs
@@ -18,7 +18,7 @@ use crate::task::blocking;
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::os::unix::fs::symlink;
 ///

--- a/src/os/unix/net/datagram.rs
+++ b/src/os/unix/net/datagram.rs
@@ -29,7 +29,7 @@ use crate::task::blocking;
 /// ## Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::os::unix::net::UnixDatagram;
 ///
@@ -57,7 +57,7 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
     ///
@@ -76,7 +76,7 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
     ///
@@ -96,7 +96,7 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
     ///
@@ -123,7 +123,7 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
     ///
@@ -143,7 +143,7 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
     ///
@@ -165,7 +165,7 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
     ///
@@ -186,7 +186,7 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
     ///
@@ -211,7 +211,7 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
     ///
@@ -232,7 +232,7 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
     ///
@@ -256,7 +256,7 @@ impl UnixDatagram {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
     ///
@@ -280,7 +280,7 @@ impl UnixDatagram {
     /// ## Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixDatagram;
     /// use std::net::Shutdown;

--- a/src/os/unix/net/listener.rs
+++ b/src/os/unix/net/listener.rs
@@ -33,7 +33,7 @@ use crate::task::{blocking, Context, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::os::unix::net::UnixListener;
 /// use async_std::prelude::*;
@@ -58,7 +58,7 @@ impl UnixListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixListener;
     ///
@@ -82,7 +82,7 @@ impl UnixListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixListener;
     ///
@@ -128,7 +128,7 @@ impl UnixListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixListener;
     /// use async_std::prelude::*;
@@ -152,7 +152,7 @@ impl UnixListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixListener;
     ///

--- a/src/os/unix/net/stream.rs
+++ b/src/os/unix/net/stream.rs
@@ -24,7 +24,7 @@ use crate::task::{blocking, Context, Poll};
 /// # Examples
 ///
 /// ```no_run
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::os::unix::net::UnixStream;
 /// use async_std::prelude::*;
@@ -47,7 +47,7 @@ impl UnixStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixStream;
     ///
@@ -75,7 +75,7 @@ impl UnixStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixStream;
     ///
@@ -99,7 +99,7 @@ impl UnixStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixStream;
     ///
@@ -117,7 +117,7 @@ impl UnixStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixStream;
     ///
@@ -138,7 +138,7 @@ impl UnixStream {
     /// [`Shutdown`]: https://doc.rust-lang.org/std/net/enum.Shutdown.html
     ///
     /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::os::unix::net::UnixStream;
     /// use std::net::Shutdown;

--- a/src/stream/empty.rs
+++ b/src/stream/empty.rs
@@ -9,7 +9,7 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::prelude::*;
 /// use async_std::stream;

--- a/src/stream/extend.rs
+++ b/src/stream/extend.rs
@@ -14,7 +14,7 @@ use crate::stream::IntoStream;
 /// ## Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::prelude::*;
 /// use async_std::stream::{self, Extend};

--- a/src/stream/from_stream.rs
+++ b/src/stream/from_stream.rs
@@ -14,7 +14,7 @@ use std::pin::Pin;
 /// Basic usage:
 ///
 /// ```
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 ///  use crate::async_std::stream::FromStream;
 ///  use async_std::prelude::*;
 ///  use async_std::stream;
@@ -30,7 +30,7 @@ use std::pin::Pin;
 /// Using `collect` to  implicitly use `FromStream`
 ///
 ///```
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// use async_std::prelude::*;
 /// use async_std::stream;
 /// let five_fives = stream::repeat(5).take(5);
@@ -87,7 +87,7 @@ use std::pin::Pin;
 ///     }
 /// }
 ///
-/// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+/// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
 /// // Now we can make a new stream...
 /// let stream = stream::repeat(5).take(5);
 ///
@@ -116,7 +116,7 @@ pub trait FromStream<T> {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// # fn main() -> std::io::Result<()> { async_std::thread::spawn_task(async {
     ///  use crate::async_std::stream::FromStream;
     ///  use async_std::prelude::*;
     ///  use async_std::stream;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -7,7 +7,7 @@
 //! # Examples
 //!
 //! ```
-//! # fn main() { async_std::task::block_on(async {
+//! # fn main() { async_std::thread::spawn_task(async {
 //! #
 //! use async_std::prelude::*;
 //! use async_std::stream;

--- a/src/stream/once.rs
+++ b/src/stream/once.rs
@@ -8,7 +8,7 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::prelude::*;
 /// use async_std::stream;

--- a/src/stream/repeat.rs
+++ b/src/stream/repeat.rs
@@ -8,7 +8,7 @@ use crate::task::{Context, Poll};
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::prelude::*;
 /// use async_std::stream;

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -7,7 +7,7 @@
 //! # Examples
 //!
 //! ```
-//! # fn main() { async_std::task::block_on(async {
+//! # fn main() { async_std::thread::spawn_task(async {
 //! #
 //! use async_std::prelude::*;
 //! use async_std::stream;
@@ -132,7 +132,7 @@ extension_trait! {
             # Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::pin::Pin;
 
@@ -185,7 +185,7 @@ extension_trait! {
             # Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use async_std::stream;
@@ -211,7 +211,7 @@ extension_trait! {
             # Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use async_std::stream;
@@ -247,7 +247,7 @@ extension_trait! {
             Basic usage:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use std::collections::VecDeque;
@@ -279,7 +279,7 @@ extension_trait! {
             Basic usage:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use std::collections::VecDeque;
@@ -316,7 +316,7 @@ extension_trait! {
             # Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use std::collections::VecDeque;
@@ -346,7 +346,7 @@ extension_trait! {
             # Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use std::collections::VecDeque;
@@ -380,7 +380,7 @@ extension_trait! {
             Basic usage:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use std::collections::VecDeque;
@@ -413,7 +413,7 @@ extension_trait! {
             # Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use async_std::stream;
@@ -444,7 +444,7 @@ extension_trait! {
             Basic usage:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::collections::VecDeque;
 
@@ -476,7 +476,7 @@ extension_trait! {
             Basic usage:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::collections::VecDeque;
 
@@ -517,7 +517,7 @@ extension_trait! {
             # Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::collections::VecDeque;
 
@@ -556,7 +556,7 @@ extension_trait! {
             Basic usage:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::collections::VecDeque;
 
@@ -572,7 +572,7 @@ extension_trait! {
             Calling `nth()` multiple times:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::collections::VecDeque;
 
@@ -590,7 +590,7 @@ extension_trait! {
             ```
             Returning `None` if the stream finished before returning `n` elements:
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::collections::VecDeque;
 
@@ -633,7 +633,7 @@ extension_trait! {
             Basic usage:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use async_std::stream;
@@ -648,7 +648,7 @@ extension_trait! {
             Empty stream:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use async_std::stream;
@@ -684,7 +684,7 @@ extension_trait! {
             Basic usage:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use std::collections::VecDeque;
@@ -699,7 +699,7 @@ extension_trait! {
             Resuming after a first find:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use std::collections::VecDeque;
@@ -729,7 +729,7 @@ extension_trait! {
             Applies function to the elements of stream and returns the first non-none result.
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use std::collections::VecDeque;
@@ -762,7 +762,7 @@ extension_trait! {
             Basic usage:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use std::collections::VecDeque;
@@ -793,7 +793,7 @@ extension_trait! {
             # Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use std::collections::VecDeque;
@@ -841,7 +841,7 @@ extension_trait! {
             Basic usage:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use async_std::stream;
@@ -855,7 +855,7 @@ extension_trait! {
             Empty stream:
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use async_std::stream;
@@ -900,7 +900,7 @@ extension_trait! {
             ## Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::collections::VecDeque;
 
@@ -941,7 +941,7 @@ extension_trait! {
             ## Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::collections::VecDeque;
 
@@ -971,7 +971,7 @@ extension_trait! {
             ## Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::collections::VecDeque;
 
@@ -999,7 +999,7 @@ extension_trait! {
             # Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::collections::VecDeque;
             use std::sync::mpsc::channel;
@@ -1057,7 +1057,7 @@ extension_trait! {
             ## Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use std::collections::VecDeque;
 
@@ -1104,7 +1104,7 @@ extension_trait! {
             # Examples
 
             ```
-            # fn main() { async_std::task::block_on(async {
+            # fn main() { async_std::thread::spawn_task(async {
             #
             use async_std::prelude::*;
             use async_std::stream;

--- a/src/sync/barrier.rs
+++ b/src/sync/barrier.rs
@@ -8,10 +8,10 @@ use crate::sync::Mutex;
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::sync::{Arc, Barrier};
-/// use async_std::task;
+/// use async_std::thread;
 ///
 /// let mut handles = Vec::with_capacity(10);
 /// let barrier = Arc::new(Barrier::new(10));
@@ -118,10 +118,10 @@ impl Barrier {
     /// # Examples
     ///
     /// ```
-    /// # fn main() { async_std::task::block_on(async {
+    /// # fn main() { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::sync::{Arc, Barrier};
-    /// use async_std::task;
+    /// use async_std::thread;
     ///
     /// let mut handles = Vec::with_capacity(10);
     /// let barrier = Arc::new(Barrier::new(10));
@@ -188,7 +188,7 @@ impl BarrierWaitResult {
     /// # Examples
     ///
     /// ```
-    /// # fn main() { async_std::task::block_on(async {
+    /// # fn main() { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::sync::Barrier;
     ///
@@ -219,7 +219,7 @@ mod test {
         // solid.
 
         for _ in 0..1_000 {
-            task::block_on(async move {
+            thread::spawn_task(async move {
                 const N: usize = 10;
 
                 let barrier = Arc::new(Barrier::new(N));

--- a/src/sync/barrier.rs
+++ b/src/sync/barrier.rs
@@ -210,7 +210,7 @@ mod test {
     use futures_util::stream::StreamExt;
 
     use crate::sync::{Arc, Barrier};
-    use crate::task;
+    use crate::thread;
 
     #[test]
     fn test_barrier() {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -9,7 +9,7 @@
 //! Spawn a task that updates an integer protected by a mutex:
 //!
 //! ```
-//! # fn main() { async_std::task::block_on(async {
+//! # fn main() { async_std::thread::spawn_task(async {
 //! #
 //! use std::sync::Arc;
 //!

--- a/src/sync/mutex.rs
+++ b/src/sync/mutex.rs
@@ -24,12 +24,12 @@ const BLOCKED: usize = 1 << 1;
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
 /// use std::sync::Arc;
 ///
 /// use async_std::sync::Mutex;
-/// use async_std::task;
+/// use async_std::thread;
 ///
 /// let m = Arc::new(Mutex::new(0));
 /// let mut tasks = vec![];
@@ -82,12 +82,12 @@ impl<T> Mutex<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() { async_std::task::block_on(async {
+    /// # fn main() { async_std::thread::spawn_task(async {
     /// #
     /// use std::sync::Arc;
     ///
     /// use async_std::sync::Mutex;
-    /// use async_std::task;
+    /// use async_std::thread;
     ///
     /// let m1 = Arc::new(Mutex::new(10));
     /// let m2 = m1.clone();
@@ -196,12 +196,12 @@ impl<T> Mutex<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() { async_std::task::block_on(async {
+    /// # fn main() { async_std::thread::spawn_task(async {
     /// #
     /// use std::sync::Arc;
     ///
     /// use async_std::sync::Mutex;
-    /// use async_std::task;
+    /// use async_std::thread;
     ///
     /// let m1 = Arc::new(Mutex::new(10));
     /// let m2 = m1.clone();
@@ -249,7 +249,7 @@ impl<T> Mutex<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() { async_std::task::block_on(async {
+    /// # fn main() { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::sync::Mutex;
     ///

--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -33,7 +33,7 @@ const READ_COUNT_MASK: usize = !(ONE_READ - 1);
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
 /// use async_std::sync::RwLock;
 ///
@@ -89,7 +89,7 @@ impl<T> RwLock<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() { async_std::task::block_on(async {
+    /// # fn main() { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::sync::RwLock;
     ///
@@ -211,7 +211,7 @@ impl<T> RwLock<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() { async_std::task::block_on(async {
+    /// # fn main() { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::sync::RwLock;
     ///
@@ -253,7 +253,7 @@ impl<T> RwLock<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() { async_std::task::block_on(async {
+    /// # fn main() { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::sync::RwLock;
     ///
@@ -374,7 +374,7 @@ impl<T> RwLock<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() { async_std::task::block_on(async {
+    /// # fn main() { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::sync::RwLock;
     ///
@@ -431,7 +431,7 @@ impl<T> RwLock<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() { async_std::task::block_on(async {
+    /// # fn main() { async_std::thread::spawn_task(async {
     /// #
     /// use async_std::sync::RwLock;
     ///

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -10,7 +10,7 @@
 //! Spawn a task and await its result:
 //!
 //! ```
-//! # fn main() { async_std::task::block_on(async {
+//! # fn main() { async_std::thread::spawn_task(async {
 //! #
 //! use async_std::task;
 //!
@@ -30,7 +30,6 @@ pub use std::task::{Context, Poll, Waker};
 #[doc(inline)]
 pub use async_macros::ready;
 
-pub use block_on::block_on;
 pub use builder::Builder;
 pub use pool::spawn;
 pub use sleep::sleep;
@@ -38,16 +37,15 @@ pub use task::{JoinHandle, Task, TaskId};
 pub use task_local::{AccessError, LocalKey};
 pub use worker::current;
 
-mod block_on;
 mod builder;
 mod pool;
 mod sleep;
 mod sleepers;
-mod task;
-mod task_local;
-mod worker;
 
 pub(crate) mod blocking;
+pub(crate) mod task;
+pub(crate) mod task_local;
+pub(crate) mod worker;
 
 /// Spawns a blocking task.
 ///
@@ -55,18 +53,18 @@ pub(crate) mod blocking;
 /// is useful to prevent long-running synchronous operations from blocking the main futures
 /// executor.
 ///
-/// See also: [`task::block_on`].
+/// See also: [`thread::spawn_task`].
 ///
-/// [`task::block_on`]: fn.block_on.html
+/// [`thread::spawn_task`]: fn.block_on.html
 ///
 /// # Examples
 ///
 /// Basic usage:
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
-/// use async_std::task;
+/// use async_std::thread;
 ///
 /// task::blocking(async {
 ///     println!("long-running task here");

--- a/src/task/pool.rs
+++ b/src/task/pool.rs
@@ -22,9 +22,9 @@ use crate::utils::abort_on_panic;
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
-/// use async_std::task;
+/// use async_std::thread;
 ///
 /// let handle = task::spawn(async {
 ///     1 + 2

--- a/src/task/sleep.rs
+++ b/src/task/sleep.rs
@@ -14,11 +14,11 @@ use crate::io;
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
 /// use std::time::Duration;
 ///
-/// use async_std::task;
+/// use async_std::thread;
 ///
 /// task::sleep(Duration::from_secs(1)).await;
 /// #

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -68,9 +68,9 @@ impl<T> JoinHandle<T> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() { async_std::task::block_on(async {
+    /// # fn main() { async_std::thread::spawn_task(async {
     /// #
-    /// use async_std::task;
+    /// use async_std::thread;
     ///
     /// let handle = task::spawn(async {
     ///     1 + 2
@@ -101,9 +101,9 @@ impl<T> Future for JoinHandle<T> {
 ///
 /// ```
 /// #
-/// use async_std::task;
+/// use async_std::thread;
 ///
-/// task::block_on(async {
+/// thread::spawn_task(async {
 ///     println!("id = {:?}", task::current().id());
 /// })
 /// ```

--- a/src/task/task_local.rs
+++ b/src/task/task_local.rs
@@ -25,14 +25,14 @@ use crate::utils::abort_on_panic;
 /// #
 /// use std::cell::Cell;
 ///
-/// use async_std::task;
+/// use async_std::thread;
 /// use async_std::prelude::*;
 ///
 /// task_local! {
 ///     static VAL: Cell<u32> = Cell::new(5);
 /// }
 ///
-/// task::block_on(async {
+/// thread::spawn_task(async {
 ///     let v = VAL.with(|c| c.get());
 ///     assert_eq!(v, 5);
 /// });
@@ -96,14 +96,14 @@ impl<T: Send + 'static> LocalKey<T> {
     /// #
     /// use std::cell::Cell;
     ///
-    /// use async_std::task;
+    /// use async_std::thread;
     /// use async_std::prelude::*;
     ///
     /// task_local! {
     ///     static NUMBER: Cell<u32> = Cell::new(5);
     /// }
     ///
-    /// task::block_on(async {
+    /// thread::spawn_task(async {
     ///     let v = NUMBER.with(|c| c.get());
     ///     assert_eq!(v, 5);
     /// });
@@ -135,14 +135,14 @@ impl<T: Send + 'static> LocalKey<T> {
     /// #
     /// use std::cell::Cell;
     ///
-    /// use async_std::task;
+    /// use async_std::thread;
     /// use async_std::prelude::*;
     ///
     /// task_local! {
     ///     static VAL: Cell<u32> = Cell::new(5);
     /// }
     ///
-    /// task::block_on(async {
+    /// thread::spawn_task(async {
     ///     let v = VAL.try_with(|c| c.get());
     ///     assert_eq!(v, Ok(5));
     /// });

--- a/src/task/worker.rs
+++ b/src/task/worker.rs
@@ -22,9 +22,9 @@ use crate::utils::abort_on_panic;
 /// # Examples
 ///
 /// ```
-/// # fn main() { async_std::task::block_on(async {
+/// # fn main() { async_std::thread::spawn_task(async {
 /// #
-/// use async_std::task;
+/// use async_std::thread;
 ///
 /// println!("The name of this task is {:?}", task::current().name());
 /// #

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -1,0 +1,8 @@
+//! Native threads.
+
+mod spawn_task;
+
+#[doc(inline)]
+pub use std::thread::{spawn, JoinHandle};
+
+pub use spawn_task::spawn_task;

--- a/src/thread/mod.rs
+++ b/src/thread/mod.rs
@@ -1,8 +1,12 @@
 //! Native threads.
 
-mod spawn_task;
-
 #[doc(inline)]
-pub use std::thread::{spawn, JoinHandle};
+pub use std::thread::Result;
+#[doc(inline)]
+pub use std::thread::{current, panicking, park, park_timeout, sleep, spawn, yield_now};
+#[doc(inline)]
+pub use std::thread::{AccessError, Builder, JoinHandle, LocalKey, Thread, ThreadId};
 
 pub use spawn_task::spawn_task;
+
+mod spawn_task;

--- a/src/thread/spawn_task.rs
+++ b/src/thread/spawn_task.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 use std::task::{RawWaker, RawWakerVTable};
 use std::thread::{self, Thread};
 
+use crate::future::Future;
 use crate::task::task;
 use crate::task::task_local;
 use crate::task::worker;
-use crate::future::Future;
 use crate::task::{Context, Poll, Waker};
 
 use kv_log_macro::trace;
@@ -42,63 +42,63 @@ where
     F: Future<Output = T>,
     T: Send,
 {
-        unsafe {
-            // A place on the stack where the result will be stored.
-            let out = &mut UnsafeCell::new(None);
+    unsafe {
+        // A place on the stack where the result will be stored.
+        let out = &mut UnsafeCell::new(None);
 
-            // Wrap the future into one that stores the result into `out`.
-            let future = {
-                let out = out.get();
+        // Wrap the future into one that stores the result into `out`.
+        let future = {
+            let out = out.get();
 
-                async move {
-                    let future = CatchUnwindFuture {
-                        future: AssertUnwindSafe(future),
-                    };
-                    *out = Some(future.await);
-                }
-            };
+            async move {
+                let future = CatchUnwindFuture {
+                    future: AssertUnwindSafe(future),
+                };
+                *out = Some(future.await);
+            }
+        };
 
-            // Create a tag for the task.
-            let tag = task::Tag::new(None);
+        // Create a tag for the task.
+        let tag = task::Tag::new(None);
 
-            // Log this `spawn_task` operation.
-            let child_id = tag.task_id().as_u64();
-            let parent_id = worker::get_task(|t| t.id().as_u64()).unwrap_or(0);
+        // Log this `spawn_task` operation.
+        let child_id = tag.task_id().as_u64();
+        let parent_id = worker::get_task(|t| t.id().as_u64()).unwrap_or(0);
 
-            trace!("spawn_task", {
+        trace!("spawn_task", {
+            parent_id: parent_id,
+            child_id: child_id,
+        });
+
+        // Wrap the future into one that drops task-local variables on exit.
+        let future = task_local::add_finalizer(future);
+
+        let future = async move {
+            future.await;
+            trace!("spawn_task completed", {
                 parent_id: parent_id,
                 child_id: child_id,
             });
+        };
 
-            // Wrap the future into one that drops task-local variables on exit.
-            let future = task_local::add_finalizer(future);
+        // Pin the future onto the stack.
+        pin_utils::pin_mut!(future);
 
-            let future = async move {
-                future.await;
-                trace!("spawn_task completed", {
-                    parent_id: parent_id,
-                    child_id: child_id,
-                });
-            };
+        // Transmute the future into one that is futurestatic.
+        let future = mem::transmute::<
+            Pin<&'_ mut dyn Future<Output = ()>>,
+            Pin<&'static mut dyn Future<Output = ()>>,
+        >(future);
 
-            // Pin the future onto the stack.
-            pin_utils::pin_mut!(future);
+        // Block on the future and and wait for it to complete.
+        worker::set_tag(&tag, || block(future));
 
-            // Transmute the future into one that is futurestatic.
-            let future = mem::transmute::<
-                Pin<&'_ mut dyn Future<Output = ()>>,
-                Pin<&'static mut dyn Future<Output = ()>>,
-            >(future);
-
-                // Block on the future and and wait for it to complete.
-                worker::set_tag(&tag, || block(future));
-
-                // Take out the result.
-                match (*out.get()).take().unwrap() {
-                    Ok(v) => v,
-                    Err(err) => panic::resume_unwind(err),
-                }
+        // Take out the result.
+        match (*out.get()).take().unwrap() {
+            Ok(v) => v,
+            Err(err) => panic::resume_unwind(err),
         }
+    }
 }
 
 struct CatchUnwindFuture<F> {

--- a/tests/addr.rs
+++ b/tests/addr.rs
@@ -8,7 +8,7 @@ where
     A: ToSocketAddrs,
     A::Iter: Send,
 {
-    let socket_addrs = task::block_on(a.to_socket_addrs());
+    let socket_addrs = thread::spawn_task(a.to_socket_addrs());
     match socket_addrs {
         Ok(a) => Ok(a.collect()),
         Err(e) => Err(e.to_string()),

--- a/tests/addr.rs
+++ b/tests/addr.rs
@@ -1,7 +1,7 @@
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 use async_std::net::ToSocketAddrs;
-use async_std::task;
+use async_std::thread;
 
 fn blocking_resolve<A>(a: A) -> Result<Vec<SocketAddr>, String>
 where

--- a/tests/block_on.rs
+++ b/tests/block_on.rs
@@ -2,14 +2,14 @@ use async_std::task;
 
 #[test]
 fn smoke() {
-    let res = task::block_on(async { 1 + 2 });
+    let res = thread::spawn_task(async { 1 + 2 });
     assert_eq!(res, 3);
 }
 
 #[test]
 #[should_panic = "boom"]
 fn panic() {
-    task::block_on(async {
+    thread::spawn_task(async {
         // This panic should get propagated into the parent thread.
         panic!("boom");
     });

--- a/tests/io_timeout.rs
+++ b/tests/io_timeout.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use async_std::io;
-use async_std::task;
+use async_std::thread;
 
 #[test]
 #[should_panic(expected = "timed out")]

--- a/tests/io_timeout.rs
+++ b/tests/io_timeout.rs
@@ -6,7 +6,7 @@ use async_std::task;
 #[test]
 #[should_panic(expected = "timed out")]
 fn io_timeout_timedout() {
-    task::block_on(async {
+    thread::spawn_task(async {
         io::timeout(Duration::from_secs(1), async {
             let stdin = io::stdin();
             let mut line = String::new();
@@ -21,7 +21,7 @@ fn io_timeout_timedout() {
 #[test]
 #[should_panic(expected = "My custom error")]
 fn io_timeout_future_err() {
-    task::block_on(async {
+    thread::spawn_task(async {
         io::timeout(Duration::from_secs(1), async {
             Err::<(), io::Error>(io::Error::new(io::ErrorKind::Other, "My custom error"))
         })
@@ -32,7 +32,7 @@ fn io_timeout_future_err() {
 
 #[test]
 fn io_timeout_future_ok() {
-    task::block_on(async {
+    thread::spawn_task(async {
         io::timeout(Duration::from_secs(1), async { Ok(()) })
             .await
             .unwrap(); // We shouldn't panic at all

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -7,7 +7,7 @@ use futures::channel::mpsc;
 
 #[test]
 fn smoke() {
-    task::block_on(async {
+    thread::spawn_task(async {
         let m = Mutex::new(());
         drop(m.lock().await);
         drop(m.lock().await);
@@ -35,7 +35,7 @@ fn get_mut() {
 
 #[test]
 fn contention() {
-    task::block_on(async {
+    thread::spawn_task(async {
         let (tx, mut rx) = mpsc::unbounded();
 
         let tx = Arc::new(tx);

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_std::prelude::*;
 use async_std::sync::Mutex;
 use async_std::task;
+use async_std::thread;
 use futures::channel::mpsc;
 
 #[test]

--- a/tests/rwlock.rs
+++ b/tests/rwlock.rs
@@ -36,7 +36,7 @@ pub fn random(n: u32) -> u32 {
 
 #[test]
 fn smoke() {
-    task::block_on(async {
+    thread::spawn_task(async {
         let lock = RwLock::new(());
         drop(lock.read().await);
         drop(lock.write().await);
@@ -47,7 +47,7 @@ fn smoke() {
 
 #[test]
 fn try_write() {
-    task::block_on(async {
+    thread::spawn_task(async {
         let lock = RwLock::new(0isize);
         let read_guard = lock.read().await;
         assert!(lock.try_write().is_none());
@@ -116,7 +116,7 @@ fn contention() {
         });
     }
 
-    task::block_on(async {
+    thread::spawn_task(async {
         for _ in 0..N {
             rx.next().await.unwrap();
         }
@@ -170,7 +170,7 @@ fn writer_and_readers() {
         }));
     }
 
-    task::block_on(async {
+    thread::spawn_task(async {
         // Wait for readers to pass their asserts.
         for r in readers {
             r.await;

--- a/tests/rwlock.rs
+++ b/tests/rwlock.rs
@@ -8,6 +8,7 @@ use std::task::{Context, Poll};
 use async_std::prelude::*;
 use async_std::sync::RwLock;
 use async_std::task;
+use async_std::thread;
 use futures::channel::mpsc;
 
 /// Generates a random number in `0..n`.

--- a/tests/spawn_task.rs
+++ b/tests/spawn_task.rs
@@ -1,4 +1,4 @@
-use async_std::task;
+use async_std::thread;
 
 #[test]
 fn smoke() {

--- a/tests/task_local.rs
+++ b/tests/task_local.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_std::task;
 use async_std::task_local;
+use async_std::thread;
 
 #[test]
 fn drop_local() {

--- a/tests/task_local.rs
+++ b/tests/task_local.rs
@@ -26,7 +26,7 @@ fn drop_local() {
     let task = handle.task().clone();
 
     // Wait for the task to finish and make sure its task-local has been dropped.
-    task::block_on(async {
+    thread::spawn_task(async {
         handle.await;
         assert!(DROP_LOCAL.load(Ordering::SeqCst));
         drop(task);

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -2,6 +2,7 @@ use async_std::io;
 use async_std::net::{TcpListener, TcpStream};
 use async_std::prelude::*;
 use async_std::task;
+use async_std::thread;
 
 const THE_WINTERS_TALE: &[u8] = b"
     Each your doing,

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -12,7 +12,7 @@ const THE_WINTERS_TALE: &[u8] = b"
 
 #[test]
 fn connect() -> io::Result<()> {
-    task::block_on(async {
+    thread::spawn_task(async {
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let addr = listener.local_addr()?;
         let t = task::spawn(async move { listener.accept().await });
@@ -29,7 +29,7 @@ fn connect() -> io::Result<()> {
 
 #[test]
 fn incoming_read() -> io::Result<()> {
-    task::block_on(async {
+    thread::spawn_task(async {
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let addr = listener.local_addr()?;
 

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -11,7 +11,7 @@ const THE_MERCHANT_OF_VENICE: &[u8] = b"
 
 #[test]
 fn send_recv() -> io::Result<()> {
-    task::block_on(async {
+    thread::spawn_task(async {
         let socket1 = UdpSocket::bind("127.0.0.1:0").await?;
         let socket2 = UdpSocket::bind("127.0.0.1:0").await?;
 

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -1,6 +1,6 @@
 use async_std::io;
 use async_std::net::UdpSocket;
-use async_std::task;
+use async_std::thread;
 
 const THE_MERCHANT_OF_VENICE: &[u8] = b"
     If you prick us, do we not bleed?

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -16,7 +16,7 @@ const JULIUS_CAESAR: &[u8] = b"
 
 #[test]
 fn send_recv() -> io::Result<()> {
-    task::block_on(async {
+    thread::spawn_task(async {
         let (socket1, socket2) = UnixDatagram::pair().unwrap();
         socket1.send(JULIUS_CAESAR).await?;
 
@@ -31,7 +31,7 @@ fn send_recv() -> io::Result<()> {
 #[test]
 fn into_raw_fd() -> io::Result<()> {
     use async_std::os::unix::io::{FromRawFd, IntoRawFd};
-    task::block_on(async {
+    thread::spawn_task(async {
         let (socket1, socket2) = UnixDatagram::pair().unwrap();
         socket1.send(JULIUS_CAESAR).await?;
 
@@ -56,14 +56,14 @@ fn socket_ping_pong() {
     let iter_cnt = 16;
 
     let listener =
-        task::block_on(async { UnixListener::bind(&sock_path).await.expect("Socket bind") });
+        thread::spawn_task(async { UnixListener::bind(&sock_path).await.expect("Socket bind") });
 
     let server_handle = std::thread::spawn(move || {
-        task::block_on(async { ping_pong_server(listener, iter_cnt).await }).unwrap()
+        thread::spawn_task(async { ping_pong_server(listener, iter_cnt).await }).unwrap()
     });
 
     let client_handle = std::thread::spawn(move || {
-        task::block_on(async { ping_pong_client(&sock_path, iter_cnt).await }).unwrap()
+        thread::spawn_task(async { ping_pong_client(&sock_path, iter_cnt).await }).unwrap()
     });
 
     client_handle.join().unwrap();

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -3,7 +3,7 @@
 use async_std::io;
 use async_std::os::unix::net::{UnixDatagram, UnixListener, UnixStream};
 use async_std::prelude::*;
-use async_std::task;
+use async_std::thread;
 
 use tempdir::TempDir;
 


### PR DESCRIPTION
Replaces `task::block_on` with `thread::spawn_task`. Ref #289 #299. Not sure if this is a great idea or terrible, but figured I'd open it anyway. We should probably think about this long and hard before we decide to add this.

This also means the addition of a new `thread` submodule.

Oh another gotcha is that because we want to block the current thread, we can't get back a `JoinHandle`. We could jump through hoops to spawn a new thread and get a handle back that way -- but that seems like a somewhat odd choice to make, and I think we should not spawn new threads just for this purpose.

Thanks!

cc/ @stjepang