### PR TITLE
Implement async Path & PathBuf

### DIFF
--- a/src/fs/canonicalize.rs
+++ b/src/fs/canonicalize.rs
@@ -32,7 +32,7 @@ use crate::task::blocking;
 /// # Ok(()) }) }
 /// ```
 pub async fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
-    let path: std::path::PathBuf = path.as_ref().to_path_buf().into();
+    let path: PathBuf = path.as_ref().to_owned();
     Ok(blocking::spawn(async move { std::fs::canonicalize(&path) })
         .await?
         .into())

--- a/src/fs/canonicalize.rs
+++ b/src/fs/canonicalize.rs
@@ -1,6 +1,5 @@
-use crate::path::{Path, PathBuf};
-
 use crate::io;
+use crate::path::{Path, PathBuf};
 use crate::task::blocking;
 
 /// Returns the canonical form of a path.
@@ -32,8 +31,6 @@ use crate::task::blocking;
 /// # Ok(()) }) }
 /// ```
 pub async fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
-    let path: PathBuf = path.as_ref().to_owned();
-    Ok(blocking::spawn(async move { std::fs::canonicalize(&path) })
-        .await?
-        .into())
+    let path = path.as_ref().to_owned();
+    blocking::spawn(async move { std::fs::canonicalize(&path).map(Into::into) }).await
 }

--- a/src/fs/canonicalize.rs
+++ b/src/fs/canonicalize.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use crate::path::{Path, PathBuf};
 
 use crate::io;
 use crate::task::blocking;
@@ -32,6 +32,8 @@ use crate::task::blocking;
 /// # Ok(()) }) }
 /// ```
 pub async fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
-    let path = path.as_ref().to_owned();
-    blocking::spawn(async move { std::fs::canonicalize(path) }).await
+    let path: std::path::PathBuf = path.as_ref().to_path_buf().into();
+    Ok(blocking::spawn(async move { std::fs::canonicalize(&path) })
+        .await?
+        .into())
 }

--- a/src/fs/copy.rs
+++ b/src/fs/copy.rs
@@ -1,6 +1,5 @@
-use std::path::Path;
-
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Copies the contents and permissions of a file to a new location.

--- a/src/fs/create_dir.rs
+++ b/src/fs/create_dir.rs
@@ -1,6 +1,5 @@
-use std::path::Path;
-
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Creates a new directory.

--- a/src/fs/create_dir_all.rs
+++ b/src/fs/create_dir_all.rs
@@ -1,6 +1,5 @@
-use std::path::Path;
-
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Creates a new directory and all of its parents if they are missing.

--- a/src/fs/dir_builder.rs
+++ b/src/fs/dir_builder.rs
@@ -1,9 +1,8 @@
-use std::path::Path;
-
 use cfg_if::cfg_if;
 
 use crate::future::Future;
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// A builder for creating directories with configurable options.

--- a/src/fs/dir_entry.rs
+++ b/src/fs/dir_entry.rs
@@ -1,12 +1,12 @@
 use std::ffi::OsString;
 use std::fmt;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use cfg_if::cfg_if;
 
 use crate::fs::{FileType, Metadata};
 use crate::io;
+use crate::path::PathBuf;
 use crate::task::blocking;
 
 /// An entry in a directory.
@@ -50,7 +50,7 @@ impl DirEntry {
     /// # Ok(()) }) }
     /// ```
     pub fn path(&self) -> PathBuf {
-        self.0.path()
+        self.0.path().into()
     }
 
     /// Reads the metadata for this entry.

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -3,7 +3,6 @@ use std::cmp;
 use std::fmt;
 use std::io::{Read as _, Seek as _, Write as _};
 use std::ops::{Deref, DerefMut};
-use std::path::Path;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -13,6 +12,7 @@ use cfg_if::cfg_if;
 use crate::fs::{Metadata, Permissions};
 use crate::future;
 use crate::io::{self, Read, Seek, SeekFrom, Write};
+use crate::path::Path;
 use crate::prelude::*;
 use crate::task::{self, blocking, Context, Poll, Waker};
 

--- a/src/fs/hard_link.rs
+++ b/src/fs/hard_link.rs
@@ -1,6 +1,5 @@
-use std::path::Path;
-
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Creates a hard link on the filesystem.

--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -35,7 +35,7 @@ use crate::task::blocking;
 /// # Ok(()) }) }
 /// ```
 pub async fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
-    let path: std::path::PathBuf = path.as_ref().to_path_buf().into();
+    let path = path.as_ref().to_owned();
     blocking::spawn(async move { std::fs::metadata(path) }).await
 }
 

--- a/src/fs/metadata.rs
+++ b/src/fs/metadata.rs
@@ -1,8 +1,7 @@
-use std::path::Path;
-
 use cfg_if::cfg_if;
 
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Reads metadata for a path.
@@ -36,7 +35,7 @@ use crate::task::blocking;
 /// # Ok(()) }) }
 /// ```
 pub async fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
-    let path = path.as_ref().to_owned();
+    let path: std::path::PathBuf = path.as_ref().to_path_buf().into();
     blocking::spawn(async move { std::fs::metadata(path) }).await
 }
 

--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -1,10 +1,9 @@
-use std::path::Path;
-
 use cfg_if::cfg_if;
 
 use crate::fs::File;
 use crate::future::Future;
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// A builder for opening files with configurable options.

--- a/src/fs/read.rs
+++ b/src/fs/read.rs
@@ -1,6 +1,5 @@
-use std::path::Path;
-
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Reads the entire contents of a file as raw bytes.

--- a/src/fs/read_dir.rs
+++ b/src/fs/read_dir.rs
@@ -1,9 +1,9 @@
-use std::path::Path;
 use std::pin::Pin;
 
 use crate::fs::DirEntry;
 use crate::future::Future;
 use crate::io;
+use crate::path::Path;
 use crate::stream::Stream;
 use crate::task::{blocking, Context, JoinHandle, Poll};
 
@@ -44,7 +44,7 @@ use crate::task::{blocking, Context, JoinHandle, Poll};
 /// # Ok(()) }) }
 /// ```
 pub async fn read_dir<P: AsRef<Path>>(path: P) -> io::Result<ReadDir> {
-    let path = path.as_ref().to_owned();
+    let path: std::path::PathBuf = path.as_ref().to_path_buf().into();
     blocking::spawn(async move { std::fs::read_dir(path) })
         .await
         .map(ReadDir::new)

--- a/src/fs/read_dir.rs
+++ b/src/fs/read_dir.rs
@@ -44,7 +44,7 @@ use crate::task::{blocking, Context, JoinHandle, Poll};
 /// # Ok(()) }) }
 /// ```
 pub async fn read_dir<P: AsRef<Path>>(path: P) -> io::Result<ReadDir> {
-    let path: std::path::PathBuf = path.as_ref().to_path_buf().into();
+    let path = path.as_ref().to_owned();
     blocking::spawn(async move { std::fs::read_dir(path) })
         .await
         .map(ReadDir::new)

--- a/src/fs/read_link.rs
+++ b/src/fs/read_link.rs
@@ -28,7 +28,5 @@ use crate::task::blocking;
 /// ```
 pub async fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref().to_owned();
-    Ok(blocking::spawn(async move { std::fs::read_link(path) })
-        .await?
-        .into())
+    blocking::spawn(async move { std::fs::read_link(path).map(Into::into) }).await
 }

--- a/src/fs/read_link.rs
+++ b/src/fs/read_link.rs
@@ -27,7 +27,7 @@ use crate::task::blocking;
 /// # Ok(()) }) }
 /// ```
 pub async fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
-    let path: std::path::PathBuf = path.as_ref().to_path_buf().into();
+    let path = path.as_ref().to_owned();
     Ok(blocking::spawn(async move { std::fs::read_link(path) })
         .await?
         .into())

--- a/src/fs/read_link.rs
+++ b/src/fs/read_link.rs
@@ -1,6 +1,5 @@
-use std::path::{Path, PathBuf};
-
 use crate::io;
+use crate::path::{Path, PathBuf};
 use crate::task::blocking;
 
 /// Reads a symbolic link and returns the path it points to.
@@ -28,6 +27,8 @@ use crate::task::blocking;
 /// # Ok(()) }) }
 /// ```
 pub async fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
-    let path = path.as_ref().to_owned();
-    blocking::spawn(async move { std::fs::read_link(path) }).await
+    let path: std::path::PathBuf = path.as_ref().to_path_buf().into();
+    Ok(blocking::spawn(async move { std::fs::read_link(path) })
+        .await?
+        .into())
 }

--- a/src/fs/read_to_string.rs
+++ b/src/fs/read_to_string.rs
@@ -1,6 +1,5 @@
-use std::path::Path;
-
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Reads the entire contents of a file as a string.

--- a/src/fs/remove_dir.rs
+++ b/src/fs/remove_dir.rs
@@ -1,6 +1,5 @@
-use std::path::Path;
-
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Removes an empty directory.

--- a/src/fs/remove_dir_all.rs
+++ b/src/fs/remove_dir_all.rs
@@ -1,6 +1,5 @@
-use std::path::Path;
-
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Removes a directory and all of its contents.

--- a/src/fs/remove_file.rs
+++ b/src/fs/remove_file.rs
@@ -1,6 +1,5 @@
-use std::path::Path;
-
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Removes a file.

--- a/src/fs/rename.rs
+++ b/src/fs/rename.rs
@@ -1,6 +1,5 @@
-use std::path::Path;
-
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Renames a file or directory to a new location.

--- a/src/fs/set_permissions.rs
+++ b/src/fs/set_permissions.rs
@@ -1,7 +1,6 @@
-use std::path::Path;
-
 use crate::fs::Permissions;
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Changes the permissions of a file or directory.

--- a/src/fs/symlink_metadata.rs
+++ b/src/fs/symlink_metadata.rs
@@ -1,7 +1,6 @@
-use std::path::Path;
-
 use crate::fs::Metadata;
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Reads metadata for a path without following symbolic links.
@@ -34,6 +33,6 @@ use crate::task::blocking;
 /// # Ok(()) }) }
 /// ```
 pub async fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
-    let path = path.as_ref().to_owned();
+    let path: std::path::PathBuf = path.as_ref().to_path_buf().into();
     blocking::spawn(async move { std::fs::symlink_metadata(path) }).await
 }

--- a/src/fs/symlink_metadata.rs
+++ b/src/fs/symlink_metadata.rs
@@ -33,6 +33,6 @@ use crate::task::blocking;
 /// # Ok(()) }) }
 /// ```
 pub async fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
-    let path: std::path::PathBuf = path.as_ref().to_path_buf().into();
+    let path = path.as_ref().to_owned();
     blocking::spawn(async move { std::fs::symlink_metadata(path) }).await
 }

--- a/src/fs/write.rs
+++ b/src/fs/write.rs
@@ -1,6 +1,5 @@
-use std::path::Path;
-
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Writes a slice of bytes as the new contents of a file.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub mod future;
 pub mod io;
 pub mod net;
 pub mod os;
+pub mod path;
 pub mod prelude;
 pub mod stream;
 pub mod sync;
