### PR TITLE
Remove unused pin-utils dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ mio = "0.6.19"
 mio-uds = "0.6.7"
 num_cpus = "1.10.1"
 once_cell = "1.2.0"
-pin-utils = "0.1.0-alpha.4"
 slab = "0.4.2"
 kv-log-macro = "1.0.4"
 broadcaster = { version = "0.2.6", optional = true, default-features = false, features = ["default-channels"] }


### PR DESCRIPTION
pin-utils is no longer used. This removes it from our dependency tree.