### PR TITLE
Add Write::write_fmt

### DIFF
--- a/src/io/write/mod.rs
+++ b/src/io/write/mod.rs
@@ -234,6 +234,9 @@ extension_trait! {
         where
             Self: Unpin,
         {
+            // In order to not have to implement an async version of `fmt` including private types
+            // and all, we convert `Arguments` to a `Result<Vec<u8>>` and pass that to the Future.
+            // Doing an owned conversion saves us from juggling references.
             let mut string = String::new();
             let res = std::fmt::write(&mut string, fmt)
                 .map(|_| string.into_bytes())

--- a/src/io/write/mod.rs
+++ b/src/io/write/mod.rs
@@ -204,7 +204,7 @@ extension_trait! {
             Writes a formatted string into this writer, returning any error encountered.
 
             This method will continuously call [`write`] until there is no more data to be
-            written or an error is returned. This method will not return until the entire
+            written or an error is returned. This future will not resolve until the entire
             buffer has been successfully written or such an error occurs.
 
             [`write`]: #tymethod.write

--- a/src/io/write/write_fmt.rs
+++ b/src/io/write/write_fmt.rs
@@ -26,7 +26,12 @@ impl<T: Write + Unpin + ?Sized> Future for WriteFmtFuture<'_, T> {
         }
 
         // Get the types from the future.
-        let Self { writer, amt, buffer, .. } = &mut *self;
+        let Self {
+            writer,
+            amt,
+            buffer,
+            ..
+        } = &mut *self;
         let mut buffer = buffer.as_mut().unwrap();
 
         // Copy the data from the buffer into the writer until it's done.

--- a/src/io/write/write_fmt.rs
+++ b/src/io/write/write_fmt.rs
@@ -1,0 +1,45 @@
+use std::pin::Pin;
+
+use crate::future::Future;
+use crate::io::{self, Write};
+use crate::task::{Context, Poll};
+
+#[doc(hidden)]
+#[allow(missing_debug_implementations)]
+pub struct WriteFmtFuture<'a, T: Unpin + ?Sized> {
+    pub(crate) writer: &'a mut T,
+    pub(crate) res: Option<io::Result<Vec<u8>>>,
+    pub(crate) buffer: Option<Vec<u8>>,
+    pub(crate) amt: u64,
+}
+
+impl<T: Write + Unpin + ?Sized> Future for WriteFmtFuture<'_, T> {
+    type Output = io::Result<()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+
+        // Process the interal Result the first time we run.
+        if self.buffer.is_none() {
+            match self.res.take().unwrap() {
+                Err(err) => return Poll::Ready(Err(err)),
+                Ok(buffer) => self.buffer = Some(buffer),
+            };
+        }
+
+        let Self { writer, amt, buffer, .. } = &mut *self;
+        let mut buffer = buffer.as_mut().unwrap();
+
+        loop {
+            if buffer.is_empty() {
+                futures_core::ready!(Pin::new(&mut **writer).poll_flush(cx))?;
+                return Poll::Ready(Ok(()));
+            }
+
+            let i = futures_core::ready!(Pin::new(&mut **writer).poll_write(cx, &mut buffer))?;
+            if i == 0 {
+                return Poll::Ready(Err(io::ErrorKind::WriteZero.into()));
+            }
+            *amt += i as u64;
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,3 +77,6 @@ cfg_if! {
 }
 
 pub(crate) mod utils;
+
+#[doc(inline)]
+pub use std::{write, writeln};


### PR DESCRIPTION
Implements `Write::write_fmt`. Ref https://github.com/async-rs/async-std/pull/245. Ref #131. 

Also added `write` and `writeln` macros to the root as re-exports from std because they work out of the box!

Figured this would be good enough, and we don't need to implement fmt (closes #247). Thanks!