@@ -62,8 +63,6 @@ pub mod task;
 
 cfg_if! {
     if #[cfg(any(feature = "unstable", feature = "docs"))] {
-        #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
-        pub mod path;
         #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
         pub mod pin;
 

--- a/src/os/unix/fs.rs
+++ b/src/os/unix/fs.rs
@@ -1,10 +1,9 @@
 //! Unix-specific filesystem extensions.
 
-use std::path::Path;
-
 use cfg_if::cfg_if;
 
 use crate::io;
+use crate::path::Path;
 use crate::task::blocking;
 
 /// Creates a new symbolic link on the filesystem.

--- a/src/os/unix/net/datagram.rs
+++ b/src/os/unix/net/datagram.rs
@@ -2,7 +2,6 @@
 
 use std::fmt;
 use std::net::Shutdown;
-use std::path::Path;
 
 use mio_uds;
 
@@ -11,6 +10,7 @@ use crate::future;
 use crate::io;
 use crate::net::driver::Watcher;
 use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use crate::path::Path;
 use crate::task::blocking;
 
 /// A Unix datagram socket.

--- a/src/os/unix/net/listener.rs
+++ b/src/os/unix/net/listener.rs
@@ -1,7 +1,6 @@
 //! Unix-specific networking extensions.
 
 use std::fmt;
-use std::path::Path;
 use std::pin::Pin;
 
 use mio_uds;
@@ -12,6 +11,7 @@ use crate::future::{self, Future};
 use crate::io;
 use crate::net::driver::Watcher;
 use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use crate::path::Path;
 use crate::stream::Stream;
 use crate::task::{blocking, Context, Poll};
 

--- a/src/os/unix/net/mod.rs
+++ b/src/os/unix/net/mod.rs
@@ -13,7 +13,8 @@ mod stream;
 cfg_if! {
     if #[cfg(feature = "docs")] {
         use std::fmt;
-        use std::path::Path;
+
+        use crate::path::Path;
 
         /// An address associated with a Unix socket.
         ///
@@ -65,9 +66,8 @@ cfg_if! {
             /// With a pathname:
             ///
             /// ```no_run
-            /// use std::path::Path;
-            ///
             /// use async_std::os::unix::net::UnixListener;
+            /// use async_std::path::Path;
             ///
             /// let socket = UnixListener::bind("/tmp/socket").await?;
             /// let addr = socket.local_addr()?;

--- a/src/os/unix/net/stream.rs
+++ b/src/os/unix/net/stream.rs
@@ -3,7 +3,6 @@
 use std::fmt;
 use std::io::{Read as _, Write as _};
 use std::net::Shutdown;
-use std::path::Path;
 use std::pin::Pin;
 
 use mio_uds;
@@ -12,6 +11,7 @@ use super::SocketAddr;
 use crate::io::{self, Read, Write};
 use crate::net::driver::Watcher;
 use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use crate::path::Path;
 use crate::task::{blocking, Context, Poll};
 
 /// A Unix stream socket.

--- a/src/path/ancestors.rs
+++ b/src/path/ancestors.rs
@@ -1,0 +1,39 @@
+use std::iter::FusedIterator;
+
+use crate::path::Path;
+
+/// An iterator over [`Path`] and its ancestors.
+///
+/// This `struct` is created by the [`ancestors`] method on [`Path`].
+/// See its documentation for more.
+///
+/// # Examples
+///
+/// ```
+/// use async_std::path::Path;
+///
+/// let path = Path::new("/foo/bar");
+///
+/// for ancestor in path.ancestors() {
+///     println!("{}", ancestor.display());
+/// }
+/// ```
+///
+/// [`ancestors`]: struct.Path.html#method.ancestors
+/// [`Path`]: struct.Path.html
+#[derive(Copy, Clone, Debug)]
+pub struct Ancestors<'a> {
+    pub(crate) next: Option<&'a Path>,
+}
+
+impl<'a> Iterator for Ancestors<'a> {
+    type Item = &'a Path;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.next;
+        self.next = next.and_then(Path::parent);
+        next
+    }
+}
+
+impl FusedIterator for Ancestors<'_> {}

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -4,6 +4,9 @@
 //!
 //! [`std::path`]: https://doc.rust-lang.org/std/path/index.html
 
+mod path;
+mod pathbuf;
+
 // Structs re-export
 #[doc(inline)]
 pub use std::path::{Ancestors, Components, Display, Iter, PrefixComponent, StripPrefixError};
@@ -19,3 +22,6 @@ pub use std::path::MAIN_SEPARATOR;
 // Functions re-export
 #[doc(inline)]
 pub use std::path::is_separator;
+
+pub use path::Path;
+pub use pathbuf::PathBuf;

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! [`std::path`]: https://doc.rust-lang.org/std/path/index.html
 
+mod ancestors;
 mod path;
 mod pathbuf;
 
@@ -23,5 +24,6 @@ pub use std::path::MAIN_SEPARATOR;
 #[doc(inline)]
 pub use std::path::is_separator;
 
-pub use path::{Ancestors, Path};
+use ancestors::Ancestors;
+pub use path::Path;
 pub use pathbuf::PathBuf;

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -9,7 +9,7 @@ mod pathbuf;
 
 // Structs re-export
 #[doc(inline)]
-pub use std::path::{Ancestors, Components, Display, Iter, PrefixComponent, StripPrefixError};
+pub use std::path::{Components, Display, Iter, PrefixComponent, StripPrefixError};
 
 // Enums re-export
 #[doc(inline)]
@@ -23,5 +23,5 @@ pub use std::path::MAIN_SEPARATOR;
 #[doc(inline)]
 pub use std::path::is_separator;
 
-pub use path::Path;
+pub use path::{Ancestors, Path};
 pub use pathbuf::PathBuf;

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -462,29 +462,6 @@ impl Path {
         fs::metadata(self).await
     }
 
-    /// Queries the metadata about a file without following symlinks.
-    ///
-    /// This is an alias to [`fs::symlink_metadata`].
-    ///
-    /// [`fs::symlink_metadata`]: ../fs/fn.symlink_metadata.html
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
-    /// #
-    /// use async_std::path::Path;
-    ///
-    /// let path = Path::new("/Minas/tirith");
-    /// let metadata = path.symlink_metadata().await.expect("symlink_metadata call failed");
-    /// println!("{:?}", metadata.file_type());
-    /// #
-    /// # Ok(()) }) }
-    /// ```
-    pub async fn symlink_metadata(&self) -> io::Result<fs::Metadata> {
-        fs::symlink_metadata(self).await
-    }
-
     /// Directly wraps a string slice as a `Path` slice.
     ///
     /// This is a cost-free conversion.
@@ -509,6 +486,52 @@ impl Path {
     /// ```
     pub fn new<S: AsRef<OsStr> + ?Sized>(s: &S) -> &Path {
         unsafe { &*(std::path::Path::new(s) as *const std::path::Path as *const Path) }
+    }
+
+    /// Returns the `Path` without its final component, if there is one.
+    ///
+    /// Returns [`None`] if the path terminates in a root or prefix.
+    ///
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/foo/bar");
+    /// let parent = path.parent().unwrap();
+    /// assert_eq!(parent, Path::new("/foo"));
+    ///
+    /// let grand_parent = parent.parent().unwrap();
+    /// assert_eq!(grand_parent, Path::new("/"));
+    /// assert_eq!(grand_parent.parent(), None);
+    /// ```
+    pub fn parent(&self) -> Option<&Path> {
+        self.inner.parent().map(|p| p.into())
+    }
+
+    /// Queries the metadata about a file without following symlinks.
+    ///
+    /// This is an alias to [`fs::symlink_metadata`].
+    ///
+    /// [`fs::symlink_metadata`]: ../fs/fn.symlink_metadata.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/Minas/tirith");
+    /// let metadata = path.symlink_metadata().await.expect("symlink_metadata call failed");
+    /// println!("{:?}", metadata.file_type());
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn symlink_metadata(&self) -> io::Result<fs::Metadata> {
+        fs::symlink_metadata(self).await
     }
 
     /// Converts a `Path` to an owned [`PathBuf`].

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 
-use crate::path::{Components, PathBuf};
+use crate::path::{Ancestors, Components, PathBuf};
 use crate::{fs, io};
 
 /// This struct is an async version of [`std::path::Path`].
@@ -12,6 +12,32 @@ pub struct Path {
 }
 
 impl Path {
+    /// Produces an iterator over `Path` and its ancestors.
+    ///
+    /// The iterator will yield the `Path` that is returned if the [`parent`] method is used zero
+    /// or more times. That means, the iterator will yield `&self`, `&self.parent().unwrap()`,
+    /// `&self.parent().unwrap().parent().unwrap()` and so on. If the [`parent`] method returns
+    /// [`None`], the iterator will do likewise. The iterator will always yield at least one value,
+    /// namely `&self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let mut ancestors = Path::new("/foo/bar").ancestors();
+    /// assert_eq!(ancestors.next(), Some(Path::new("/foo/bar").into()));
+    /// assert_eq!(ancestors.next(), Some(Path::new("/foo").into()));
+    /// assert_eq!(ancestors.next(), Some(Path::new("/").into()));
+    /// assert_eq!(ancestors.next(), None);
+    /// ```
+    ///
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html
+    /// [`parent`]: struct.Path.html#method.parent
+    pub fn ancestors(&self) -> Ancestors<'_> {
+        self.inner.ancestors()
+    }
+
     /// Yields the underlying [`OsStr`] slice.
     ///
     /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -250,6 +250,26 @@ impl Path {
         self.inner.file_stem()
     }
 
+    /// Returns `true` if the `Path` has a root.
+    ///
+    /// * On Unix, a path has a root if it begins with `/`.
+    ///
+    /// * On Windows, a path has a root if it:
+    ///     * has no prefix and begins with a separator, e.g., `\windows`
+    ///     * has a prefix followed by a separator, e.g., `c:\windows` but not `c:windows`
+    ///     * has any non-disk prefix, e.g., `\\server\share`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// assert!(Path::new("/etc/passwd").has_root());
+    /// ```
+    pub fn has_root(&self) -> bool {
+        self.inner.has_root()
+    }
+
     /// Converts a [`Box<Path>`][`Box`] into a [`PathBuf`] without copying or
     /// allocating.
     ///

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -6,6 +6,7 @@ use crate::{fs, io};
 /// This struct is an async version of [`std::path::Path`].
 ///
 /// [`std::path::Path`]: https://doc.rust-lang.org/std/path/struct.Path.html
+#[derive(Debug, PartialEq)]
 pub struct Path {
     inner: std::path::Path,
 }
@@ -28,10 +29,14 @@ impl Path {
     /// # Examples
     ///
     /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
     /// use async_std::path::{Path, PathBuf};
     ///
     /// let path = Path::new("/foo/test/../test/bar.rs");
-    /// assert_eq!(path.canonicalize().unwrap(), PathBuf::from("/foo/test/bar.rs"));
+    /// assert_eq!(path.canonicalize().await.unwrap(), PathBuf::from("/foo/test/bar.rs"));
+    /// #
+    /// # Ok(()) }) }
     /// ```
     pub async fn canonicalize(&self) -> io::Result<PathBuf> {
         fs::canonicalize(self).await
@@ -86,8 +91,12 @@ impl Path {
     /// # Examples
     ///
     /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
     /// use async_std::path::Path;
-    /// assert_eq!(Path::new("does_not_exist.txt").exists(), false);
+    /// assert_eq!(Path::new("does_not_exist.txt").exists().await, false);
+    /// #
+    /// # Ok(()) }) }
     /// ```
     ///
     /// # See Also
@@ -155,14 +164,26 @@ impl<'a> Into<&'a std::path::Path> for &'a Path {
     }
 }
 
+impl AsRef<OsStr> for Path {
+    fn as_ref(&self) -> &OsStr {
+        self.inner.as_ref()
+    }
+}
+
 impl AsRef<Path> for Path {
     fn as_ref(&self) -> &Path {
         self
     }
 }
 
-impl std::fmt::Debug for Path {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(&self.inner, formatter)
+impl AsRef<Path> for OsStr {
+    fn as_ref(&self) -> &Path {
+        Path::new(self)
+    }
+}
+
+impl AsRef<Path> for str {
+    fn as_ref(&self) -> &Path {
+        Path::new(self)
     }
 }

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 
-use crate::path::{Ancestors, Components, Display, PathBuf};
+use crate::path::{Ancestors, Components, Display, Iter, PathBuf};
 use crate::{fs, io};
 
 /// This struct is an async version of [`std::path::Path`].
@@ -388,6 +388,31 @@ impl Path {
     /// [`is_absolute`]: #method.is_absolute
     pub fn is_relative(&self) -> bool {
         self.inner.is_relative()
+    }
+
+    /// Produces an iterator over the path's components viewed as [`OsStr`]
+    /// slices.
+    ///
+    /// For more information about the particulars of how the path is separated
+    /// into components, see [`components`].
+    ///
+    /// [`components`]: #method.components
+    /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{self, Path};
+    /// use std::ffi::OsStr;
+    ///
+    /// let mut it = Path::new("/tmp/foo.txt").iter();
+    /// assert_eq!(it.next(), Some(OsStr::new(&path::MAIN_SEPARATOR.to_string())));
+    /// assert_eq!(it.next(), Some(OsStr::new("tmp")));
+    /// assert_eq!(it.next(), Some(OsStr::new("foo.txt")));
+    /// assert_eq!(it.next(), None)
+    /// ```
+    pub fn iter(&self) -> Iter<'_> {
+        self.inner.iter()
     }
 
     /// Queries the file system to get information about a file, directory, etc.

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 
-use crate::path::PathBuf;
+use crate::path::{Components, PathBuf};
 use crate::{fs, io};
 
 /// This struct is an async version of [`std::path::Path`].
@@ -28,13 +28,52 @@ impl Path {
     /// # Examples
     ///
     /// ```no_run
-    /// use crate::path::{Path, PathBuf};
+    /// use async_std::path::{Path, PathBuf};
     ///
     /// let path = Path::new("/foo/test/../test/bar.rs");
     /// assert_eq!(path.canonicalize().unwrap(), PathBuf::from("/foo/test/bar.rs"));
     /// ```
     pub async fn canonicalize(&self) -> io::Result<PathBuf> {
         fs::canonicalize(self).await
+    }
+
+    /// Produces an iterator over the [`Component`]s of the path.
+    ///
+    /// When parsing the path, there is a small amount of normalization:
+    ///
+    /// * Repeated separators are ignored, so `a/b` and `a//b` both have
+    ///   `a` and `b` as components.
+    ///
+    /// * Occurrences of `.` are normalized away, except if they are at the
+    ///   beginning of the path. For example, `a/./b`, `a/b/`, `a/b/.` and
+    ///   `a/b` all have `a` and `b` as components, but `./a/b` starts with
+    ///   an additional [`CurDir`] component.
+    ///
+    /// * A trailing slash is normalized away, `/a/b` and `/a/b/` are equivalent.
+    ///
+    /// Note that no other normalization takes place; in particular, `a/c`
+    /// and `a/b/../c` are distinct, to account for the possibility that `b`
+    /// is a symbolic link (so its parent isn't `a`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{Path, Component};
+    /// use std::ffi::OsStr;
+    ///
+    /// let mut components = Path::new("/tmp/foo.txt").components();
+    ///
+    /// assert_eq!(components.next(), Some(Component::RootDir));
+    /// assert_eq!(components.next(), Some(Component::Normal(OsStr::new("tmp"))));
+    /// assert_eq!(components.next(), Some(Component::Normal(OsStr::new("foo.txt"))));
+    /// assert_eq!(components.next(), None)
+    /// ```
+    ///
+    /// [`Component`]: enum.Component.html
+    /// [`CurDir`]: enum.Component.html#variant.CurDir
+    pub fn components(&self) -> Components<'_> {
+        let path: &std::path::Path = self.into();
+        path.components()
     }
 
     /// Directly wraps a string slice as a `Path` slice.
@@ -44,7 +83,7 @@ impl Path {
     /// # Examples
     ///
     /// ```
-    /// use crate::path::Path;
+    /// use async_std::path::Path;
     ///
     /// Path::new("foo.txt");
     /// ```
@@ -52,7 +91,7 @@ impl Path {
     /// You can create `Path`s from `String`s, or even other `Path`s:
     ///
     /// ```
-    /// use crate::path::Path;
+    /// use async_std::path::Path;
     ///
     /// let string = String::from("foo.txt");
     /// let from_string = Path::new(&string);
@@ -70,7 +109,7 @@ impl Path {
     /// # Examples
     ///
     /// ```
-    /// use crate::path::{Path, PathBuf};
+    /// use async_std::path::{Path, PathBuf};
     ///
     /// let path_buf = Path::new("foo.txt").to_path_buf();
     /// assert_eq!(path_buf, PathBuf::from("foo.txt"));
@@ -98,8 +137,40 @@ impl AsRef<Path> for Path {
     }
 }
 
+impl AsRef<Path> for OsStr {
+    fn as_ref(&self) -> &Path {
+        Path::new(self)
+    }
+}
+
+impl AsRef<Path> for str {
+    fn as_ref(&self) -> &Path {
+        Path::new(self)
+    }
+}
+
 impl std::fmt::Debug for Path {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Debug::fmt(&self.inner, formatter)
+    }
+}
+
+impl std::cmp::PartialEq for Path {
+    fn eq(&self, other: &Path) -> bool {
+        self.components().eq(other.components())
+    }
+}
+
+impl std::cmp::Eq for Path {}
+
+impl std::cmp::PartialOrd for Path {
+    fn partial_cmp(&self, other: &Path) -> Option<std::cmp::Ordering> {
+        self.components().partial_cmp(other.components())
+    }
+}
+
+impl std::cmp::Ord for Path {
+    fn cmp(&self, other: &Path) -> std::cmp::Ordering {
+        self.components().cmp(other.components())
     }
 }

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -224,6 +224,32 @@ impl Path {
         self.inner.file_name()
     }
 
+    /// Extracts the stem (non-extension) portion of [`self.file_name`].
+    ///
+    /// [`self.file_name`]: struct.Path.html#method.file_name
+    ///
+    /// The stem is:
+    ///
+    /// * [`None`], if there is no file name;
+    /// * The entire file name if there is no embedded `.`;
+    /// * The entire file name if the file name begins with `.` and has no other `.`s within;
+    /// * Otherwise, the portion of the file name before the final `.`
+    ///
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("foo.rs");
+    ///
+    /// assert_eq!("foo", path.file_stem().unwrap());
+    /// ```
+    pub fn file_stem(&self) -> Option<&OsStr> {
+        self.inner.file_stem()
+    }
+
     /// Converts a [`Box<Path>`][`Box`] into a [`PathBuf`] without copying or
     /// allocating.
     ///

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -830,3 +830,11 @@ impl AsRef<Path> for String {
         Path::new(self)
     }
 }
+
+impl std::borrow::ToOwned for Path {
+    type Owned = PathBuf;
+
+    fn to_owned(&self) -> PathBuf {
+        self.to_path_buf()
+    }
+}

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -728,6 +728,28 @@ impl Path {
     pub fn with_extension<S: AsRef<OsStr>>(&self, extension: S) -> PathBuf {
         self.inner.with_extension(extension).into()
     }
+
+    /// Creates an owned [`PathBuf`] like `self` but with the given file name.
+    ///
+    /// See [`PathBuf::set_file_name`] for more details.
+    ///
+    /// [`PathBuf`]: struct.PathBuf.html
+    /// [`PathBuf::set_file_name`]: struct.PathBuf.html#method.set_file_name
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{Path, PathBuf};
+    ///
+    /// let path = Path::new("/tmp/foo.txt");
+    /// assert_eq!(path.with_file_name("bar.txt"), PathBuf::from("/tmp/bar.txt"));
+    ///
+    /// let path = Path::new("/tmp");
+    /// assert_eq!(path.with_file_name("var"), PathBuf::from("/var"));
+    /// ```
+    pub fn with_file_name<S: AsRef<OsStr>>(&self, file_name: S) -> PathBuf {
+        self.inner.with_file_name(file_name).into()
+    }
 }
 
 impl<'a> From<&'a std::path::Path> for &'a Path {

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -529,6 +529,7 @@ impl Path {
     /// #
     /// use async_std::path::Path;
     /// use async_std::fs;
+    /// use futures_util::stream::StreamExt;
     ///
     /// let path = Path::new("/laputa");
     /// let mut dir = fs::read_dir(&path).await.expect("read_dir call failed");
@@ -541,6 +542,28 @@ impl Path {
     /// ```
     pub async fn read_dir(&self) -> io::Result<fs::ReadDir> {
         fs::read_dir(self).await
+    }
+
+    /// Reads a symbolic link, returning the file that the link points to.
+    ///
+    /// This is an alias to [`fs::read_link`].
+    ///
+    /// [`fs::read_link`]: ../fs/fn.read_link.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/laputa/sky_castle.rs");
+    /// let path_link = path.read_link().await.expect("read_link call failed");
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn read_link(&self) -> io::Result<PathBuf> {
+        fs::read_link(self).await
     }
 
     /// Queries the metadata about a file without following symlinks.

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -1,0 +1,105 @@
+use std::ffi::OsStr;
+
+use crate::path::PathBuf;
+use crate::{fs, io};
+
+/// This struct is an async version of [`std::path::Path`].
+///
+/// [`std::path::Path`]: https://doc.rust-lang.org/std/path/struct.Path.html
+pub struct Path {
+    inner: OsStr,
+}
+
+impl Path {
+    /// Yields the underlying [`OsStr`] slice.
+    ///
+    /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
+    pub fn as_os_str(&self) -> &OsStr {
+        &self.inner
+    }
+
+    /// Returns the canonical, absolute form of the path with all intermediate
+    /// components normalized and symbolic links resolved.
+    ///
+    /// This is an alias to [`fs::canonicalize`].
+    ///
+    /// [`fs::canonicalize`]: ../fs/fn.canonicalize.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use crate::path::{Path, PathBuf};
+    ///
+    /// let path = Path::new("/foo/test/../test/bar.rs");
+    /// assert_eq!(path.canonicalize().unwrap(), PathBuf::from("/foo/test/bar.rs"));
+    /// ```
+    pub async fn canonicalize(&self) -> io::Result<PathBuf> {
+        fs::canonicalize(self).await
+    }
+
+    /// Directly wraps a string slice as a `Path` slice.
+    ///
+    /// This is a cost-free conversion.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crate::path::Path;
+    ///
+    /// Path::new("foo.txt");
+    /// ```
+    ///
+    /// You can create `Path`s from `String`s, or even other `Path`s:
+    ///
+    /// ```
+    /// use crate::path::Path;
+    ///
+    /// let string = String::from("foo.txt");
+    /// let from_string = Path::new(&string);
+    /// let from_path = Path::new(&from_string);
+    /// assert_eq!(from_string, from_path);
+    /// ```
+    pub fn new<S: AsRef<OsStr> + ?Sized>(s: &S) -> &Path {
+        unsafe { &*(s.as_ref() as *const OsStr as *const Path) }
+    }
+
+    /// Converts a `Path` to an owned [`PathBuf`].
+    ///
+    /// [`PathBuf`]: struct.PathBuf.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use crate::path::{Path, PathBuf};
+    ///
+    /// let path_buf = Path::new("foo.txt").to_path_buf();
+    /// assert_eq!(path_buf, PathBuf::from("foo.txt"));
+    /// ```
+    pub fn to_path_buf(&self) -> PathBuf {
+        PathBuf::from(self.inner.to_os_string())
+    }
+}
+
+impl<'a> From<&'a std::path::Path> for &'a Path {
+    fn from(path: &'a std::path::Path) -> &'a Path {
+        &Path::new(path.as_os_str())
+    }
+}
+
+impl<'a> Into<&'a std::path::Path> for &'a Path {
+    fn into(self) -> &'a std::path::Path {
+        std::path::Path::new(&self.inner)
+    }
+}
+
+impl AsRef<Path> for Path {
+    fn as_ref(&self) -> &Path {
+        self
+    }
+}
+
+impl std::fmt::Debug for Path {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.inner, formatter)
+    }
+}

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -75,6 +75,31 @@ impl Path {
         self.inner.components()
     }
 
+    /// Returns `true` if the path points at an existing entity.
+    ///
+    /// This function will traverse symbolic links to query information about the
+    /// destination file. In case of broken symbolic links this will return `false`.
+    ///
+    /// If you cannot access the directory containing the file, e.g., because of a
+    /// permission error, this will return `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use async_std::path::Path;
+    /// assert_eq!(Path::new("does_not_exist.txt").exists(), false);
+    /// ```
+    ///
+    /// # See Also
+    ///
+    /// This is a convenience function that coerces errors to false. If you want to
+    /// check errors, call [fs::metadata].
+    ///
+    /// [fs::metadata]: ../fs/fn.metadata.html
+    pub async fn exists(&self) -> bool {
+        fs::metadata(self).await.is_ok()
+    }
+
     /// Directly wraps a string slice as a `Path` slice.
     ///
     /// This is a cost-free conversion.

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -109,6 +109,55 @@ impl Path {
         fs::metadata(self).await.is_ok()
     }
 
+    /// Queries the file system to get information about a file, directory, etc.
+    ///
+    /// This function will traverse symbolic links to query information about the
+    /// destination file.
+    ///
+    /// This is an alias to [`fs::metadata`].
+    ///
+    /// [`fs::metadata`]: ../fs/fn.metadata.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/Minas/tirith");
+    /// let metadata = path.metadata().await.expect("metadata call failed");
+    /// println!("{:?}", metadata.file_type());
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn metadata(&self) -> io::Result<fs::Metadata> {
+        fs::metadata(self).await
+    }
+
+    /// Queries the metadata about a file without following symlinks.
+    ///
+    /// This is an alias to [`fs::symlink_metadata`].
+    ///
+    /// [`fs::symlink_metadata`]: ../fs/fn.symlink_metadata.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/Minas/tirith");
+    /// let metadata = path.symlink_metadata().await.expect("symlink_metadata call failed");
+    /// println!("{:?}", metadata.file_type());
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn symlink_metadata(&self) -> io::Result<fs::Metadata> {
+        fs::symlink_metadata(self).await
+    }
+
     /// Directly wraps a string slice as a `Path` slice.
     ///
     /// This is a cost-free conversion.

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -664,6 +664,26 @@ impl Path {
     pub fn to_path_buf(&self) -> PathBuf {
         PathBuf::from(self.inner.to_path_buf())
     }
+
+    /// Yields a [`&str`] slice if the `Path` is valid unicode.
+    ///
+    /// This conversion may entail doing a check for UTF-8 validity.
+    /// Note that validation is performed because non-UTF-8 strings are
+    /// perfectly valid for some OS.
+    ///
+    /// [`&str`]: https://doc.rust-lang.org/std/primitive.str.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("foo.txt");
+    /// assert_eq!(path.to_str(), Some("foo.txt"));
+    /// ```
+    pub fn to_str(&self) -> Option<&str> {
+        self.inner.to_str()
+    }
 }
 
 impl<'a> From<&'a std::path::Path> for &'a Path {

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -801,15 +801,27 @@ impl<'a> Into<&'a std::path::Path> for &'a Path {
     }
 }
 
