### PR TITLE
Added TCP smoke tests against std Listener and Stream

### DIFF
--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -49,3 +49,48 @@ fn incoming_read() -> io::Result<()> {
         Ok(())
     })
 }
+
+#[test]
+fn smoke_std_stream_to_async_listener() -> io::Result<()> {
+    use std::io::Write;
+
+    task::block_on(async {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+
+        let mut std_stream = std::net::TcpStream::connect(&addr)?;
+        std_stream.write_all(THE_WINTERS_TALE)?;
+
+        let mut buf = vec![0; 1024];
+        let mut incoming = listener.incoming();
+        let mut stream = incoming.next().await.unwrap()?;
+
+        let n = stream.read(&mut buf).await?;
+        assert_eq!(&buf[..n], THE_WINTERS_TALE);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn smoke_async_stream_to_std_listener() -> io::Result<()> {
+    use std::io::Read;
+
+    let std_listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    let addr = std_listener.local_addr()?;
+
+    task::block_on(async move {
+        let mut stream = TcpStream::connect(&addr).await?;
+        stream.write_all(THE_WINTERS_TALE).await?;
+        io::Result::Ok(())
+    })?;
+
+    let mut buf = vec![0; 1024];
+    let mut incoming = std_listener.incoming();
+    let mut stream = incoming.next().unwrap()?;
+
+    let n = stream.read(&mut buf).unwrap();
+    assert_eq!(&buf[..n], THE_WINTERS_TALE);
+
+    Ok(())
+}


### PR DESCRIPTION
Adds tests which exercise the async TcpListener and TcpStream against their std library counterparts.

Resolves #407