### PR TITLE
stabilize task::ready!

### DIFF
--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -25,8 +25,6 @@
 #[doc(inline)]
 pub use std::task::{Context, Poll, Waker};
 
-#[cfg(any(feature = "unstable", feature = "docs"))]
-#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[doc(inline)]
 pub use async_macros::ready;
 


### PR DESCRIPTION
This stabilizes `task::ready!`. This seems like an uncontroversial API that's already battle-tested in futures-rs. The only question was whether having it as a macro inside a submodule would make sense; and now that we have 3 different submodules with macros in them it seems like we're okay enough with that idea that I think it would make sense to stabilize this.

Thanks!