### PR TITLE
stabilize future::timeout

### DIFF
--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -56,17 +56,17 @@ use cfg_if::cfg_if;
 pub use pending::pending;
 pub use poll_fn::poll_fn;
 pub use ready::ready;
+pub use timeout::{timeout, TimeoutError};
 
 mod pending;
 mod poll_fn;
 mod ready;
+mod timeout;
 
 cfg_if! {
     if #[cfg(any(feature = "unstable", feature = "docs"))] {
         mod into_future;
-        mod timeout;
 
         pub use into_future::IntoFuture;
-        pub use timeout::{timeout, TimeoutError};
     }
 }

--- a/src/future/timeout.rs
+++ b/src/future/timeout.rs
@@ -28,8 +28,6 @@ use crate::task::{Context, Poll};
 /// #
 /// # Ok(()) }) }
 /// ```
-#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
-#[cfg(any(feature = "unstable", feature = "docs"))]
 pub async fn timeout<F, T>(dur: Duration, f: F) -> Result<T, TimeoutError>
 where
     F: Future<Output = T>,
@@ -42,8 +40,6 @@ where
 }
 
 /// A future that times out after a duration of time.
-#[doc(hidden)]
-#[allow(missing_debug_implementations)]
 struct TimeoutFuture<F> {
     future: F,
     delay: Delay,
@@ -69,8 +65,6 @@ impl<F: Future> Future for TimeoutFuture<F> {
 }
 
 /// An error returned when a future times out.
-#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
-#[cfg(any(feature = "unstable", feature = "docs"))]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct TimeoutError {
     _private: (),


### PR DESCRIPTION
Removes the "unstable" marker from `future::timeout`. It seems this function generally does what we want it to, and provides a counterpart to `io::timeout`. Thanks!