-impl AsRef<OsStr> for Path {
-    fn as_ref(&self) -> &OsStr {
-        self.inner.as_ref()
+impl AsRef<std::path::Path> for Path {
+    fn as_ref(&self) -> &std::path::Path {
+        self.into()
+    }
+}
+
+impl AsRef<Path> for std::path::Path {
+    fn as_ref(&self) -> &Path {
+        self.into()
     }
 }
 
 impl AsRef<Path> for Path {
     fn as_ref(&self) -> &Path {
         self
+    }
+}
+
+impl AsRef<OsStr> for Path {
+    fn as_ref(&self) -> &OsStr {
+        self.inner.as_ref()
     }
 }
 

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -684,6 +684,31 @@ impl Path {
     pub fn to_str(&self) -> Option<&str> {
         self.inner.to_str()
     }
+
+    /// Converts a `Path` to a [`Cow<str>`].
+    ///
+    /// Any non-Unicode sequences are replaced with
+    /// [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].
+    ///
+    /// [`Cow<str>`]: https://doc.rust-lang.org/std/borrow/enum.Cow.html
+    /// [U+FFFD]: https://doc.rust-lang.org/std/char/constant.REPLACEMENT_CHARACTER.html
+    ///
+    /// # Examples
+    ///
+    /// Calling `to_string_lossy` on a `Path` with valid unicode:
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("foo.txt");
+    /// assert_eq!(path.to_string_lossy(), "foo.txt");
+    /// ```
+    ///
+    /// Had `path` contained invalid unicode, the `to_string_lossy` call might
+    /// have returned `"fo�.txt"`.
+    pub fn to_string_lossy(&self) -> std::borrow::Cow<'_, str> {
+        self.inner.to_string_lossy()
+    }
 }
 
 impl<'a> From<&'a std::path::Path> for &'a Path {

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -124,6 +124,26 @@ impl Path {
         self.inner.display()
     }
 
+    /// Determines whether `child` is a suffix of `self`.
+    ///
+    /// Only considers whole path components to match.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/etc/passwd");
+    ///
+    /// assert!(path.ends_with("passwd"));
+    /// ```
+    pub fn ends_with<P: AsRef<Path>>(&self, child: P) -> bool
+    where
+        P: std::convert::AsRef<std::path::Path>,
+    {
+        self.inner.ends_with(child)
+    }
+
     /// Returns `true` if the path points at an existing entity.
     ///
     /// This function will traverse symbolic links to query information about the

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -173,6 +173,31 @@ impl Path {
         fs::metadata(self).await.is_ok()
     }
 
+    /// Extracts the extension of [`self.file_name`], if possible.
+    ///
+    /// The extension is:
+    ///
+    /// * [`None`], if there is no file name;
+    /// * [`None`], if there is no embedded `.`;
+    /// * [`None`], if the file name begins with `.` and has no other `.`s within;
+    /// * Otherwise, the portion of the file name after the final `.`
+    ///
+    /// [`self.file_name`]: struct.Path.html#method.file_name
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("foo.rs");
+    ///
+    /// assert_eq!("rs", path.extension().unwrap());
+    /// ```
+    pub fn extension(&self) -> Option<&OsStr> {
+        self.inner.extension()
+    }
+
     /// Converts a [`Box<Path>`][`Box`] into a [`PathBuf`] without copying or
     /// allocating.
     ///

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -7,7 +7,7 @@ use crate::{fs, io};
 ///
 /// [`std::path::Path`]: https://doc.rust-lang.org/std/path/struct.Path.html
 pub struct Path {
-    inner: OsStr,
+    inner: std::path::Path,
 }
 
 impl Path {
@@ -15,7 +15,7 @@ impl Path {
     ///
     /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
     pub fn as_os_str(&self) -> &OsStr {
-        &self.inner
+        self.inner.as_os_str()
     }
 
     /// Returns the canonical, absolute form of the path with all intermediate
@@ -72,8 +72,7 @@ impl Path {
     /// [`Component`]: enum.Component.html
     /// [`CurDir`]: enum.Component.html#variant.CurDir
     pub fn components(&self) -> Components<'_> {
-        let path: &std::path::Path = self.into();
-        path.components()
+        self.inner.components()
     }
 
     /// Directly wraps a string slice as a `Path` slice.
@@ -99,7 +98,7 @@ impl Path {
     /// assert_eq!(from_string, from_path);
     /// ```
     pub fn new<S: AsRef<OsStr> + ?Sized>(s: &S) -> &Path {
-        unsafe { &*(s.as_ref() as *const OsStr as *const Path) }
+        unsafe { &*(std::path::Path::new(s) as *const std::path::Path as *const Path) }
     }
 
     /// Converts a `Path` to an owned [`PathBuf`].
@@ -115,7 +114,7 @@ impl Path {
     /// assert_eq!(path_buf, PathBuf::from("foo.txt"));
     /// ```
     pub fn to_path_buf(&self) -> PathBuf {
-        PathBuf::from(self.inner.to_os_string())
+        PathBuf::from(self.inner.to_path_buf())
     }
 }
 
@@ -137,40 +136,8 @@ impl AsRef<Path> for Path {
     }
 }
 
-impl AsRef<Path> for OsStr {
-    fn as_ref(&self) -> &Path {
-        Path::new(self)
-    }
-}
-
-impl AsRef<Path> for str {
-    fn as_ref(&self) -> &Path {
-        Path::new(self)
-    }
-}
-
 impl std::fmt::Debug for Path {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Debug::fmt(&self.inner, formatter)
-    }
-}
-
-impl std::cmp::PartialEq for Path {
-    fn eq(&self, other: &Path) -> bool {
-        self.components().eq(other.components())
-    }
-}
-
-impl std::cmp::Eq for Path {}
-
-impl std::cmp::PartialOrd for Path {
-    fn partial_cmp(&self, other: &Path) -> Option<std::cmp::Ordering> {
-        self.components().partial_cmp(other.components())
-    }
-}
-
-impl std::cmp::Ord for Path {
-    fn cmp(&self, other: &Path) -> std::cmp::Ordering {
-        self.components().cmp(other.components())
     }
 }

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -281,6 +281,28 @@ impl Path {
         inner.into_path_buf().into()
     }
 
+    /// Returns `true` if the `Path` is absolute, i.e., if it is independent of
+    /// the current directory.
+    ///
+    /// * On Unix, a path is absolute if it starts with the root, so
+    /// `is_absolute` and [`has_root`] are equivalent.
+    ///
+    /// * On Windows, a path is absolute if it has a prefix and starts with the
+    /// root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// assert!(!Path::new("foo.txt").is_absolute());
+    /// ```
+    ///
+    /// [`has_root`]: #method.has_root
+    pub fn is_absolute(&self) -> bool {
+        self.inner.is_absolute()
+    }
+
     /// Queries the file system to get information about a file, directory, etc.
     ///
     /// This function will traverse symbolic links to query information about the

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 
-use crate::path::{Ancestors, Components, PathBuf};
+use crate::path::{Ancestors, Components, Display, PathBuf};
 use crate::{fs, io};
 
 /// This struct is an async version of [`std::path::Path`].
@@ -104,6 +104,24 @@ impl Path {
     /// [`CurDir`]: enum.Component.html#variant.CurDir
     pub fn components(&self) -> Components<'_> {
         self.inner.components()
+    }
+
+    /// Returns an object that implements [`Display`] for safely printing paths
+    /// that may contain non-Unicode data.
+    ///
+    /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/tmp/foo.rs");
+    ///
+    /// println!("{}", path.display());
+    /// ```
+    pub fn display(&self) -> Display<'_> {
+        self.inner.display()
     }
 
     /// Returns `true` if the path points at an existing entity.

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -303,6 +303,76 @@ impl Path {
         self.inner.is_absolute()
     }
 
+    /// Returns `true` if the path exists on disk and is pointing at a directory.
+    ///
+    /// This function will traverse symbolic links to query information about the
+    /// destination file. In case of broken symbolic links this will return `false`.
+    ///
+    /// If you cannot access the directory containing the file, e.g., because of a
+    /// permission error, this will return `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    /// assert_eq!(Path::new("./is_a_directory/").is_dir().await, true);
+    /// assert_eq!(Path::new("a_file.txt").is_dir().await, false);
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    ///
+    /// # See Also
+    ///
+    /// This is a convenience function that coerces errors to false. If you want to
+    /// check errors, call [fs::metadata] and handle its Result. Then call
+    /// [fs::Metadata::is_dir] if it was Ok.
+    ///
+    /// [fs::metadata]: ../fs/fn.metadata.html
+    /// [fs::Metadata::is_dir]: ../fs/struct.Metadata.html#method.is_dir
+    pub async fn is_dir(&self) -> bool {
+        fs::metadata(self)
+            .await
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` if the path exists on disk and is pointing at a regular file.
+    ///
+    /// This function will traverse symbolic links to query information about the
+    /// destination file. In case of broken symbolic links this will return `false`.
+    ///
+    /// If you cannot access the directory containing the file, e.g., because of a
+    /// permission error, this will return `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    /// assert_eq!(Path::new("./is_a_directory/").is_file().await, false);
+    /// assert_eq!(Path::new("a_file.txt").is_file().await, true);
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    ///
+    /// # See Also
+    ///
+    /// This is a convenience function that coerces errors to false. If you want to
+    /// check errors, call [fs::metadata] and handle its Result. Then call
+    /// [fs::Metadata::is_file] if it was Ok.
+    ///
+    /// [fs::metadata]: ../fs/fn.metadata.html
+    /// [fs::Metadata::is_file]: ../fs/struct.Metadata.html#method.is_file
+    pub async fn is_file(&self) -> bool {
+        fs::metadata(self)
+            .await
+            .map(|m| m.is_file())
+            .unwrap_or(false)
+    }
+
     /// Queries the file system to get information about a file, directory, etc.
     ///
     /// This function will traverse symbolic links to query information about the

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -1,7 +1,6 @@
 use std::ffi::OsStr;
-use std::iter::FusedIterator;
 
-use crate::path::{Components, Display, Iter, PathBuf, StripPrefixError};
+use crate::path::{Ancestors, Components, Display, Iter, PathBuf, StripPrefixError};
 use crate::{fs, io};
 
 /// This struct is an async version of [`std::path::Path`].
@@ -13,456 +12,6 @@ pub struct Path {
 }
 
 impl Path {
-    /// Produces an iterator over `Path` and its ancestors.
-    ///
-    /// The iterator will yield the `Path` that is returned if the [`parent`] method is used zero
-    /// or more times. That means, the iterator will yield `&self`, `&self.parent().unwrap()`,
-    /// `&self.parent().unwrap().parent().unwrap()` and so on. If the [`parent`] method returns
-    /// [`None`], the iterator will do likewise. The iterator will always yield at least one value,
-    /// namely `&self`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::Path;
-    ///
-    /// let mut ancestors = Path::new("/foo/bar").ancestors();
-    /// assert_eq!(ancestors.next(), Some(Path::new("/foo/bar").into()));
-    /// assert_eq!(ancestors.next(), Some(Path::new("/foo").into()));
-    /// assert_eq!(ancestors.next(), Some(Path::new("/").into()));
-    /// assert_eq!(ancestors.next(), None);
-    /// ```
-    ///
-    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html
-    /// [`parent`]: struct.Path.html#method.parent
-    pub fn ancestors(&self) -> Ancestors<'_> {
-        Ancestors { next: Some(&self) }
-    }
-
-    /// Yields the underlying [`OsStr`] slice.
-    ///
-    /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
-    pub fn as_os_str(&self) -> &OsStr {
-        self.inner.as_os_str()
-    }
-
-    /// Returns the canonical, absolute form of the path with all intermediate
-    /// components normalized and symbolic links resolved.
-    ///
-    /// This is an alias to [`fs::canonicalize`].
-    ///
-    /// [`fs::canonicalize`]: ../fs/fn.canonicalize.html
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
-    /// #
-    /// use async_std::path::{Path, PathBuf};
-    ///
-    /// let path = Path::new("/foo/test/../test/bar.rs");
-    /// assert_eq!(path.canonicalize().await.unwrap(), PathBuf::from("/foo/test/bar.rs"));
-    /// #
-    /// # Ok(()) }) }
-    /// ```
-    pub async fn canonicalize(&self) -> io::Result<PathBuf> {
-        fs::canonicalize(self).await
-    }
-
-    /// Produces an iterator over the [`Component`]s of the path.
-    ///
-    /// When parsing the path, there is a small amount of normalization:
-    ///
-    /// * Repeated separators are ignored, so `a/b` and `a//b` both have
-    ///   `a` and `b` as components.
-    ///
-    /// * Occurrences of `.` are normalized away, except if they are at the
-    ///   beginning of the path. For example, `a/./b`, `a/b/`, `a/b/.` and
-    ///   `a/b` all have `a` and `b` as components, but `./a/b` starts with
-    ///   an additional [`CurDir`] component.
-    ///
-    /// * A trailing slash is normalized away, `/a/b` and `/a/b/` are equivalent.
-    ///
-    /// Note that no other normalization takes place; in particular, `a/c`
-    /// and `a/b/../c` are distinct, to account for the possibility that `b`
-    /// is a symbolic link (so its parent isn't `a`).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::{Path, Component};
-    /// use std::ffi::OsStr;
-    ///
-    /// let mut components = Path::new("/tmp/foo.txt").components();
-    ///
-    /// assert_eq!(components.next(), Some(Component::RootDir));
-    /// assert_eq!(components.next(), Some(Component::Normal(OsStr::new("tmp"))));
-    /// assert_eq!(components.next(), Some(Component::Normal(OsStr::new("foo.txt"))));
-    /// assert_eq!(components.next(), None)
-    /// ```
-    ///
-    /// [`Component`]: enum.Component.html
-    /// [`CurDir`]: enum.Component.html#variant.CurDir
-    pub fn components(&self) -> Components<'_> {
-        self.inner.components()
-    }
-
-    /// Returns an object that implements [`Display`] for safely printing paths
-    /// that may contain non-Unicode data.
-    ///
-    /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::Path;
-    ///
-    /// let path = Path::new("/tmp/foo.rs");
-    ///
-    /// println!("{}", path.display());
-    /// ```
-    pub fn display(&self) -> Display<'_> {
-        self.inner.display()
-    }
-
-    /// Determines whether `child` is a suffix of `self`.
-    ///
-    /// Only considers whole path components to match.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::Path;
-    ///
-    /// let path = Path::new("/etc/passwd");
-    ///
-    /// assert!(path.ends_with("passwd"));
-    /// ```
-    pub fn ends_with<P: AsRef<Path>>(&self, child: P) -> bool
-    where
-        P: std::convert::AsRef<std::path::Path>,
-    {
-        self.inner.ends_with(child)
-    }
-
-    /// Returns `true` if the path points at an existing entity.
-    ///
-    /// This function will traverse symbolic links to query information about the
-    /// destination file. In case of broken symbolic links this will return `false`.
-    ///
-    /// If you cannot access the directory containing the file, e.g., because of a
-    /// permission error, this will return `false`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
-    /// #
-    /// use async_std::path::Path;
-    /// assert_eq!(Path::new("does_not_exist.txt").exists().await, false);
-    /// #
-    /// # Ok(()) }) }
-    /// ```
-    ///
-    /// # See Also
-    ///
-    /// This is a convenience function that coerces errors to false. If you want to
-    /// check errors, call [fs::metadata].
-    ///
-    /// [fs::metadata]: ../fs/fn.metadata.html
-    pub async fn exists(&self) -> bool {
-        fs::metadata(self).await.is_ok()
-    }
-
-    /// Extracts the extension of [`self.file_name`], if possible.
-    ///
-    /// The extension is:
-    ///
-    /// * [`None`], if there is no file name;
-    /// * [`None`], if there is no embedded `.`;
-    /// * [`None`], if the file name begins with `.` and has no other `.`s within;
-    /// * Otherwise, the portion of the file name after the final `.`
-    ///
-    /// [`self.file_name`]: struct.Path.html#method.file_name
-    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::Path;
-    ///
-    /// let path = Path::new("foo.rs");
-    ///
-    /// assert_eq!("rs", path.extension().unwrap());
-    /// ```
-    pub fn extension(&self) -> Option<&OsStr> {
-        self.inner.extension()
-    }
-
-    /// Returns the final component of the `Path`, if there is one.
-    ///
-    /// If the path is a normal file, this is the file name. If it's the path of a directory, this
-    /// is the directory name.
-    ///
-    /// Returns [`None`] if the path terminates in `..`.
-    ///
-    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::Path;
-    /// use std::ffi::OsStr;
-    ///
-    /// assert_eq!(Some(OsStr::new("bin")), Path::new("/usr/bin/").file_name());
-    /// assert_eq!(Some(OsStr::new("foo.txt")), Path::new("tmp/foo.txt").file_name());
-    /// assert_eq!(Some(OsStr::new("foo.txt")), Path::new("foo.txt/.").file_name());
-    /// assert_eq!(Some(OsStr::new("foo.txt")), Path::new("foo.txt/.//").file_name());
-    /// assert_eq!(None, Path::new("foo.txt/..").file_name());
-    /// assert_eq!(None, Path::new("/").file_name());
-    /// ```
-    pub fn file_name(&self) -> Option<&OsStr> {
-        self.inner.file_name()
-    }
-
-    /// Extracts the stem (non-extension) portion of [`self.file_name`].
-    ///
-    /// [`self.file_name`]: struct.Path.html#method.file_name
-    ///
-    /// The stem is:
-    ///
-    /// * [`None`], if there is no file name;
-    /// * The entire file name if there is no embedded `.`;
-    /// * The entire file name if the file name begins with `.` and has no other `.`s within;
-    /// * Otherwise, the portion of the file name before the final `.`
-    ///
-    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::Path;
-    ///
-    /// let path = Path::new("foo.rs");
-    ///
-    /// assert_eq!("foo", path.file_stem().unwrap());
-    /// ```
-    pub fn file_stem(&self) -> Option<&OsStr> {
-        self.inner.file_stem()
-    }
-
-    /// Returns `true` if the `Path` has a root.
-    ///
-    /// * On Unix, a path has a root if it begins with `/`.
-    ///
-    /// * On Windows, a path has a root if it:
-    ///     * has no prefix and begins with a separator, e.g., `\windows`
-    ///     * has a prefix followed by a separator, e.g., `c:\windows` but not `c:windows`
-    ///     * has any non-disk prefix, e.g., `\\server\share`
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::Path;
-    ///
-    /// assert!(Path::new("/etc/passwd").has_root());
-    /// ```
-    pub fn has_root(&self) -> bool {
-        self.inner.has_root()
-    }
-
-    /// Converts a [`Box<Path>`][`Box`] into a [`PathBuf`] without copying or
-    /// allocating.
-    ///
-    /// [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
-    /// [`PathBuf`]: struct.PathBuf.html
-    pub fn into_path_buf(self: Box<Path>) -> PathBuf {
-        let rw = Box::into_raw(self) as *mut std::path::Path;
-        let inner = unsafe { Box::from_raw(rw) };
-        inner.into_path_buf().into()
-    }
-
-    /// Returns `true` if the `Path` is absolute, i.e., if it is independent of
-    /// the current directory.
-    ///
-    /// * On Unix, a path is absolute if it starts with the root, so
-    /// `is_absolute` and [`has_root`] are equivalent.
-    ///
-    /// * On Windows, a path is absolute if it has a prefix and starts with the
-    /// root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::Path;
-    ///
-    /// assert!(!Path::new("foo.txt").is_absolute());
-    /// ```
-    ///
-    /// [`has_root`]: #method.has_root
-    pub fn is_absolute(&self) -> bool {
-        self.inner.is_absolute()
-    }
-
-    /// Returns `true` if the path exists on disk and is pointing at a directory.
-    ///
-    /// This function will traverse symbolic links to query information about the
-    /// destination file. In case of broken symbolic links this will return `false`.
-    ///
-    /// If you cannot access the directory containing the file, e.g., because of a
-    /// permission error, this will return `false`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
-    /// #
-    /// use async_std::path::Path;
-    /// assert_eq!(Path::new("./is_a_directory/").is_dir().await, true);
-    /// assert_eq!(Path::new("a_file.txt").is_dir().await, false);
-    /// #
-    /// # Ok(()) }) }
-    /// ```
-    ///
-    /// # See Also
-    ///
-    /// This is a convenience function that coerces errors to false. If you want to
-    /// check errors, call [fs::metadata] and handle its Result. Then call
-    /// [fs::Metadata::is_dir] if it was Ok.
-    ///
-    /// [fs::metadata]: ../fs/fn.metadata.html
-    /// [fs::Metadata::is_dir]: ../fs/struct.Metadata.html#method.is_dir
-    pub async fn is_dir(&self) -> bool {
-        fs::metadata(self)
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-    }
-
-    /// Returns `true` if the path exists on disk and is pointing at a regular file.
-    ///
-    /// This function will traverse symbolic links to query information about the
-    /// destination file. In case of broken symbolic links this will return `false`.
-    ///
-    /// If you cannot access the directory containing the file, e.g., because of a
-    /// permission error, this will return `false`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
-    /// #
-    /// use async_std::path::Path;
-    /// assert_eq!(Path::new("./is_a_directory/").is_file().await, false);
-    /// assert_eq!(Path::new("a_file.txt").is_file().await, true);
-    /// #
-    /// # Ok(()) }) }
-    /// ```
-    ///
-    /// # See Also
-    ///
-    /// This is a convenience function that coerces errors to false. If you want to
-    /// check errors, call [fs::metadata] and handle its Result. Then call
-    /// [fs::Metadata::is_file] if it was Ok.
-    ///
-    /// [fs::metadata]: ../fs/fn.metadata.html
-    /// [fs::Metadata::is_file]: ../fs/struct.Metadata.html#method.is_file
-    pub async fn is_file(&self) -> bool {
-        fs::metadata(self)
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    }
-
-    /// Returns `true` if the `Path` is relative, i.e., not absolute.
-    ///
-    /// See [`is_absolute`]'s documentation for more details.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::Path;
-    ///
-    /// assert!(Path::new("foo.txt").is_relative());
-    /// ```
-    ///
-    /// [`is_absolute`]: #method.is_absolute
-    pub fn is_relative(&self) -> bool {
-        self.inner.is_relative()
-    }
-
-    /// Produces an iterator over the path's components viewed as [`OsStr`]
-    /// slices.
-    ///
-    /// For more information about the particulars of how the path is separated
-    /// into components, see [`components`].
-    ///
-    /// [`components`]: #method.components
-    /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::{self, Path};
-    /// use std::ffi::OsStr;
-    ///
-    /// let mut it = Path::new("/tmp/foo.txt").iter();
-    /// assert_eq!(it.next(), Some(OsStr::new(&path::MAIN_SEPARATOR.to_string())));
-    /// assert_eq!(it.next(), Some(OsStr::new("tmp")));
-    /// assert_eq!(it.next(), Some(OsStr::new("foo.txt")));
-    /// assert_eq!(it.next(), None)
-    /// ```
-    pub fn iter(&self) -> Iter<'_> {
-        self.inner.iter()
-    }
-
-    /// Creates an owned [`PathBuf`] with `path` adjoined to `self`.
-    ///
-    /// See [`PathBuf::push`] for more details on what it means to adjoin a path.
-    ///
-    /// [`PathBuf`]: struct.PathBuf.html
-    /// [`PathBuf::push`]: struct.PathBuf.html#method.push
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::{Path, PathBuf};
-    ///
-    /// assert_eq!(Path::new("/etc").join("passwd"), PathBuf::from("/etc/passwd"));
-    /// ```
-    pub fn join<P: AsRef<Path>>(&self, path: P) -> PathBuf
-    where
-        P: std::convert::AsRef<std::path::Path>,
-    {
-        self.inner.join(path).into()
-    }
-
-    /// Queries the file system to get information about a file, directory, etc.
-    ///
-    /// This function will traverse symbolic links to query information about the
-    /// destination file.
-    ///
-    /// This is an alias to [`fs::metadata`].
-    ///
-    /// [`fs::metadata`]: ../fs/fn.metadata.html
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
-    /// #
-    /// use async_std::path::Path;
-    ///
-    /// let path = Path::new("/Minas/tirith");
-    /// let metadata = path.metadata().await.expect("metadata call failed");
-    /// println!("{:?}", metadata.file_type());
-    /// #
-    /// # Ok(()) }) }
-    /// ```
-    pub async fn metadata(&self) -> io::Result<fs::Metadata> {
-        fs::metadata(self).await
-    }
-
     /// Directly wraps a string slice as a `Path` slice.
     ///
     /// This is a cost-free conversion.
