### PR TITLE
fix doc recursion limit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
 #![doc(html_logo_url = "https://async.rs/images/logo--hero.svg")]
-#![recursion_limit = "1024"]
+#![recursion_limit = "2048"]
 
 #[macro_use]
 mod utils;


### PR DESCRIPTION
Fix doc recursion limit on master. Building docs currently fails, and this fixes that. Thanks!