### PR TITLE
correctly mark stream::Merge as unstable

### DIFF
--- a/src/stream/interval.rs
+++ b/src/stream/interval.rs
@@ -43,6 +43,7 @@ use futures_timer::Delay;
 /// #
 /// # Ok(()) }) }
 /// ```
+#[cfg(any(feature = "unstable", feature = "docs"))]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[doc(inline)]
 pub fn interval(dur: Duration) -> Interval {

--- a/src/stream/stream/merge.rs
+++ b/src/stream/stream/merge.rs
@@ -8,6 +8,8 @@ use futures_core::Stream;
 /// This stream is returned by [`Stream::merge`].
 ///
 /// [`Stream::merge`]: trait.Stream.html#method.merge
+#[cfg(any(feature = "unstable", feature = "docs"))]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[derive(Debug)]
 pub struct Merge<L, R> {
     left: L,


### PR DESCRIPTION
Mark `Merge` as unstable. We forgot to add this. Thanks!