@@ -489,181 +38,11 @@ impl Path {
         unsafe { &*(std::path::Path::new(s) as *const std::path::Path as *const Path) }
     }
 
-    /// Returns the `Path` without its final component, if there is one.
+    /// Yields the underlying [`OsStr`] slice.
     ///
-    /// Returns [`None`] if the path terminates in a root or prefix.
-    ///
-    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::Path;
-    ///
-    /// let path = Path::new("/foo/bar");
-    /// let parent = path.parent().unwrap();
-    /// assert_eq!(parent, Path::new("/foo"));
-    ///
-    /// let grand_parent = parent.parent().unwrap();
-    /// assert_eq!(grand_parent, Path::new("/"));
-    /// assert_eq!(grand_parent.parent(), None);
-    /// ```
-    pub fn parent(&self) -> Option<&Path> {
-        self.inner.parent().map(|p| p.into())
-    }
-
-    /// Returns an iterator over the entries within a directory.
-    ///
-    /// The iterator will yield instances of [`io::Result`]`<`[`DirEntry`]`>`. New
-    /// errors may be encountered after an iterator is initially constructed.
-    ///
-    /// This is an alias to [`fs::read_dir`].
-    ///
-    /// [`io::Result`]: ../io/type.Result.html
-    /// [`DirEntry`]: ../fs/struct.DirEntry.html
-    /// [`fs::read_dir`]: ../fs/fn.read_dir.html
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
-    /// #
-    /// use async_std::path::Path;
-    /// use async_std::fs;
-    /// use futures_util::stream::StreamExt;
-    ///
-    /// let path = Path::new("/laputa");
-    /// let mut dir = fs::read_dir(&path).await.expect("read_dir call failed");
-    /// while let Some(res) = dir.next().await {
-    ///     let entry = res?;
-    ///     println!("{}", entry.file_name().to_string_lossy());
-    /// }
-    /// #
-    /// # Ok(()) }) }
-    /// ```
-    pub async fn read_dir(&self) -> io::Result<fs::ReadDir> {
-        fs::read_dir(self).await
-    }
-
-    /// Reads a symbolic link, returning the file that the link points to.
-    ///
-    /// This is an alias to [`fs::read_link`].
-    ///
-    /// [`fs::read_link`]: ../fs/fn.read_link.html
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
-    /// #
-    /// use async_std::path::Path;
-    ///
-    /// let path = Path::new("/laputa/sky_castle.rs");
-    /// let path_link = path.read_link().await.expect("read_link call failed");
-    /// #
-    /// # Ok(()) }) }
-    /// ```
-    pub async fn read_link(&self) -> io::Result<PathBuf> {
-        fs::read_link(self).await
-    }
-
-    /// Determines whether `base` is a prefix of `self`.
-    ///
-    /// Only considers whole path components to match.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::Path;
-    ///
-    /// let path = Path::new("/etc/passwd");
-    ///
-    /// assert!(path.starts_with("/etc"));
-    /// assert!(path.starts_with("/etc/"));
-    /// assert!(path.starts_with("/etc/passwd"));
-    /// assert!(path.starts_with("/etc/passwd/"));
-    ///
-    /// assert!(!path.starts_with("/e"));
-    /// ```
-    pub fn starts_with<P: AsRef<Path>>(&self, base: P) -> bool
-    where
-        P: std::convert::AsRef<std::path::Path>,
-    {
-        self.inner.starts_with(base)
-    }
-
-    /// Returns a path that, when joined onto `base`, yields `self`.
-    ///
-    /// # Errors
-    ///
-    /// If `base` is not a prefix of `self` (i.e., [`starts_with`]
-    /// returns `false`), returns [`Err`].
-    ///
-    /// [`starts_with`]: #method.starts_with
-    /// [`Err`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::{Path, PathBuf};
-    ///
-    /// let path = Path::new("/test/haha/foo.txt");
-    ///
-    /// assert_eq!(path.strip_prefix("/"), Ok(Path::new("test/haha/foo.txt")));
-    /// assert_eq!(path.strip_prefix("/test"), Ok(Path::new("haha/foo.txt")));
-    /// assert_eq!(path.strip_prefix("/test/"), Ok(Path::new("haha/foo.txt")));
-    /// assert_eq!(path.strip_prefix("/test/haha/foo.txt"), Ok(Path::new("")));
-    /// assert_eq!(path.strip_prefix("/test/haha/foo.txt/"), Ok(Path::new("")));
-    /// assert_eq!(path.strip_prefix("test").is_ok(), false);
-    /// assert_eq!(path.strip_prefix("/haha").is_ok(), false);
-    ///
-    /// let prefix = PathBuf::from("/test/");
-    /// assert_eq!(path.strip_prefix(prefix), Ok(Path::new("haha/foo.txt")));
-    /// ```
-    pub fn strip_prefix<P>(&self, base: P) -> Result<&Path, StripPrefixError>
-    where
-        P: AsRef<std::path::Path>,
-    {
-        Ok(self.inner.strip_prefix(base)?.into())
-    }
-
-    /// Queries the metadata about a file without following symlinks.
-    ///
-    /// This is an alias to [`fs::symlink_metadata`].
-    ///
-    /// [`fs::symlink_metadata`]: ../fs/fn.symlink_metadata.html
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
-    /// #
-    /// use async_std::path::Path;
-    ///
-    /// let path = Path::new("/Minas/tirith");
-    /// let metadata = path.symlink_metadata().await.expect("symlink_metadata call failed");
-    /// println!("{:?}", metadata.file_type());
-    /// #
-    /// # Ok(()) }) }
-    /// ```
-    pub async fn symlink_metadata(&self) -> io::Result<fs::Metadata> {
-        fs::symlink_metadata(self).await
-    }
-
-    /// Converts a `Path` to an owned [`PathBuf`].
-    ///
-    /// [`PathBuf`]: struct.PathBuf.html
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use async_std::path::{Path, PathBuf};
-    ///
-    /// let path_buf = Path::new("foo.txt").to_path_buf();
-    /// assert_eq!(path_buf, PathBuf::from("foo.txt"));
-    /// ```
-    pub fn to_path_buf(&self) -> PathBuf {
-        PathBuf::from(self.inner.to_path_buf())
+    /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
+    pub fn as_os_str(&self) -> &OsStr {
+        self.inner.as_os_str()
     }
 
     /// Yields a [`&str`] slice if the `Path` is valid unicode.
@@ -711,23 +90,297 @@ impl Path {
         self.inner.to_string_lossy()
     }
 
-    /// Creates an owned [`PathBuf`] like `self` but with the given extension.
-    ///
-    /// See [`PathBuf::set_extension`] for more details.
+    /// Converts a `Path` to an owned [`PathBuf`].
     ///
     /// [`PathBuf`]: struct.PathBuf.html
-    /// [`PathBuf::set_extension`]: struct.PathBuf.html#method.set_extension
     ///
     /// # Examples
     ///
     /// ```
     /// use async_std::path::{Path, PathBuf};
     ///
-    /// let path = Path::new("foo.rs");
-    /// assert_eq!(path.with_extension("txt"), PathBuf::from("foo.txt"));
+    /// let path_buf = Path::new("foo.txt").to_path_buf();
+    /// assert_eq!(path_buf, PathBuf::from("foo.txt"));
     /// ```
-    pub fn with_extension<S: AsRef<OsStr>>(&self, extension: S) -> PathBuf {
-        self.inner.with_extension(extension).into()
+    pub fn to_path_buf(&self) -> PathBuf {
+        PathBuf::from(self.inner.to_path_buf())
+    }
+
+    /// Returns `true` if the `Path` is absolute, i.e., if it is independent of
+    /// the current directory.
+    ///
+    /// * On Unix, a path is absolute if it starts with the root, so
+    /// `is_absolute` and [`has_root`] are equivalent.
+    ///
+    /// * On Windows, a path is absolute if it has a prefix and starts with the
+    /// root: `c:\windows` is absolute, while `c:temp` and `\temp` are not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// assert!(!Path::new("foo.txt").is_absolute());
+    /// ```
+    ///
+    /// [`has_root`]: #method.has_root
+    pub fn is_absolute(&self) -> bool {
+        self.inner.is_absolute()
+    }
+
+    /// Returns `true` if the `Path` is relative, i.e., not absolute.
+    ///
+    /// See [`is_absolute`]'s documentation for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// assert!(Path::new("foo.txt").is_relative());
+    /// ```
+    ///
+    /// [`is_absolute`]: #method.is_absolute
+    pub fn is_relative(&self) -> bool {
+        self.inner.is_relative()
+    }
+
+    /// Returns `true` if the `Path` has a root.
+    ///
+    /// * On Unix, a path has a root if it begins with `/`.
+    ///
+    /// * On Windows, a path has a root if it:
+    ///     * has no prefix and begins with a separator, e.g., `\windows`
+    ///     * has a prefix followed by a separator, e.g., `c:\windows` but not `c:windows`
+    ///     * has any non-disk prefix, e.g., `\\server\share`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// assert!(Path::new("/etc/passwd").has_root());
+    /// ```
+    pub fn has_root(&self) -> bool {
+        self.inner.has_root()
+    }
+
+    /// Returns the `Path` without its final component, if there is one.
+    ///
+    /// Returns [`None`] if the path terminates in a root or prefix.
+    ///
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/foo/bar");
+    /// let parent = path.parent().unwrap();
+    /// assert_eq!(parent, Path::new("/foo"));
+    ///
+    /// let grand_parent = parent.parent().unwrap();
+    /// assert_eq!(grand_parent, Path::new("/"));
+    /// assert_eq!(grand_parent.parent(), None);
+    /// ```
+    pub fn parent(&self) -> Option<&Path> {
+        self.inner.parent().map(|p| p.into())
+    }
+
+    /// Produces an iterator over `Path` and its ancestors.
+    ///
+    /// The iterator will yield the `Path` that is returned if the [`parent`] method is used zero
+    /// or more times. That means, the iterator will yield `&self`, `&self.parent().unwrap()`,
+    /// `&self.parent().unwrap().parent().unwrap()` and so on. If the [`parent`] method returns
+    /// [`None`], the iterator will do likewise. The iterator will always yield at least one value,
+    /// namely `&self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let mut ancestors = Path::new("/foo/bar").ancestors();
+    /// assert_eq!(ancestors.next(), Some(Path::new("/foo/bar").into()));
+    /// assert_eq!(ancestors.next(), Some(Path::new("/foo").into()));
+    /// assert_eq!(ancestors.next(), Some(Path::new("/").into()));
+    /// assert_eq!(ancestors.next(), None);
+    /// ```
+    ///
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html
+    /// [`parent`]: struct.Path.html#method.parent
+    pub fn ancestors(&self) -> Ancestors<'_> {
+        Ancestors { next: Some(&self) }
+    }
+
+    /// Returns the final component of the `Path`, if there is one.
+    ///
+    /// If the path is a normal file, this is the file name. If it's the path of a directory, this
+    /// is the directory name.
+    ///
+    /// Returns [`None`] if the path terminates in `..`.
+    ///
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    /// use std::ffi::OsStr;
+    ///
+    /// assert_eq!(Some(OsStr::new("bin")), Path::new("/usr/bin/").file_name());
+    /// assert_eq!(Some(OsStr::new("foo.txt")), Path::new("tmp/foo.txt").file_name());
+    /// assert_eq!(Some(OsStr::new("foo.txt")), Path::new("foo.txt/.").file_name());
+    /// assert_eq!(Some(OsStr::new("foo.txt")), Path::new("foo.txt/.//").file_name());
+    /// assert_eq!(None, Path::new("foo.txt/..").file_name());
+    /// assert_eq!(None, Path::new("/").file_name());
+    /// ```
+    pub fn file_name(&self) -> Option<&OsStr> {
+        self.inner.file_name()
+    }
+
+    /// Returns a path that, when joined onto `base`, yields `self`.
+    ///
+    /// # Errors
+    ///
+    /// If `base` is not a prefix of `self` (i.e., [`starts_with`]
+    /// returns `false`), returns [`Err`].
+    ///
+    /// [`starts_with`]: #method.starts_with
+    /// [`Err`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{Path, PathBuf};
+    ///
+    /// let path = Path::new("/test/haha/foo.txt");
+    ///
+    /// assert_eq!(path.strip_prefix("/"), Ok(Path::new("test/haha/foo.txt")));
+    /// assert_eq!(path.strip_prefix("/test"), Ok(Path::new("haha/foo.txt")));
+    /// assert_eq!(path.strip_prefix("/test/"), Ok(Path::new("haha/foo.txt")));
+    /// assert_eq!(path.strip_prefix("/test/haha/foo.txt"), Ok(Path::new("")));
+    /// assert_eq!(path.strip_prefix("/test/haha/foo.txt/"), Ok(Path::new("")));
+    /// assert_eq!(path.strip_prefix("test").is_ok(), false);
+    /// assert_eq!(path.strip_prefix("/haha").is_ok(), false);
+    ///
+    /// let prefix = PathBuf::from("/test/");
+    /// assert_eq!(path.strip_prefix(prefix), Ok(Path::new("haha/foo.txt")));
+    /// ```
+    pub fn strip_prefix<P>(&self, base: P) -> Result<&Path, StripPrefixError>
+    where
+        P: AsRef<Path>,
+    {
+        Ok(self.inner.strip_prefix(base.as_ref())?.into())
+    }
+
+    /// Determines whether `base` is a prefix of `self`.
+    ///
+    /// Only considers whole path components to match.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/etc/passwd");
+    ///
+    /// assert!(path.starts_with("/etc"));
+    /// assert!(path.starts_with("/etc/"));
+    /// assert!(path.starts_with("/etc/passwd"));
+    /// assert!(path.starts_with("/etc/passwd/"));
+    ///
+    /// assert!(!path.starts_with("/e"));
+    /// ```
+    pub fn starts_with<P: AsRef<Path>>(&self, base: P) -> bool {
+        self.inner.starts_with(base.as_ref())
+    }
+
+    /// Determines whether `child` is a suffix of `self`.
+    ///
+    /// Only considers whole path components to match.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/etc/passwd");
+    ///
+    /// assert!(path.ends_with("passwd"));
+    /// ```
+    pub fn ends_with<P: AsRef<Path>>(&self, child: P) -> bool {
+        self.inner.ends_with(child.as_ref())
+    }
+
+    /// Extracts the stem (non-extension) portion of [`self.file_name`].
+    ///
+    /// [`self.file_name`]: struct.Path.html#method.file_name
+    ///
+    /// The stem is:
+    ///
+    /// * [`None`], if there is no file name;
+    /// * The entire file name if there is no embedded `.`;
+    /// * The entire file name if the file name begins with `.` and has no other `.`s within;
+    /// * Otherwise, the portion of the file name before the final `.`
+    ///
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("foo.rs");
+    ///
+    /// assert_eq!("foo", path.file_stem().unwrap());
+    /// ```
+    pub fn file_stem(&self) -> Option<&OsStr> {
+        self.inner.file_stem()
+    }
+
+    /// Extracts the extension of [`self.file_name`], if possible.
+    ///
+    /// The extension is:
+    ///
+    /// * [`None`], if there is no file name;
+    /// * [`None`], if there is no embedded `.`;
+    /// * [`None`], if the file name begins with `.` and has no other `.`s within;
+    /// * Otherwise, the portion of the file name after the final `.`
+    ///
+    /// [`self.file_name`]: struct.Path.html#method.file_name
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("foo.rs");
+    ///
+    /// assert_eq!("rs", path.extension().unwrap());
+    /// ```
+    pub fn extension(&self) -> Option<&OsStr> {
+        self.inner.extension()
+    }
+
+    /// Creates an owned [`PathBuf`] with `path` adjoined to `self`.
+    ///
+    /// See [`PathBuf::push`] for more details on what it means to adjoin a path.
+    ///
+    /// [`PathBuf`]: struct.PathBuf.html
+    /// [`PathBuf::push`]: struct.PathBuf.html#method.push
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{Path, PathBuf};
+    ///
+    /// assert_eq!(Path::new("/etc").join("passwd"), PathBuf::from("/etc/passwd"));
+    /// ```
+    pub fn join<P: AsRef<Path>>(&self, path: P) -> PathBuf {
+        self.inner.join(path.as_ref()).into()
     }
 
     /// Creates an owned [`PathBuf`] like `self` but with the given file name.
@@ -751,43 +404,344 @@ impl Path {
     pub fn with_file_name<S: AsRef<OsStr>>(&self, file_name: S) -> PathBuf {
         self.inner.with_file_name(file_name).into()
     }
-}
 
-/// An iterator over [`Path`] and its ancestors.
-///
-/// This `struct` is created by the [`ancestors`] method on [`Path`].
-/// See its documentation for more.
-///
-/// # Examples
-///
-/// ```
-/// use async_std::path::Path;
-///
-/// let path = Path::new("/foo/bar");
-///
-/// for ancestor in path.ancestors() {
-///     println!("{}", ancestor.display());
-/// }
-/// ```
-///
-/// [`ancestors`]: struct.Path.html#method.ancestors
-/// [`Path`]: struct.Path.html
-#[derive(Copy, Clone, Debug)]
-pub struct Ancestors<'a> {
-    next: Option<&'a Path>,
-}
+    /// Creates an owned [`PathBuf`] like `self` but with the given extension.
+    ///
+    /// See [`PathBuf::set_extension`] for more details.
+    ///
+    /// [`PathBuf`]: struct.PathBuf.html
+    /// [`PathBuf::set_extension`]: struct.PathBuf.html#method.set_extension
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{Path, PathBuf};
+    ///
+    /// let path = Path::new("foo.rs");
+    /// assert_eq!(path.with_extension("txt"), PathBuf::from("foo.txt"));
+    /// ```
+    pub fn with_extension<S: AsRef<OsStr>>(&self, extension: S) -> PathBuf {
+        self.inner.with_extension(extension).into()
+    }
 
