### PR TITLE
Remove usage of actions-rs/clippy-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,13 @@ on:
       - staging
       - trying
 
+env:
+  RUSTFLAGS: -Dwarnings
+
 jobs:
   build_and_test:
     name: Build and test
     runs-on: ${{ matrix.os }}
-    env:
-      RUSTFLAGS: -Dwarnings
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
@@ -48,8 +49,6 @@ jobs:
   check_fmt_and_docs:
     name: Checking fmt and docs
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: -Dwarnings
     steps:
     - uses: actions/checkout@master
 
@@ -81,19 +80,11 @@ jobs:
   clippy_check:
     name: Clippy check
     runs-on: ubuntu-latest
-    # TODO: There is a lot of warnings
-    # env:
-    #   RUSTFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v1
-      - id: component
-        uses: actions-rs/components-nightly@v1
-        with:
-          component: clippy
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: ${{ steps.component.outputs.toolchain }}
-            override: true
-      - run: rustup component add clippy
+      - name: Install rust
+        run: rustup update beta && rustup default beta
+      - name: Install clippy
+        run: rustup component add clippy
       - name: clippy
         run: cargo clippy --all --features unstable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,5 @@ jobs:
             toolchain: ${{ steps.component.outputs.toolchain }}
             override: true
       - run: rustup component add clippy
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: clippy
+        run: cargo clippy --all --features unstable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@
 
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![allow(clippy::mutex_atomic, clippy::module_inception)]
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
 #![doc(html_logo_url = "https://async.rs/images/logo--hero.svg")]

--- a/src/stream/exact_size_stream.rs
+++ b/src/stream/exact_size_stream.rs
@@ -75,6 +75,7 @@ pub use crate::stream::Stream;
 /// assert_eq!(5, counter.len());
 /// # });
 /// ```
+#[allow(clippy::len_without_is_empty)] // ExactSizeIterator::is_empty is unstable
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 pub trait ExactSizeStream: Stream {

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -167,6 +167,7 @@ impl Tag {
     }
 
     pub fn task(&self) -> &Task {
+        #[allow(clippy::transmute_ptr_to_ptr)]
         unsafe {
             let raw = self.raw_metadata.load(Ordering::Acquire);
 
@@ -189,6 +190,7 @@ impl Tag {
                 }
             }
 
+            #[allow(clippy::transmute_ptr_to_ptr)]
             mem::transmute::<&AtomicUsize, &Option<Task>>(&self.raw_metadata)
                 .as_ref()
                 .unwrap()


### PR DESCRIPTION
#286, #384, and #385's CI is failing because of this error. I think this action is broken.

https://github.com/async-rs/async-std/pull/286/checks?check_run_id=276113673:

```text
##[error]Unable to create clippy annotations! Reason: HttpError: Resource not accessible by integration
##[warning]It seems that this Action is executed from the forked repository.
##[warning]GitHub Actions are not allowed to create Check annotations, when executed for a forked repos. See https://github.com/actions-rs/clippy-check/issues/2 for details.
Posting clippy checks here instead.
```

Related: https://github.com/actions-rs/clippy-check/issues/2#issuecomment-538655240
