### PR TITLE
Don't flush files if they weren't written to

### DIFF
--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -284,7 +284,10 @@ impl OpenOptions {
     pub fn open<P: AsRef<Path>>(&self, path: P) -> impl Future<Output = io::Result<File>> {
         let path = path.as_ref().to_owned();
         let options = self.0.clone();
-        async move { blocking::spawn(move || options.open(path).map(|f| f.into())).await }
+        async move {
+            let file = blocking::spawn(move || options.open(path)).await?;
+            Ok(File::new(file, true))
+        }
     }
 }
 


### PR DESCRIPTION
Before this PR, files that were opened and then never written to would get flushed on drop, which is a useless operation and especially concerning when small files are read.

Newly opened files now start in flushed state. When constructing `async_std::fs::File` from a `std::fs::File`, we still have to start in "dirty" (not flushed) state because we don't know if the handle was previously written to.