-impl<'a> Iterator for Ancestors<'a> {
-    type Item = &'a Path;
+    /// Produces an iterator over the [`Component`]s of the path.
+    ///
+    /// When parsing the path, there is a small amount of normalization:
+    ///
+    /// * Repeated separators are ignored, so `a/b` and `a//b` both have
+    ///   `a` and `b` as components.
+    ///
+    /// * Occurrences of `.` are normalized away, except if they are at the
+    ///   beginning of the path. For example, `a/./b`, `a/b/`, `a/b/.` and
+    ///   `a/b` all have `a` and `b` as components, but `./a/b` starts with
+    ///   an additional [`CurDir`] component.
+    ///
+    /// * A trailing slash is normalized away, `/a/b` and `/a/b/` are equivalent.
+    ///
+    /// Note that no other normalization takes place; in particular, `a/c`
+    /// and `a/b/../c` are distinct, to account for the possibility that `b`
+    /// is a symbolic link (so its parent isn't `a`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{Path, Component};
+    /// use std::ffi::OsStr;
+    ///
+    /// let mut components = Path::new("/tmp/foo.txt").components();
+    ///
+    /// assert_eq!(components.next(), Some(Component::RootDir));
+    /// assert_eq!(components.next(), Some(Component::Normal(OsStr::new("tmp"))));
+    /// assert_eq!(components.next(), Some(Component::Normal(OsStr::new("foo.txt"))));
+    /// assert_eq!(components.next(), None)
+    /// ```
+    ///
+    /// [`Component`]: enum.Component.html
+    /// [`CurDir`]: enum.Component.html#variant.CurDir
+    pub fn components(&self) -> Components<'_> {
+        self.inner.components()
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
-        let next = self.next;
-        self.next = next.and_then(Path::parent);
-        next
+    /// Produces an iterator over the path's components viewed as [`OsStr`]
+    /// slices.
+    ///
+    /// For more information about the particulars of how the path is separated
+    /// into components, see [`components`].
+    ///
+    /// [`components`]: #method.components
+    /// [`OsStr`]: https://doc.rust-lang.org/std/ffi/struct.OsStr.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{self, Path};
+    /// use std::ffi::OsStr;
+    ///
+    /// let mut it = Path::new("/tmp/foo.txt").iter();
+    /// assert_eq!(it.next(), Some(OsStr::new(&path::MAIN_SEPARATOR.to_string())));
+    /// assert_eq!(it.next(), Some(OsStr::new("tmp")));
+    /// assert_eq!(it.next(), Some(OsStr::new("foo.txt")));
+    /// assert_eq!(it.next(), None)
+    /// ```
+    pub fn iter(&self) -> Iter<'_> {
+        self.inner.iter()
+    }
+
+    /// Returns an object that implements [`Display`] for safely printing paths
+    /// that may contain non-Unicode data.
+    ///
+    /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/tmp/foo.rs");
+    ///
+    /// println!("{}", path.display());
+    /// ```
+    pub fn display(&self) -> Display<'_> {
+        self.inner.display()
+    }
+
+    /// Queries the file system to get information about a file, directory, etc.
+    ///
+    /// This function will traverse symbolic links to query information about the
+    /// destination file.
+    ///
+    /// This is an alias to [`fs::metadata`].
+    ///
+    /// [`fs::metadata`]: ../fs/fn.metadata.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/Minas/tirith");
+    /// let metadata = path.metadata().await.expect("metadata call failed");
+    /// println!("{:?}", metadata.file_type());
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn metadata(&self) -> io::Result<fs::Metadata> {
+        fs::metadata(self).await
+    }
+
+    /// Queries the metadata about a file without following symlinks.
+    ///
+    /// This is an alias to [`fs::symlink_metadata`].
+    ///
+    /// [`fs::symlink_metadata`]: ../fs/fn.symlink_metadata.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/Minas/tirith");
+    /// let metadata = path.symlink_metadata().await.expect("symlink_metadata call failed");
+    /// println!("{:?}", metadata.file_type());
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn symlink_metadata(&self) -> io::Result<fs::Metadata> {
+        fs::symlink_metadata(self).await
+    }
+
+    /// Returns the canonical, absolute form of the path with all intermediate
+    /// components normalized and symbolic links resolved.
+    ///
+    /// This is an alias to [`fs::canonicalize`].
+    ///
+    /// [`fs::canonicalize`]: ../fs/fn.canonicalize.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::{Path, PathBuf};
+    ///
+    /// let path = Path::new("/foo/test/../test/bar.rs");
+    /// assert_eq!(path.canonicalize().await.unwrap(), PathBuf::from("/foo/test/bar.rs"));
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn canonicalize(&self) -> io::Result<PathBuf> {
+        fs::canonicalize(self).await
+    }
+
+    /// Reads a symbolic link, returning the file that the link points to.
+    ///
+    /// This is an alias to [`fs::read_link`].
+    ///
+    /// [`fs::read_link`]: ../fs/fn.read_link.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/laputa/sky_castle.rs");
+    /// let path_link = path.read_link().await.expect("read_link call failed");
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn read_link(&self) -> io::Result<PathBuf> {
+        fs::read_link(self).await
+    }
+
+    /// Returns an iterator over the entries within a directory.
+    ///
+    /// The iterator will yield instances of [`io::Result`]`<`[`DirEntry`]`>`. New
+    /// errors may be encountered after an iterator is initially constructed.
+    ///
+    /// This is an alias to [`fs::read_dir`].
+    ///
+    /// [`io::Result`]: ../io/type.Result.html
+    /// [`DirEntry`]: ../fs/struct.DirEntry.html
+    /// [`fs::read_dir`]: ../fs/fn.read_dir.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    /// use async_std::fs;
+    /// use futures_util::stream::StreamExt;
+    ///
+    /// let path = Path::new("/laputa");
+    /// let mut dir = fs::read_dir(&path).await.expect("read_dir call failed");
+    /// while let Some(res) = dir.next().await {
+    ///     let entry = res?;
+    ///     println!("{}", entry.file_name().to_string_lossy());
+    /// }
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn read_dir(&self) -> io::Result<fs::ReadDir> {
+        fs::read_dir(self).await
+    }
+
+    /// Returns `true` if the path points at an existing entity.
+    ///
+    /// This function will traverse symbolic links to query information about the
+    /// destination file. In case of broken symbolic links this will return `false`.
+    ///
+    /// If you cannot access the directory containing the file, e.g., because of a
+    /// permission error, this will return `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    /// assert_eq!(Path::new("does_not_exist.txt").exists().await, false);
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    ///
+    /// # See Also
+    ///
+    /// This is a convenience function that coerces errors to false. If you want to
+    /// check errors, call [fs::metadata].
+    ///
+    /// [fs::metadata]: ../fs/fn.metadata.html
+    pub async fn exists(&self) -> bool {
+        fs::metadata(self).await.is_ok()
+    }
+
+    /// Returns `true` if the path exists on disk and is pointing at a regular file.
+    ///
+    /// This function will traverse symbolic links to query information about the
+    /// destination file. In case of broken symbolic links this will return `false`.
+    ///
+    /// If you cannot access the directory containing the file, e.g., because of a
+    /// permission error, this will return `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    /// assert_eq!(Path::new("./is_a_directory/").is_file().await, false);
+    /// assert_eq!(Path::new("a_file.txt").is_file().await, true);
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    ///
+    /// # See Also
+    ///
+    /// This is a convenience function that coerces errors to false. If you want to
+    /// check errors, call [fs::metadata] and handle its Result. Then call
+    /// [fs::Metadata::is_file] if it was Ok.
+    ///
+    /// [fs::metadata]: ../fs/fn.metadata.html
+    /// [fs::Metadata::is_file]: ../fs/struct.Metadata.html#method.is_file
+    pub async fn is_file(&self) -> bool {
+        fs::metadata(self)
+            .await
+            .map(|m| m.is_file())
+            .unwrap_or(false)
+    }
+
+    /// Returns `true` if the path exists on disk and is pointing at a directory.
+    ///
+    /// This function will traverse symbolic links to query information about the
+    /// destination file. In case of broken symbolic links this will return `false`.
+    ///
+    /// If you cannot access the directory containing the file, e.g., because of a
+    /// permission error, this will return `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    /// assert_eq!(Path::new("./is_a_directory/").is_dir().await, true);
+    /// assert_eq!(Path::new("a_file.txt").is_dir().await, false);
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    ///
+    /// # See Also
+    ///
+    /// This is a convenience function that coerces errors to false. If you want to
+    /// check errors, call [fs::metadata] and handle its Result. Then call
+    /// [fs::Metadata::is_dir] if it was Ok.
+    ///
+    /// [fs::metadata]: ../fs/fn.metadata.html
+    /// [fs::Metadata::is_dir]: ../fs/struct.Metadata.html#method.is_dir
+    pub async fn is_dir(&self) -> bool {
+        fs::metadata(self)
+            .await
+            .map(|m| m.is_dir())
+            .unwrap_or(false)
+    }
+
+    /// Converts a [`Box<Path>`][`Box`] into a [`PathBuf`] without copying or
+    /// allocating.
+    ///
+    /// [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
+    /// [`PathBuf`]: struct.PathBuf.html
+    pub fn into_path_buf(self: Box<Path>) -> PathBuf {
+        let rw = Box::into_raw(self) as *mut std::path::Path;
+        let inner = unsafe { Box::from_raw(rw) };
+        inner.into_path_buf().into()
     }
 }
