### PR TITLE
add stream::FusedStream as "unstable"

### DIFF
--- a/src/stream/fused_stream.rs
+++ b/src/stream/fused_stream.rs
@@ -1,0 +1,21 @@
+use crate::stream::Stream;
+
+/// A stream that always continues to yield `None` when exhausted.
+///
+/// Calling next on a fused stream that has returned `None` once is guaranteed
+/// to return [`None`] again. This trait should be implemented by all streams
+/// that behave this way because it allows optimizing [`Stream::fuse`].
+///
+/// Note: In general, you should not use `FusedStream` in generic bounds if
+/// you need a fused stream. Instead, you should just call [`Stream::fuse`]
+/// on the stream. If the stream is already fused, the additional [`Fuse`]
+/// wrapper will be a no-op with no performance penalty.
+///
+/// [`None`]: https://doc.rust-lang.org/std/option/enum.Option.html#variant.None
+/// [`Stream::fuse`]: trait.Stream.html#method.fuse
+/// [`Fuse`]: struct.Fuse.html
+#[cfg(any(feature = "unstable", feature = "docs"))]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+pub trait FusedStream: Stream {}
+
+impl<S: FusedStream + ?Sized + Unpin> FusedStream for &mut S {}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -37,6 +37,7 @@ mod repeat;
 cfg_if! {
     if #[cfg(any(feature = "unstable", feature = "docs"))] {
         mod double_ended_stream;
+        mod fused_stream;
         mod extend;
         mod from_stream;
         mod into_stream;
@@ -45,6 +46,7 @@ cfg_if! {
         pub use extend::Extend;
         pub use from_stream::FromStream;
         pub use into_stream::IntoStream;
+        pub use fused_stream::FusedStream;
 
         pub use stream::Merge;
     }


### PR DESCRIPTION
Implements `Stream::FusedStream`. This is a [different API from futures-rs](https://docs.rs/futures-core-preview/0.3.0-alpha.19/futures_core/stream/trait.FusedStream.html) that instead is closer to std, and resembles the API futures-rs had prior to `0.3.0-alpha.10` (added in https://github.com/rust-lang-nursery/futures-rs/pull/1259, October 2018).

Because we don't require `select! {}` for stream multiplexing in async-std, the `is_terminated` method doesn't really serve a purpose for us, and really only requires extra bookkeeping.

Because `FusedStream` is used for optimization purposes only, I think it's not a big deal to diverge from futures-rs on this account.

Thanks!