### PR TITLE
Remove deprecated action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,15 +52,10 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - id: component
-      uses: actions-rs/components-nightly@v1
-      with:
-        component: rustfmt
-
     - uses: actions-rs/toolchain@v1
       with:
           profile: minimal
-          toolchain: ${{ steps.component.outputs.toolchain }}
+          toolchain: nightly
           override: true
           components: rustfmt
 


### PR DESCRIPTION
actions-rs/components-nightly is deprecated now and we can use actions-rs/toolchain directly.

ref. https://github.com/actions-rs/components-nightly#deprecation-notice