### PR TITLE
Put everything behind a 'stable' feature to avoid future breaking changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
+default = ["stable"]
 docs = ["unstable"]
 unstable = ["broadcaster"]
+stable = []
 
 [dependencies]
 async-macros = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,9 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
-default = ["stable"]
+default = []
 docs = ["unstable"]
 unstable = ["broadcaster"]
-stable = []
 
 [dependencies]
 async-macros = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 //! features = ["unstable"]
 //! ```
 
+#![cfg(feature = "default")]
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 #![allow(clippy::mutex_atomic, clippy::module_inception)]
@@ -49,46 +50,33 @@
 #![doc(html_logo_url = "https://async.rs/images/logo--hero.svg")]
 #![recursion_limit = "2048"]
 
-/// Declares stable items.
-#[doc(hidden)]
-macro_rules! cfg_stable {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "stable")]
-            $item
-        )*
-    }
+#[macro_use]
+mod utils;
+
+pub mod fs;
+pub mod future;
+pub mod io;
+pub mod net;
+pub mod os;
+pub mod path;
+pub mod prelude;
+pub mod stream;
+pub mod sync;
+pub mod task;
+
+cfg_unstable! {
+    pub mod pin;
+    pub mod process;
+
+    mod unit;
+    mod vec;
+    mod result;
+    mod option;
+    mod string;
+    mod collections;
+
+    #[doc(inline)]
+    pub use std::{write, writeln};
 }
 
-cfg_stable! {
-    #[macro_use]
-    mod utils;
-
-    pub mod fs;
-    pub mod future;
-    pub mod io;
-    pub mod net;
-    pub mod os;
-    pub mod path;
-    pub mod prelude;
-    pub mod stream;
-    pub mod sync;
-    pub mod task;
-
-    cfg_unstable! {
-        pub mod pin;
-        pub mod process;
-
-        mod unit;
-        mod vec;
-        mod result;
-        mod option;
-        mod string;
-        mod collections;
-
-        #[doc(inline)]
-        pub use std::{write, writeln};
-    }
-
-    mod macros;
-}
+mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,33 +49,46 @@
 #![doc(html_logo_url = "https://async.rs/images/logo--hero.svg")]
 #![recursion_limit = "2048"]
 
-#[macro_use]
-mod utils;
-
-pub mod fs;
-pub mod future;
-pub mod io;
-pub mod net;
-pub mod os;
-pub mod path;
-pub mod prelude;
-pub mod stream;
-pub mod sync;
-pub mod task;
-
-cfg_unstable! {
-    pub mod pin;
-    pub mod process;
-
-    mod unit;
-    mod vec;
-    mod result;
-    mod option;
-    mod string;
-    mod collections;
-
-    #[doc(inline)]
-    pub use std::{write, writeln};
+/// Declares stable items.
+#[doc(hidden)]
+macro_rules! cfg_stable {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "stable")]
+            $item
+        )*
+    }
 }
 
-mod macros;
+cfg_stable! {
+    #[macro_use]
+    mod utils;
+
+    pub mod fs;
+    pub mod future;
+    pub mod io;
+    pub mod net;
+    pub mod os;
+    pub mod path;
+    pub mod prelude;
+    pub mod stream;
+    pub mod sync;
+    pub mod task;
+
+    cfg_unstable! {
+        pub mod pin;
+        pub mod process;
+
+        mod unit;
+        mod vec;
+        mod result;
+        mod option;
+        mod string;
+        mod collections;
+
+        #[doc(inline)]
+        pub use std::{write, writeln};
+    }
+
+    mod macros;
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,8 +23,6 @@ pub use crate::io::Seek as _;
 pub use crate::io::Write as _;
 #[doc(no_inline)]
 pub use crate::stream::Stream;
-#[doc(no_inline)]
-pub use crate::task_local;
 
 #[doc(hidden)]
 pub use crate::future::future::FutureExt as _;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,6 +23,8 @@ pub use crate::io::Seek as _;
 pub use crate::io::Write as _;
 #[doc(no_inline)]
 pub use crate::stream::Stream;
+#[doc(no_inline)]
+pub use crate::task_local;
 
 #[doc(hidden)]
 pub use crate::future::future::FutureExt as _;
@@ -36,8 +38,6 @@ pub use crate::io::seek::SeekExt as _;
 pub use crate::io::write::WriteExt as _;
 #[doc(hidden)]
 pub use crate::stream::stream::StreamExt as _;
-#[doc(hidden)]
-pub use crate::task_local;
 
 cfg_unstable! {
     #[doc(no_inline)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -36,6 +36,8 @@ pub use crate::io::seek::SeekExt as _;
 pub use crate::io::write::WriteExt as _;
 #[doc(hidden)]
 pub use crate::stream::stream::StreamExt as _;
+#[doc(hidden)]
+pub use crate::task_local;
 
 cfg_unstable! {
     #[doc(no_inline)]


### PR DESCRIPTION
This fixes #417, although I don't know if this is the ideal way, can anybody point me the best way?

I had to define the macro in `lib.rs` otherwise everything else on `util.rs` would have to be behind the same macro, I could move it to `utils.rs` tho.

Also, since things on `unstable` seem to depend on `stable` (does it really need to?). So for now `unstable` needs `stable`, that could become a problem when specific features are added, since you may need to play feature hide and seek with them to use the `unstable` features. What do you guys think about that?

If we put only the pub exports behind the flag a bunch of "unused" warnings will pop up, is it better than putting everything behind the flag (it may fix the `unstable` problem)? Should we just add a `allow(unused)`?

And for some weird reason `prelude.rs` stopped compiling referencing this PR rust-lang/rust#52234, which seems like a problem so I removed the `pub use`, specially because now the macro won't be in the prelude. Any ideas on that?  (this actually breaks a test, what is the best way to fix it?)