### PR TITLE
rename stream::join to Stream::merge

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -48,6 +48,6 @@ cfg_if! {
 
         #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
         #[doc(inline)]
-        pub use async_macros::{join_stream as join, JoinStream as Join};
+        pub use async_macros::{join_stream as merge, JoinStream as Merge};
     }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -45,5 +45,7 @@ cfg_if! {
         pub use extend::Extend;
         pub use from_stream::FromStream;
         pub use into_stream::IntoStream;
+
+        pub use stream::Merge;
     }
 }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -45,9 +45,5 @@ cfg_if! {
         pub use extend::Extend;
         pub use from_stream::FromStream;
         pub use into_stream::IntoStream;
-
-        #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
-        #[doc(inline)]
-        pub use async_macros::{join_stream as merge, JoinStream as Merge};
     }
 }

--- a/src/stream/stream/merge.rs
+++ b/src/stream/stream/merge.rs
@@ -1,0 +1,42 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::Stream;
+
+/// A stream merging two streams.
+///
+/// This stream is returned by [`Stream::merge`].
+///
+/// [`Stream::merge`]:
+#[derive(Debug)]
+pub struct Merge<L, R> {
+    left: L,
+    right: R,
+}
+
+impl<L, R> Unpin for Merge<L, R> {}
+
+impl<L, R> Merge<L, R> {
+    pub(crate) fn new(left: L, right: R) -> Self {
+        Self { left, right }
+    }
+}
+
+impl<L, R, T> Stream for Merge<L, R>
+where
+    L: Stream<Item = T> + Unpin,
+    R: Stream<Item = T> + Unpin,
+{
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if let Poll::Ready(Some(item)) = Pin::new(&mut self.left).poll_next(cx) {
+            // The first stream made progress. The Merge needs to be polled
+            // again to check the progress of the second stream.
+            cx.waker().wake_by_ref();
+            Poll::Ready(Some(item))
+        } else {
+            Pin::new(&mut self.right).poll_next(cx)
+        }
+    }
+}

--- a/src/stream/stream/merge.rs
+++ b/src/stream/stream/merge.rs
@@ -3,11 +3,11 @@ use std::task::{Context, Poll};
 
 use futures_core::Stream;
 
-/// A stream merging two streams.
+/// A stream that merges two other streams into a single stream.
 ///
 /// This stream is returned by [`Stream::merge`].
 ///
-/// [`Stream::merge`]:
+/// [`Stream::merge`]: trait.Stream.html#method.merge
 #[derive(Debug)]
 pub struct Merge<L, R> {
     left: L,

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -1155,7 +1155,8 @@ extension_trait! {
         #[doc = r#"
             Combines multiple streams into a single stream of all their outputs.
 
-            This macro is only usable inside of async functions, closures, and blocks.
+            Items are yielded as soon as they're received, and the stream continues yield until both
+            streams have been exhausted.
 
             # Examples
 

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -34,7 +34,6 @@ mod for_each;
 mod fuse;
 mod inspect;
 mod map;
-mod merge;
 mod min_by;
 mod next;
 mod nth;
@@ -88,6 +87,8 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(any(feature = "unstable", feature = "docs"))] {
+        mod merge;
+
         use std::pin::Pin;
 
         use crate::future::Future;


### PR DESCRIPTION
Feedback from Boats was that `stream::join` may not be the right name because the output isn't polymorphic the way `future::join` is. 

This PR changes `stream::join!` macro to the `Stream::merge` method, mirroring Rx's [`merge`](https://www.learnrxjs.io/operators/combination/merge.html) method. Also conveniently makes it similar to `Stream::zip` and `Stream::chain` in use. Thanks!