### PR TITLE
Add only rustfmt on Checking fmt and docs actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,10 @@ jobs:
 
     - uses: actions-rs/toolchain@v1
       with:
+          profile: minimal
           toolchain: ${{ steps.component.outputs.toolchain }}
           override: true
+          components: rustfmt
 
     - name: setup
       run: |


### PR DESCRIPTION
Recently, I often see ci failed on this error message.

```
/usr/share/rust/.cargo/bin/rustup show
Default host: x86_64-unknown-linux-gnu
rustup home:  /home/runner/.rustup

stable-x86_64-unknown-linux-gnu (default)
rustc 1.38.0 (625451e37 2019-09-23)
/usr/share/rust/.cargo/bin/rustup toolchain install nightly-2019-10-29-x86_64-unknown-linux-gnu
info: syncing channel updates for 'nightly-2019-10-29-x86_64-unknown-linux-gnu'
info: latest update on 2019-10-29, rust version 1.40.0-nightly (b497e1899 2019-10-28)
error: component 'clippy' for target 'x86_64-unknown-linux-gnu' is unavailable for download for channel nightly-2019-10-29
##[error]The process '/usr/share/rust/.cargo/bin/rustup' failed with exit code 1
##[error]Node run failed with exit code 1
```

All we need is rustfmt, but it looks like CI are trying to install clippy.
This PR will solve it.

Thanks!