### PR TITLE
mark stdio-lock structs as unstable

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -282,9 +282,9 @@ pub use read::Read;
 pub use repeat::{repeat, Repeat};
 pub use seek::Seek;
 pub use sink::{sink, Sink};
-pub use stderr::{stderr, Stderr, StderrLock};
-pub use stdin::{stdin, Stdin, StdinLock};
-pub use stdout::{stdout, Stdout, StdoutLock};
+pub use stderr::{stderr, Stderr};
+pub use stdin::{stdin, Stdin};
+pub use stdout::{stdout, Stdout};
 pub use timeout::timeout;
 pub use write::Write;
 
@@ -311,3 +311,9 @@ mod stdin;
 mod stdio;
 mod stdout;
 mod timeout;
+
+cfg_unstable! {
+    pub use stderr::StderrLock;
+    pub use stdin::StdinLock;
+    pub use stdout::StdoutLock;
+}

--- a/src/io/stderr.rs
+++ b/src/io/stderr.rs
@@ -1,4 +1,3 @@
-use std::io::Write as StdWrite;
 use std::pin::Pin;
 use std::sync::Mutex;
 
@@ -8,6 +7,7 @@ use crate::task::{spawn_blocking, Context, JoinHandle, Poll};
 
 cfg_unstable! {
     use once_cell::sync::Lazy;
+    use std::io::Write as _;
 }
 
 /// Constructs a new handle to the standard error of the current process.
@@ -59,13 +59,19 @@ pub fn stderr() -> Stderr {
 pub struct Stderr(Mutex<State>);
 
 /// A locked reference to the Stderr handle.
-/// This handle implements the [`Write`] traits, and is constructed via the [`Stderr::lock`] method.
+///
+/// This handle implements the [`Write`] traits, and is constructed via the [`Stderr::lock`]
+/// method.
 ///
 /// [`Write`]: trait.Read.html
 /// [`Stderr::lock`]: struct.Stderr.html#method.lock
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[derive(Debug)]
 pub struct StderrLock<'a>(std::io::StderrLock<'a>);
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 unsafe impl Send for StderrLock<'_> {}
 
 /// The state of the asynchronous stderr.
@@ -234,7 +240,9 @@ cfg_windows! {
     }
 }
 
-impl Write for StderrLock<'_> {
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+impl io::Write for StderrLock<'_> {
     fn poll_write(
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,

--- a/src/io/stdin.rs
+++ b/src/io/stdin.rs
@@ -7,6 +7,7 @@ use crate::task::{spawn_blocking, Context, JoinHandle, Poll};
 
 cfg_unstable! {
     use once_cell::sync::Lazy;
+    use std::io::Read as _;
 }
 
 /// Constructs a new handle to the standard input of the current process.
@@ -59,13 +60,18 @@ pub fn stdin() -> Stdin {
 pub struct Stdin(Mutex<State>);
 
 /// A locked reference to the Stdin handle.
+///
 /// This handle implements the [`Read`] traits, and is constructed via the [`Stdin::lock`] method.
 ///
 /// [`Read`]: trait.Read.html
 /// [`Stdin::lock`]: struct.Stdin.html#method.lock
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+#[cfg(feature = "unstable")]
 #[derive(Debug)]
 pub struct StdinLock<'a>(std::io::StdinLock<'a>);
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 unsafe impl Send for StdinLock<'_> {}
 
 /// The state of the asynchronous stdin.
@@ -257,14 +263,14 @@ cfg_windows! {
     }
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 impl Read for StdinLock<'_> {
     fn poll_read(
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        use std::io::Read as StdRead;
-
         Poll::Ready(self.0.read(buf))
     }
 }

--- a/src/io/stdout.rs
+++ b/src/io/stdout.rs
@@ -1,4 +1,3 @@
-use std::io::Write as StdWrite;
 use std::pin::Pin;
 use std::sync::Mutex;
 
@@ -8,6 +7,7 @@ use crate::task::{spawn_blocking, Context, JoinHandle, Poll};
 
 cfg_unstable! {
     use once_cell::sync::Lazy;
+    use std::io::Write as _;
 }
 
 /// Constructs a new handle to the standard output of the current process.
@@ -59,13 +59,19 @@ pub fn stdout() -> Stdout {
 pub struct Stdout(Mutex<State>);
 
 /// A locked reference to the Stderr handle.
-/// This handle implements the [`Write`] traits, and is constructed via the [`Stdout::lock`] method.
+///
+/// This handle implements the [`Write`] traits, and is constructed via the [`Stdout::lock`]
+/// method.
 ///
 /// [`Write`]: trait.Read.html
 /// [`Stdout::lock`]: struct.Stdout.html#method.lock
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[derive(Debug)]
 pub struct StdoutLock<'a>(std::io::StdoutLock<'a>);
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 unsafe impl Send for StdoutLock<'_> {}
 
 /// The state of the asynchronous stdout.
@@ -234,6 +240,8 @@ cfg_windows! {
     }
 }
 
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 impl Write for StdoutLock<'_> {
     fn poll_write(
         mut self: Pin<&mut Self>,


### PR DESCRIPTION
Follow-up to https://github.com/async-rs/async-std/pull/334, this marks some of the extra stdio structs as "unstable". It was already never possible to create them so merging the patch was already correct. But this adds some extra polish. Thanks heaps!