### PR TITLE
stabilize pin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,13 +58,13 @@ pub mod io;
 pub mod net;
 pub mod os;
 pub mod path;
+pub mod pin;
 pub mod prelude;
 pub mod stream;
 pub mod sync;
 pub mod task;
 
 cfg_unstable! {
-    pub mod pin;
     pub mod process;
 
     mod unit;


### PR DESCRIPTION
Removes the `"unstable"` marker from `async_std::pin`. Even in the absence of #258, there's great value in being able to import everything required for implementing `Future` from `async_std`. This may not seem like a big deal at first glance, but it removes a cognitive speed bump when implementing futures, which makes async-std more intuitive to use.

Thanks!

## Proposed
```rust
use async_std::future::Future;
use async_std::task::{Context, Poll};
use async_std::pin::Pin;

impl Future for MyStruct {
    type Output = ();
    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
        Poll::Ready(())
    }
}
```

## Current
```rust
use std::pin::Pin;

use async_std::future::Future;
use async_std::task::{Context, Poll};

impl Future for MyStruct {
    type Output = ();
    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
        Poll::Ready(())
    }
}
```