### PR TITLE
Unstabilize Arc and Weak

### DIFF
--- a/src/sync/barrier.rs
+++ b/src/sync/barrier.rs
@@ -10,7 +10,9 @@ use crate::sync::Mutex;
 /// ```
 /// # async_std::task::block_on(async {
 /// #
-/// use async_std::sync::{Arc, Barrier};
+/// use std::sync::Arc;
+///
+/// use async_std::sync::Barrier;
 /// use async_std::task;
 ///
 /// let mut handles = Vec::with_capacity(10);
@@ -121,7 +123,9 @@ impl Barrier {
     /// ```
     /// # async_std::task::block_on(async {
     /// #
-    /// use async_std::sync::{Arc, Barrier};
+    /// use std::sync::Arc;
+    ///
+    /// use async_std::sync::Barrier;
     /// use async_std::task;
     ///
     /// let mut handles = Vec::with_capacity(10);

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -121,10 +121,6 @@
 //! The following is an overview of the available synchronization
 //! objects:
 //!
-//! - [`Arc`]: Atomically Reference-Counted pointer, which can be used
-//!   in multithreaded environments to prolong the lifetime of some
-//!   data until all the threads have finished using it.
-//!
 //! - [`Barrier`]: Ensures multiple threads will wait for each other
 //!   to reach a point in the program, before continuing execution all
 //!   together.
@@ -142,7 +138,6 @@
 //!   writer at a time. In some cases, this can be more efficient than
 //!   a mutex.
 //!
-//! [`Arc`]: crate::sync::Arc
 //! [`Barrier`]: crate::sync::Barrier
 //! [`Condvar`]: crate::sync::Condvar
 //! [`channel`]: fn.channel.html
@@ -175,6 +170,8 @@
 //! # })
 //! ```
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[doc(inline)]
 pub use std::sync::{Arc, Weak};
 


### PR DESCRIPTION
Two users on Discord have been confused by the existence of `async_std::sync::Arc` since they expected it to be somehow different from `std::sync::Arc`, but it's just a re-export. I share similar feelings. Perhaps it'd be wise to unstabilize it before publishing 1.0, just in case.

To elaborate a bit more... It's "obvious" to me how `async_std::fs::File` or `async_std::sync::Mutex` are different from their `std` counterparts. While we do re-export a bunch of types like `std::fs::FileType` or `std::net::Shutdown`, those are not important and only exist as auxiliary types supporting those that *are* important. In my mind, `Arc` is not such an auxiliary type, which is probably why it feels odd to have it re-exported. But that's just my mental model of the library :)

I should also note that it's possible I (and perhaps other users) will get warmed up to the idea of this re-export but it just doesn't sit right with me right now.

Opinions? How do you think about all this? What should we do here?
cc @yoshuawuyts @skade @matklad @taiki-e 