-
-impl FusedIterator for Ancestors<'_> {}
 
 impl<'a> From<&'a std::path::Path> for &'a Path {
     fn from(path: &'a std::path::Path) -> &'a Path {

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -843,6 +843,12 @@ impl AsRef<Path> for String {
     }
 }
 
+impl AsRef<Path> for std::path::PathBuf {
+    fn as_ref(&self) -> &Path {
+        Path::new(self.into())
+    }
+}
+
 impl std::borrow::ToOwned for Path {
     type Owned = PathBuf;
 

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -511,6 +511,38 @@ impl Path {
         self.inner.parent().map(|p| p.into())
     }
 
+    /// Returns an iterator over the entries within a directory.
+    ///
+    /// The iterator will yield instances of [`io::Result`]`<`[`DirEntry`]`>`. New
+    /// errors may be encountered after an iterator is initially constructed.
+    ///
+    /// This is an alias to [`fs::read_dir`].
+    ///
+    /// [`io::Result`]: ../io/type.Result.html
+    /// [`DirEntry`]: ../fs/struct.DirEntry.html
+    /// [`fs::read_dir`]: ../fs/fn.read_dir.html
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::path::Path;
+    /// use async_std::fs;
+    ///
+    /// let path = Path::new("/laputa");
+    /// let mut dir = fs::read_dir(&path).await.expect("read_dir call failed");
+    /// while let Some(res) = dir.next().await {
+    ///     let entry = res?;
+    ///     println!("{}", entry.file_name().to_string_lossy());
+    /// }
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub async fn read_dir(&self) -> io::Result<fs::ReadDir> {
+        fs::read_dir(self).await
+    }
+
     /// Queries the metadata about a file without following symlinks.
     ///
     /// This is an alias to [`fs::symlink_metadata`].
@@ -582,6 +614,12 @@ impl AsRef<Path> for OsStr {
 }
 
 impl AsRef<Path> for str {
+    fn as_ref(&self) -> &Path {
+        Path::new(self)
+    }
+}
+
+impl AsRef<Path> for String {
     fn as_ref(&self) -> &Path {
         Path::new(self)
     }

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -566,6 +566,31 @@ impl Path {
         fs::read_link(self).await
     }
 
+    /// Determines whether `base` is a prefix of `self`.
+    ///
+    /// Only considers whole path components to match.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// let path = Path::new("/etc/passwd");
+    ///
+    /// assert!(path.starts_with("/etc"));
+    /// assert!(path.starts_with("/etc/"));
+    /// assert!(path.starts_with("/etc/passwd"));
+    /// assert!(path.starts_with("/etc/passwd/"));
+    ///
+    /// assert!(!path.starts_with("/e"));
+    /// ```
+    pub fn starts_with<P: AsRef<Path>>(&self, base: P) -> bool
+    where
+        P: std::convert::AsRef<std::path::Path>,
+    {
+        self.inner.starts_with(base)
+    }
+
     /// Queries the metadata about a file without following symlinks.
     ///
     /// This is an alias to [`fs::symlink_metadata`].

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -415,6 +415,27 @@ impl Path {
         self.inner.iter()
     }
 
+    /// Creates an owned [`PathBuf`] with `path` adjoined to `self`.
+    ///
+    /// See [`PathBuf::push`] for more details on what it means to adjoin a path.
+    ///
+    /// [`PathBuf`]: struct.PathBuf.html
+    /// [`PathBuf::push`]: struct.PathBuf.html#method.push
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{Path, PathBuf};
+    ///
+    /// assert_eq!(Path::new("/etc").join("passwd"), PathBuf::from("/etc/passwd"));
+    /// ```
+    pub fn join<P: AsRef<Path>>(&self, path: P) -> PathBuf
+    where
+        P: std::convert::AsRef<std::path::Path>,
+    {
+        self.inner.join(path).into()
+    }
+
     /// Queries the file system to get information about a file, directory, etc.
     ///
     /// This function will traverse symbolic links to query information about the

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -373,6 +373,23 @@ impl Path {
             .unwrap_or(false)
     }
 
+    /// Returns `true` if the `Path` is relative, i.e., not absolute.
+    ///
+    /// See [`is_absolute`]'s documentation for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    ///
+    /// assert!(Path::new("foo.txt").is_relative());
+    /// ```
+    ///
+    /// [`is_absolute`]: #method.is_absolute
+    pub fn is_relative(&self) -> bool {
+        self.inner.is_relative()
+    }
+
     /// Queries the file system to get information about a file, directory, etc.
     ///
     /// This function will traverse symbolic links to query information about the

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -183,7 +183,7 @@ impl Path {
     /// * Otherwise, the portion of the file name after the final `.`
     ///
     /// [`self.file_name`]: struct.Path.html#method.file_name
-    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
     ///
     /// # Examples
     ///
@@ -196,6 +196,32 @@ impl Path {
     /// ```
     pub fn extension(&self) -> Option<&OsStr> {
         self.inner.extension()
+    }
+
+    /// Returns the final component of the `Path`, if there is one.
+    ///
+    /// If the path is a normal file, this is the file name. If it's the path of a directory, this
+    /// is the directory name.
+    ///
+    /// Returns [`None`] if the path terminates in `..`.
+    ///
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::Path;
+    /// use std::ffi::OsStr;
+    ///
+    /// assert_eq!(Some(OsStr::new("bin")), Path::new("/usr/bin/").file_name());
+    /// assert_eq!(Some(OsStr::new("foo.txt")), Path::new("tmp/foo.txt").file_name());
+    /// assert_eq!(Some(OsStr::new("foo.txt")), Path::new("foo.txt/.").file_name());
+    /// assert_eq!(Some(OsStr::new("foo.txt")), Path::new("foo.txt/.//").file_name());
+    /// assert_eq!(None, Path::new("foo.txt/..").file_name());
+    /// assert_eq!(None, Path::new("/").file_name());
+    /// ```
+    pub fn file_name(&self) -> Option<&OsStr> {
+        self.inner.file_name()
     }
 
     /// Converts a [`Box<Path>`][`Box`] into a [`PathBuf`] without copying or

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -709,6 +709,25 @@ impl Path {
     pub fn to_string_lossy(&self) -> std::borrow::Cow<'_, str> {
         self.inner.to_string_lossy()
     }
+
+    /// Creates an owned [`PathBuf`] like `self` but with the given extension.
+    ///
+    /// See [`PathBuf::set_extension`] for more details.
+    ///
+    /// [`PathBuf`]: struct.PathBuf.html
+    /// [`PathBuf::set_extension`]: struct.PathBuf.html#method.set_extension
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{Path, PathBuf};
+    ///
+    /// let path = Path::new("foo.rs");
+    /// assert_eq!(path.with_extension("txt"), PathBuf::from("foo.txt"));
+    /// ```
+    pub fn with_extension<S: AsRef<OsStr>>(&self, extension: S) -> PathBuf {
+        self.inner.with_extension(extension).into()
+    }
 }
 
 impl<'a> From<&'a std::path::Path> for &'a Path {

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -109,6 +109,17 @@ impl Path {
         fs::metadata(self).await.is_ok()
     }
 
+    /// Converts a [`Box<Path>`][`Box`] into a [`PathBuf`] without copying or
+    /// allocating.
+    ///
+    /// [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
+    /// [`PathBuf`]: struct.PathBuf.html
+    pub fn into_path_buf(self: Box<Path>) -> PathBuf {
+        let rw = Box::into_raw(self) as *mut std::path::Path;
+        let inner = unsafe { Box::from_raw(rw) };
+        inner.into_path_buf().into()
+    }
+
     /// Queries the file system to get information about a file, directory, etc.
     ///
     /// This function will traverse symbolic links to query information about the

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -152,6 +152,44 @@ impl PathBuf {
     pub fn set_extension<S: AsRef<OsStr>>(&mut self, extension: S) -> bool {
         self.inner.set_extension(extension)
     }
+
+    /// Updates [`self.file_name`] to `file_name`.
+    ///
+    /// If [`self.file_name`] was [`None`], this is equivalent to pushing
+    /// `file_name`.
+    ///
+    /// Otherwise it is equivalent to calling [`pop`] and then pushing
+    /// `file_name`. The new path will be a sibling of the original path.
+    /// (That is, it will have the same parent.)
+    ///
+    /// [`self.file_name`]: struct.PathBuf.html#method.file_name
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    /// [`pop`]: struct.PathBuf.html#method.pop
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::PathBuf;
+    ///
+    /// let mut buf = PathBuf::from("/");
+    /// assert!(buf.file_name() == None);
+    /// buf.set_file_name("bar");
+    /// assert!(buf == PathBuf::from("/bar"));
+    /// assert!(buf.file_name().is_some());
+    /// buf.set_file_name("baz.txt");
+    /// assert!(buf == PathBuf::from("/baz.txt"));
+    /// ```
+    pub fn set_file_name<S: AsRef<OsStr>>(&mut self, file_name: S) {
+        self.inner.set_file_name(file_name)
+    }
+}
+
+impl std::ops::Deref for PathBuf {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        self.as_ref()
+    }
 }
 
 impl From<std::path::PathBuf> for PathBuf {

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -6,14 +6,12 @@ use crate::path::Path;
 ///
 /// [`std::path::Path`]: https://doc.rust-lang.org/std/path/struct.PathBuf.html
 pub struct PathBuf {
-    inner: OsString,
+    inner: std::path::PathBuf,
 }
 
 impl From<std::path::PathBuf> for PathBuf {
     fn from(path: std::path::PathBuf) -> PathBuf {
-        PathBuf {
-            inner: path.into_os_string(),
-        }
+        PathBuf { inner: path }
     }
 }
 
@@ -25,7 +23,9 @@ impl Into<std::path::PathBuf> for PathBuf {
 
 impl From<OsString> for PathBuf {
     fn from(path: OsString) -> PathBuf {
-        PathBuf { inner: path }
+        PathBuf {
+            inner: std::path::PathBuf::from(path),
+        }
     }
 }
 

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -1,5 +1,7 @@
 use std::ffi::OsString;
 
+use crate::path::Path;
+
 /// This struct is an async version of [`std::path::PathBuf`].
 ///
 /// [`std::path::Path`]: https://doc.rust-lang.org/std/path/struct.PathBuf.html
@@ -24,6 +26,12 @@ impl Into<std::path::PathBuf> for PathBuf {
 impl From<OsString> for PathBuf {
     fn from(path: OsString) -> PathBuf {
         PathBuf { inner: path }
+    }
+}
+
+impl AsRef<Path> for PathBuf {
+    fn as_ref(&self) -> &Path {
+        Path::new(&self.inner)
     }
 }
 

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -51,6 +51,19 @@ impl PathBuf {
     pub fn into_os_string(self) -> OsString {
         self.inner.into_os_string()
     }
+
+    /// Allocates an empty `PathBuf`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::PathBuf;
+    ///
+    /// let path = PathBuf::new();
+    /// ```
+    pub fn new() -> PathBuf {
+        std::path::PathBuf::new().into()
+    }
 }
 
 impl From<std::path::PathBuf> for PathBuf {

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -88,6 +88,41 @@ impl PathBuf {
     pub fn pop(&mut self) -> bool {
         self.inner.pop()
     }
+
+    /// Extends `self` with `path`.
+    ///
+    /// If `path` is absolute, it replaces the current path.
+    ///
+    /// On Windows:
+    ///
+    /// * if `path` has a root but no prefix (e.g., `\windows`), it
+    ///   replaces everything except for the prefix (if any) of `self`.
+    /// * if `path` has a prefix but no root, it replaces `self`.
+    ///
+    /// # Examples
+    ///
+    /// Pushing a relative path extends the existing path:
+    ///
+    /// ```
+    /// use async_std::path::PathBuf;
+    ///
+    /// let mut path = PathBuf::from("/tmp");
+    /// path.push("file.bk");
+    /// assert_eq!(path, PathBuf::from("/tmp/file.bk"));
+    /// ```
+    ///
+    /// Pushing an absolute path replaces the existing path:
+    ///
+    /// ```
+    /// use async_std::path::PathBuf;
+    ///
+    /// let mut path = PathBuf::from("/tmp");
+    /// path.push("/etc");
+    /// assert_eq!(path, PathBuf::from("/etc"));
+    /// ```
+    pub fn push<P: AsRef<std::path::Path>>(&mut self, path: P) {
+        self.inner.push(path)
+    }
 }
 
 impl From<std::path::PathBuf> for PathBuf {

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -26,6 +26,15 @@ impl PathBuf {
     pub fn as_path(&self) -> &Path {
         self.inner.as_path().into()
     }
+
+    /// Converts this `PathBuf` into a [boxed][`Box`] [`Path`].
+    ///
+    /// [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
+    /// [`Path`]: struct.Path.html
+    pub fn into_boxed_path(self) -> Box<Path> {
+        let rw = Box::into_raw(self.inner.into_boxed_path()) as *mut Path;
+        unsafe { Box::from_raw(rw) }
+    }
 }
 
 impl From<std::path::PathBuf> for PathBuf {

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -10,6 +10,24 @@ pub struct PathBuf {
     inner: std::path::PathBuf,
 }
 
+impl PathBuf {
+    /// Coerces to a [`Path`] slice.
+    ///
+    /// [`Path`]: struct.Path.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{Path, PathBuf};
+    ///
+    /// let p = PathBuf::from("/test");
+    /// assert_eq!(Path::new("/test"), p.as_path());
+    /// ```
+    pub fn as_path(&self) -> &Path {
+        self.inner.as_path().into()
+    }
+}
+
 impl From<std::path::PathBuf> for PathBuf {
     fn from(path: std::path::PathBuf) -> PathBuf {
         PathBuf { inner: path }

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -64,6 +64,30 @@ impl PathBuf {
     pub fn new() -> PathBuf {
         std::path::PathBuf::new().into()
     }
+
+    /// Truncates `self` to [`self.parent`].
+    ///
+    /// Returns `false` and does nothing if [`self.parent`] is [`None`].
+    /// Otherwise, returns `true`.
+    ///
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    /// [`self.parent`]: struct.PathBuf.html#method.parent
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{Path, PathBuf};
+    ///
+    /// let mut p = PathBuf::from("/test/test.rs");
+    ///
+    /// p.pop();
+    /// assert_eq!(Path::new("/test"), p.as_ref());
+    /// p.pop();
+    /// assert_eq!(Path::new("/"), p.as_ref());
+    /// ```
+    pub fn pop(&mut self) -> bool {
+        self.inner.pop()
+    }
 }
 
 impl From<std::path::PathBuf> for PathBuf {

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -192,6 +192,12 @@ impl std::ops::Deref for PathBuf {
     }
 }
 
+impl std::borrow::Borrow<Path> for PathBuf {
+    fn borrow(&self) -> &Path {
+        &**self
+    }
+}
+
 impl From<std::path::PathBuf> for PathBuf {
     fn from(path: std::path::PathBuf) -> PathBuf {
         PathBuf { inner: path }

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -39,3 +39,9 @@ impl AsRef<Path> for PathBuf {
         Path::new(&self.inner)
     }
 }
+
+impl AsRef<std::path::Path> for PathBuf {
+    fn as_ref(&self) -> &std::path::Path {
+        self.inner.as_ref()
+    }
+}

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -5,6 +5,7 @@ use crate::path::Path;
 /// This struct is an async version of [`std::path::PathBuf`].
 ///
 /// [`std::path::Path`]: https://doc.rust-lang.org/std/path/struct.PathBuf.html
+#[derive(Debug, PartialEq)]
 pub struct PathBuf {
     inner: std::path::PathBuf,
 }
@@ -23,20 +24,18 @@ impl Into<std::path::PathBuf> for PathBuf {
 
 impl From<OsString> for PathBuf {
     fn from(path: OsString) -> PathBuf {
-        PathBuf {
-            inner: std::path::PathBuf::from(path),
-        }
+        std::path::PathBuf::from(path).into()
+    }
+}
+
+impl From<&str> for PathBuf {
+    fn from(path: &str) -> PathBuf {
+        std::path::PathBuf::from(path).into()
     }
 }
 
 impl AsRef<Path> for PathBuf {
     fn as_ref(&self) -> &Path {
         Path::new(&self.inner)
-    }
-}
-
-impl std::fmt::Debug for PathBuf {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(&self.inner, formatter)
     }
 }

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -1,4 +1,4 @@
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 
 use crate::path::Path;
 
@@ -122,6 +122,35 @@ impl PathBuf {
     /// ```
     pub fn push<P: AsRef<std::path::Path>>(&mut self, path: P) {
         self.inner.push(path)
+    }
+
+    /// Updates [`self.extension`] to `extension`.
+    ///
+    /// Returns `false` and does nothing if [`self.file_name`] is [`None`],
+    /// returns `true` and updates the extension otherwise.
+    ///
+    /// If [`self.extension`] is [`None`], the extension is added; otherwise
+    /// it is replaced.
+    ///
+    /// [`self.file_name`]: struct.PathBuf.html#method.file_name
+    /// [`self.extension`]: struct.PathBuf.html#method.extension
+    /// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::{Path, PathBuf};
+    ///
+    /// let mut p = PathBuf::from("/feel/the");
+    ///
+    /// p.set_extension("force");
+    /// assert_eq!(Path::new("/feel/the.force"), p.as_path());
+    ///
+    /// p.set_extension("dark_side");
+    /// assert_eq!(Path::new("/feel/the.dark_side"), p.as_path());
+    /// ```
+    pub fn set_extension<S: AsRef<OsStr>>(&mut self, extension: S) -> bool {
+        self.inner.set_extension(extension)
     }
 }
 

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -1,0 +1,34 @@
+use std::ffi::OsString;
+
+/// This struct is an async version of [`std::path::PathBuf`].
+///
+/// [`std::path::Path`]: https://doc.rust-lang.org/std/path/struct.PathBuf.html
+pub struct PathBuf {
+    inner: OsString,
+}
+
+impl From<std::path::PathBuf> for PathBuf {
+    fn from(path: std::path::PathBuf) -> PathBuf {
+        PathBuf {
+            inner: path.into_os_string(),
+        }
+    }
+}
+
+impl Into<std::path::PathBuf> for PathBuf {
+    fn into(self) -> std::path::PathBuf {
+        self.inner.into()
+    }
+}
+
+impl From<OsString> for PathBuf {
+    fn from(path: OsString) -> PathBuf {
+        PathBuf { inner: path }
+    }
+}
+
+impl std::fmt::Debug for PathBuf {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.inner, formatter)
+    }
+}

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -35,6 +35,22 @@ impl PathBuf {
         let rw = Box::into_raw(self.inner.into_boxed_path()) as *mut Path;
         unsafe { Box::from_raw(rw) }
     }
+
+    /// Consumes the `PathBuf`, yielding its internal [`OsString`] storage.
+    ///
+    /// [`OsString`]: https://doc.rust-lang.org/std/ffi/struct.OsString.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use async_std::path::PathBuf;
+    ///
+    /// let p = PathBuf::from("/the/head");
+    /// let os_str = p.into_os_string();
+    /// ```
+    pub fn into_os_string(self) -> OsString {
+        self.inner.into_os_string()
+    }
 }
 
 impl From<std::path::PathBuf> for PathBuf {


### PR DESCRIPTION
Partially closes #183. Tracking PR as quite a lot of methods need to be implemented.

# PathBuf
- [x]  path::PathBuf::as_path
- [x]  path::PathBuf::into_boxed_path
- [x]  path::PathBuf::into_os_string
- [x]  path::PathBuf::new
- [x]  path::PathBuf::pop
- [x]  path::PathBuf::push
- [x]  path::PathBuf::set_extension
- [x]  path::PathBuf::set_file_name

# Path
- [x]  path::Path::ancestors
- [x]  path::Path::as_os_str
- [x]  path::Path::canonicalize
- [x]  path::Path::components
- [x]  path::Path::display
- [x]  path::Path::ends_with
- [x]  path::Path::exists
- [x]  path::Path::extension
- [x]  path::Path::file_name
- [x]  path::Path::file_stem
- [x]  path::Path::has_root
- [x]  path::Path::into_path_buf
- [x]  path::Path::is_absolute
- [x]  path::Path::is_dir
- [x]  path::Path::is_file
- [x]  path::Path::is_relative
- [x]  path::Path::iter
- [x]  path::Path::join
- [x]  path::Path::metadata
- [x]  path::Path::new
- [x]  path::Path::parent
- [x]  path::Path::read_dir
- [x]  path::Path::read_link
- [x]  path::Path::starts_with
- [x]  path::Path::strip_prefix
- [x]  path::Path::symlink_metadata
- [x]  path::Path::to_path_buf
- [x]  path::Path::to_str
- [x]  path::Path::to_string_lossy
- [x]  path::Path::with_extension
- [x]  path::Path::with_file_name