### PR TITLE
stabilize future::{join,try_join}

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -45,8 +45,11 @@
 pub use std::future::Future;
 
 #[doc(inline)]
+pub use async_macros::{join, try_join};
+
+#[doc(inline)]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
-pub use async_macros::{join, select, try_join, try_select};
+pub use async_macros::{select, try_select};
 
 use cfg_if::cfg_if;
 


### PR DESCRIPTION
Stabilizes `future::{join,try_join}` as they've been working out quite well for folks it seems and the design seems stable.

This PR does _not_ stabilize `future::{select, try_select}` as the path forward here seems less clear. In particular: these macros do not require output polymorphism but solely exist as a macro to match the feel of `join` and `try_join`. I think there's arguments for both; and possibly we should have both. But for now I'd like to punt that question, and focus on `join` and `try_join`!

Thanks!