### PR TITLE
stabilize stream::{FromStream,IntoStream,Extend}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,18 +66,18 @@ cfg_if! {
         pub mod path;
         #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
         pub mod pin;
-
-        mod unit;
-        mod vec;
-        mod result;
-        mod option;
-        mod string;
-        mod collections;
     }
 }
 
-mod macros;
 pub(crate) mod utils;
+
+mod collections;
+mod macros;
+mod option;
+mod result;
+mod string;
+mod unit;
+mod vec;
 
 #[doc(inline)]
 pub use std::{write, writeln};

--- a/src/stream/extend.rs
+++ b/src/stream/extend.rs
@@ -27,7 +27,6 @@ use crate::stream::IntoStream;
 /// #
 /// # }) }
 /// ```
-#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 pub trait Extend<A> {
     /// Extends a collection with the contents of a stream.
     fn stream_extend<'a, T: IntoStream<Item = A> + 'a>(

--- a/src/stream/from_stream.rs
+++ b/src/stream/from_stream.rs
@@ -106,8 +106,6 @@ use std::pin::Pin;
 ///```
 ///
 /// [`IntoStream`]: trait.IntoStream.html
-#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
-#[cfg(any(feature = "unstable", feature = "docs"))]
 pub trait FromStream<T> {
     /// Creates a value from a stream.
     ///

--- a/src/stream/into_stream.rs
+++ b/src/stream/into_stream.rs
@@ -13,8 +13,6 @@ use crate::stream::Stream;
 /// See also: [`FromStream`].
 ///
 /// [`FromStream`]: trait.FromStream.html
-#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
-#[cfg(any(feature = "unstable", feature = "docs"))]
 pub trait IntoStream {
     /// The type of the elements being iterated over.
     type Item;

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -24,6 +24,9 @@
 use cfg_if::cfg_if;
 
 pub use empty::{empty, Empty};
+pub use extend::Extend;
+pub use from_stream::FromStream;
+pub use into_stream::IntoStream;
 pub use once::{once, Once};
 pub use repeat::{repeat, Repeat};
 pub use stream::{Chain, Filter, Fuse, Inspect, Scan, Skip, SkipWhile, StepBy, Stream, Take, Zip};
@@ -31,20 +34,17 @@ pub use stream::{Chain, Filter, Fuse, Inspect, Scan, Skip, SkipWhile, StepBy, St
 pub(crate) mod stream;
 
 mod empty;
+mod extend;
+mod from_stream;
+mod into_stream;
 mod once;
 mod repeat;
 
 cfg_if! {
     if #[cfg(any(feature = "unstable", feature = "docs"))] {
         mod double_ended_stream;
-        mod extend;
-        mod from_stream;
-        mod into_stream;
 
         pub use double_ended_stream::DoubleEndedStream;
-        pub use extend::Extend;
-        pub use from_stream::FromStream;
-        pub use into_stream::IntoStream;
 
         #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
         #[doc(inline)]

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -72,9 +72,12 @@ pub use zip::Zip;
 
 use std::cmp::Ordering;
 use std::marker::PhantomData;
+use std::pin::Pin;
 
 use cfg_if::cfg_if;
 
+use crate::future::Future;
+use crate::stream::FromStream;
 use crate::utils::extension_trait;
 
 cfg_if! {
@@ -82,15 +85,6 @@ cfg_if! {
         use std::ops::{Deref, DerefMut};
 
         use crate::task::{Context, Poll};
-    }
-}
-
-cfg_if! {
-    if #[cfg(any(feature = "unstable", feature = "docs"))] {
-        use std::pin::Pin;
-
-        use crate::future::Future;
-        use crate::stream::FromStream;
     }
 }
 
@@ -1135,8 +1129,6 @@ extension_trait! {
 
             [`stream`]: trait.Stream.html#tymethod.next
         "#]
-        #[cfg(any(feature = "unstable", feature = "docs"))]
-        #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
         #[must_use = "if you really need to exhaust the iterator, consider `.for_each(drop)` instead (TODO)"]
         fn collect<'a, B>(
             self,


### PR DESCRIPTION
I'd like to propose we remove the "unstable" marker from `stream::{FromStream,IntoStream,Extend}` and `Stream::collect`. We've proven that we can use these traits to achieve parity with std, and they seem to work really well! Also we've had them for close to a month now without any problems.

I guess this is one of the first times we're moving something large from "unstable" to stable, so I guess this is somewhat defining. My reasoning here is not that we're sure everything is bug-free; but that we're sure that at least the external API is correct and we don't think we'll want to change it. To that extent this seems to pass that test.

Thanks!