### PR TITLE
update Stream::fuse docs

### DIFF
--- a/src/stream/stream/fuse.rs
+++ b/src/stream/stream/fuse.rs
@@ -6,8 +6,7 @@ use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
 pin_project! {
-    /// A `Stream` that is permanently closed once a single call to `poll` results in
-    /// `Poll::Ready(None)`, returning `Poll::Ready(None)` for all future calls to `poll`.
+    /// A stream that yields `None` forever after the underlying stream yields `None` once.
     ///
     /// This `struct` is created by the [`fuse`] method on [`Stream`]. See its
     /// documentation for more.

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -501,9 +501,11 @@ extension_trait! {
         }
 
         #[doc = r#"
-            Transforms this `Stream` into a "fused" `Stream` such that after the first time
-            `poll` returns `Poll::Ready(None)`, all future calls to `poll` will also return
-            `Poll::Ready(None)`.
+            Creates a stream which ends after the first `None`.
+
+            After a stream returns `None`, future calls may or may not yield `Some(T)` again.
+            `fuse()` adapts an iterator, ensuring that after a `None` is given, it will always
+            return `None` forever.
 
             # Examples
 


### PR DESCRIPTION
The `Stream::fuse` docs were a bit lengthy; this patch brings them closer to `Iterator::fuse`, which fit nicely on a single line. Thanks!

## Screenshots
![Screenshot_2019-10-28 async_std stream - Rust(1)](https://user-images.githubusercontent.com/2467194/67677017-3531d100-f983-11e9-8fe0-141c83819526.png)
