### PR TITLE
Enable tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --all --doc --features unstable
+        args: --all --features unstable
 
   check_fmt_and_docs:
     name: Checking fmt and docs

--- a/tests/buf_writer.rs
+++ b/tests/buf_writer.rs
@@ -48,13 +48,13 @@ fn test_buffered_writer() {
 }
 
 #[test]
-fn test_buffered_writer_inner_into_inner_does_not_flush() {
+fn test_buffered_writer_inner_into_inner_flushes() {
     task::block_on(async {
         let mut w = BufWriter::with_capacity(3, Vec::new());
         w.write(&[0, 1]).await.unwrap();
         assert_eq!(*w.get_ref(), []);
         let w = w.into_inner().await.unwrap();
-        assert_eq!(w, []);
+        assert_eq!(w, [0, 1]);
     })
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/async-rs/async-std/pull/286#discussion_r331923531, if cargo test contains --doc arguments, only doc test is executed.