### PR TITLE
fix doc tests

### DIFF
--- a/src/stream/stream/min.rs
+++ b/src/stream/stream/min.rs
@@ -1,5 +1,5 @@
+use std::cmp::{Ord, Ordering};
 use std::marker::PhantomData;
-use std::cmp::{Ordering, Ord};
 use std::pin::Pin;
 
 use pin_project_lite::pin_project;

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -774,19 +774,19 @@ extension_trait! {
 
             # Examples
 
-            ```
+            ```ignore
             # fn main() { async_std::task::block_on(async {
             #
-            // use std::collections::VecDeque;
-            // use async_std::prelude::*;
+            use std::collections::VecDeque;
+            use async_std::prelude::*;
 
-            // let s: VecDeque<usize> = vec![1, 2, 3].into_iter().collect();
+            let s: VecDeque<usize> = vec![1, 2, 3].into_iter().collect();
 
-            // let min = s.clone().min().await;
-            // assert_eq!(min, Some(1));
+            let min = s.clone().min().await;
+            assert_eq!(min, Some(1));
 
-            // let min = VecDeque::<usize>::new().min().await;
-            // assert_eq!(min, None);
+            let min = VecDeque::<usize>::new().min().await;
+            assert_eq!(min, None);
             #
             # }) }
             ```

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -777,17 +777,16 @@ extension_trait! {
             ```
             # fn main() { async_std::task::block_on(async {
             #
-            use std::collections::VecDeque;
+            // use std::collections::VecDeque;
+            // use async_std::prelude::*;
 
-            use async_std::prelude::*;
+            // let s: VecDeque<usize> = vec![1, 2, 3].into_iter().collect();
 
-            let s: VecDeque<usize> = vec![1, 2, 3].into_iter().collect();
+            // let min = s.clone().min().await;
+            // assert_eq!(min, Some(1));
 
-            let min = s.clone().min().await;
-            assert_eq!(min, Some(1));
-
-            let min = VecDeque::<usize>::new().min().await;
-            assert_eq!(min, None);
+            // let min = VecDeque::<usize>::new().min().await;
+            // assert_eq!(min, None);
             #
             # }) }
             ```


### PR DESCRIPTION
It seems #409 broke our tests. The problem is that `VecDeque` implements `Ord` which has a conflicting `min` method. I've disabled the doc test for `min`, in anticipation of #430. We can re-enable it once we land #415. Thanks!