### PR TITLE
Stream::merge does not end prematurely if one stream is delayed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,11 @@ futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
 # These are used by the book for examples
 futures-channel-preview = "=0.3.0-alpha.19"
 futures-util-preview = "=0.3.0-alpha.19"
+
+[[test]]
+name = "stream"
+required-features = ["unstable"]
+
+[[example]]
+name = "tcp-ipv4-and-6-echo"
+required-features = ["unstable"]

--- a/src/stream/stream/merge.rs
+++ b/src/stream/stream/merge.rs
@@ -4,6 +4,9 @@ use std::task::{Context, Poll};
 use futures_core::Stream;
 use pin_project_lite::pin_project;
 
+use crate::prelude::*;
+use crate::stream::Fuse;
+
 pin_project! {
     /// A stream that merges two other streams into a single stream.
     ///
@@ -17,15 +20,15 @@ pin_project! {
     #[derive(Debug)]
     pub struct Merge<L, R> {
         #[pin]
-        left: L,
+        left: Fuse<L>,
         #[pin]
-        right: R,
+        right: Fuse<R>,
     }
 }
 
-impl<L, R> Merge<L, R> {
+impl<L: Stream, R: Stream> Merge<L, R> {
     pub(crate) fn new(left: L, right: R) -> Self {
-        Self { left, right }
+        Self { left: left.fuse(), right: right.fuse() }
     }
 }
 

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -1590,7 +1590,7 @@ extension_trait! {
         }
 
         #[doc = r#"
-            Searches for an element in a Stream that satisfies a predicate, returning 
+            Searches for an element in a Stream that satisfies a predicate, returning
             its index.
 
             # Examples

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,0 +1,47 @@
+use async_std::prelude::*;
+use async_std::stream;
+use async_std::sync::channel;
+use async_std::task;
+
+#[test]
+/// Checks that streams are merged fully even if one of the components
+/// experiences delay.
+fn merging_delayed_streams_work() {
+    let (sender, receiver) = channel::<i32>(10);
+
+    let mut s = receiver.merge(stream::empty());
+    let t = task::spawn(async move {
+        let mut xs = Vec::new();
+        while let Some(x) = s.next().await {
+            xs.push(x);
+        }
+        xs
+    });
+
+    task::block_on(async move {
+        task::sleep(std::time::Duration::from_millis(500)).await;
+        sender.send(92).await;
+        drop(sender);
+        let xs = t.await;
+        assert_eq!(xs, vec![92])
+    });
+
+    let (sender, receiver) = channel::<i32>(10);
+
+    let mut s = stream::empty().merge(receiver);
+    let t = task::spawn(async move {
+        let mut xs = Vec::new();
+        while let Some(x) = s.next().await {
+            xs.push(x);
+        }
+        xs
+    });
+
+    task::block_on(async move {
+        task::sleep(std::time::Duration::from_millis(500)).await;
+        sender.send(92).await;
+        drop(sender);
+        let xs = t.await;
+        assert_eq!(xs, vec![92])
+    });
+}


### PR DESCRIPTION
r? @yoshuawuyts 

The bug was that if `left` returned `Poll::Pending`, the right could have returnrf `Poll::Ready(None)`, and we would consider the stream as finished, although we haven't really polled the left part thoroughly enough. 

I also don't understand why we need `cx.waker().wake_by_ref();` here: we are returning `Poll::Ready`, and calling `wake_by_ref` is only required if you return `Pending`? 