### PR TITLE
Add max_by

### DIFF
--- a/src/stream/stream/min_by.rs
+++ b/src/stream/stream/min_by.rs
@@ -20,19 +20,28 @@ pin_project! {
 }
 
 #[derive(PartialEq, Eq)]
-pub(crate) enum Direction {
+enum Direction {
     Maximizing,
     Minimizing,
 }
 
 
 impl<S, F, T> MinMaxByFuture<S, F, T> {
-    pub(super) fn new(stream: S, compare: F, direction: Direction) -> Self {
+    pub(super) fn new_min(stream: S, compare: F) -> Self {
         MinMaxByFuture {
             stream,
             compare,
             value: None,
-            direction,
+            direction: Direction::Minimizing,
+        }
+    }
+
+    pub(super) fn new_max(stream: S, compare: F) -> Self {
+        MinMaxByFuture {
+            stream,
+            compare,
+            value: None,
+            direction: Direction::Maximizing,
         }
     }
 }

--- a/src/stream/stream/min_by.rs
+++ b/src/stream/stream/min_by.rs
@@ -28,20 +28,19 @@ enum Direction {
 
 impl<S, F, T> MinMaxByFuture<S, F, T> {
     pub(super) fn new_min(stream: S, compare: F) -> Self {
-        MinMaxByFuture {
-            stream,
-            compare,
-            value: None,
-            direction: Direction::Minimizing,
-        }
+        MinMaxByFuture::new(stream, compare, Direction::Minimizing)
     }
 
     pub(super) fn new_max(stream: S, compare: F) -> Self {
+        MinMaxByFuture::new(stream, compare, Direction::Maximizing)
+    }
+
+    fn new(stream: S, compare: F, direction: Direction) -> Self {
         MinMaxByFuture {
             stream,
             compare,
             value: None,
-            direction: Direction::Maximizing,
+            direction,
         }
     }
 }

--- a/src/stream/stream/min_by.rs
+++ b/src/stream/stream/min_by.rs
@@ -25,7 +25,6 @@ enum Direction {
     Minimizing,
 }
 
-
 impl<S, F, T> MinMaxByFuture<S, F, T> {
     pub(super) fn new_min(stream: S, compare: F) -> Self {
         MinMaxByFuture::new(stream, compare, Direction::Minimizing)

--- a/src/stream/stream/min_by.rs
+++ b/src/stream/stream/min_by.rs
@@ -10,7 +10,7 @@ use crate::task::{Context, Poll};
 pin_project! {
     #[doc(hidden)]
     #[allow(missing_debug_implementations)]
-    pub struct MinByFuture<S, F, T> {
+    pub struct MinMaxByFuture<S, F, T> {
         #[pin]
         stream: S,
         compare: F,
@@ -23,9 +23,10 @@ enum Direction {
     Minimizing,
 }
 
-impl<S, F, T> MinByFuture<S, F, T> {
+
+impl<S, F, T> MinMaxByFuture<S, F, T> {
     pub(super) fn new(stream: S, compare: F) -> Self {
-        MinByFuture {
+        MinMaxByFuture {
             stream,
             compare,
             min: None,
@@ -34,7 +35,7 @@ impl<S, F, T> MinByFuture<S, F, T> {
     }
 }
 
-impl<S, F> Future for MinByFuture<S, F, S::Item>
+impl<S, F> Future for MinMaxByFuture<S, F, S::Item>
 where
     S: Stream + Unpin + Sized,
     S::Item: Copy,

--- a/src/stream/stream/min_by.rs
+++ b/src/stream/stream/min_by.rs
@@ -15,7 +15,12 @@ pin_project! {
         stream: S,
         compare: F,
         min: Option<T>,
+        direction: Direction,
     }
+}
+enum Direction {
+    Maximizing,
+    Minimizing,
 }
 
 impl<S, F, T> MinByFuture<S, F, T> {
@@ -24,6 +29,7 @@ impl<S, F, T> MinByFuture<S, F, T> {
             stream,
             compare,
             min: None,
+            direction: Direction::Minimizing,
         }
     }
 }

--- a/src/stream/stream/min_by.rs
+++ b/src/stream/stream/min_by.rs
@@ -18,6 +18,8 @@ pin_project! {
         direction: Direction,
     }
 }
+
+#[derive(PartialEq, Eq)]
 enum Direction {
     Maximizing,
     Minimizing,
@@ -53,7 +55,7 @@ where
                 match this.value.take() {
                     None => this.value.replace(new),
                     Some(old) => match (this.compare)(&new, &old) {
-                        Ordering::Less => this.value.replace(new),
+                        Ordering::Less if Direction::Minimizing == *this.direction => this.value.replace(new),
                         _ => this.value.replace(old),
                     },
                 };

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -636,7 +636,7 @@ extension_trait! {
             Self: Sized,
             F: FnMut(&Self::Item, &Self::Item) -> Ordering,
         {
-            MinMaxByFuture::new(self, compare, min_by::Direction::Maximizing)
+            MinMaxByFuture::new_max(self, compare)
         }
 
         #[doc = r#"
@@ -675,7 +675,7 @@ extension_trait! {
             Self: Sized,
             F: FnMut(&Self::Item, &Self::Item) -> Ordering,
         {
-            MinMaxByFuture::new(self, compare, min_by::Direction::Minimizing)
+            MinMaxByFuture::new_min(self, compare)
         }
 
         #[doc = r#"

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -601,6 +601,45 @@ extension_trait! {
         }
 
         #[doc = r#"
+            Returns the element that gives the maximum value with respect to the
+            specified comparison function. If several elements are equally maximum,
+            the first element is returned. If the stream is empty, `None` is returned.
+
+            # Examples
+
+            ```
+            # fn main() { async_std::task::block_on(async {
+            #
+            use std::collections::VecDeque;
+
+            use async_std::prelude::*;
+
+            let s: VecDeque<usize> = vec![1, 2, 3].into_iter().collect();
+
+            let min = s.clone().max_by(|x, y| x.cmp(y)).await;
+            assert_eq!(min, Some(3));
+
+            let min = s.max_by(|x, y| y.cmp(x)).await;
+            assert_eq!(min, Some(1));
+
+            let min = VecDeque::<usize>::new().max_by(|x, y| x.cmp(y)).await;
+            assert_eq!(min, None);
+            #
+            # }) }
+            ```
+        "#]
+        fn max_by<F>(
+            self,
+            compare: F,
+        ) -> impl Future<Output = Option<Self::Item>> [MinMaxByFuture<Self, F, Self::Item>]
+        where
+            Self: Sized,
+            F: FnMut(&Self::Item, &Self::Item) -> Ordering,
+        {
+            MinMaxByFuture::new(self, compare, min_by::Direction::Maximizing)
+        }
+
+        #[doc = r#"
             Returns the element that gives the minimum value with respect to the
             specified comparison function. If several elements are equally minimum,
             the first element is returned. If the stream is empty, `None` is returned.
@@ -636,7 +675,7 @@ extension_trait! {
             Self: Sized,
             F: FnMut(&Self::Item, &Self::Item) -> Ordering,
         {
-            MinMaxByFuture::new(self, compare)
+            MinMaxByFuture::new(self, compare, min_by::Direction::Minimizing)
         }
 
         #[doc = r#"

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -68,7 +68,7 @@ use gt::GtFuture;
 use last::LastFuture;
 use le::LeFuture;
 use lt::LtFuture;
-use min_by::MinByFuture;
+use min_by::MinMaxByFuture;
 use next::NextFuture;
 use nth::NthFuture;
 use partial_cmp::PartialCmpFuture;
@@ -631,12 +631,12 @@ extension_trait! {
         fn min_by<F>(
             self,
             compare: F,
-        ) -> impl Future<Output = Option<Self::Item>> [MinByFuture<Self, F, Self::Item>]
+        ) -> impl Future<Output = Option<Self::Item>> [MinMaxByFuture<Self, F, Self::Item>]
         where
             Self: Sized,
             F: FnMut(&Self::Item, &Self::Item) -> Ordering,
         {
-            MinByFuture::new(self, compare)
+            MinMaxByFuture::new(self, compare)
         }
 
         #[doc = r#"


### PR DESCRIPTION
Theoretically its was possibly to create an equivalent of max_by by using min_by.
That would have been awkward to read for users though.

I first tried to Box the comparison function and simply passing it down from max_by to min_by with `reverse()` applied. That got too tedious and meant users were exposed to the Box.

This variation adds a new field to the strut - now renamed MinMaxBy - that tells us whether we are maximising or minimising. 