### PR TITLE
add Stream::copied

### DIFF
--- a/src/stream/stream/copied.rs
+++ b/src/stream/stream/copied.rs
@@ -1,0 +1,33 @@
+use crate::stream::Stream;
+use crate::task::{Context, Poll};
+use pin_project_lite::pin_project;
+use std::pin::Pin;
+
+pin_project! {
+    #[doc(hidden)]
+    #[allow(missing_debug_implementations)]
+    pub struct Copied<S> {
+        #[pin]
+        stream: S,
+    }
+}
+
+impl<S> Copied<S> {
+    pub(super) fn new(stream: S) -> Self {
+        Copied { stream }
+    }
+}
+
+impl<'a, S, T: 'a> Stream for Copied<S>
+where
+    S: Stream<Item = &'a T>,
+    T: Copy,
+{
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        let next = futures_core::ready!(this.stream.poll_next(cx));
+        Poll::Ready(next.copied())
+    }
+}

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -25,6 +25,7 @@ mod all;
 mod any;
 mod chain;
 mod cmp;
+mod copied;
 mod enumerate;
 mod eq;
 mod filter;
@@ -88,6 +89,7 @@ use try_fold::TryFoldFuture;
 use try_for_each::TryForEachFuture;
 
 pub use chain::Chain;
+pub use copied::Copied;
 pub use filter::Filter;
 pub use fuse::Fuse;
 pub use inspect::Inspect;
@@ -367,6 +369,42 @@ extension_trait! {
             U: Stream<Item = Self::Item> + Sized,
         {
             Chain::new(self, other)
+        }
+
+
+        #[doc = r#"
+            Creates an stream which copies all of its elements.
+
+            # Examples
+
+            Basic usage:
+
+            ```
+            # fn main() { async_std::task::block_on(async {
+            #
+            use async_std::prelude::*;
+            use std::collections::VecDeque;
+
+            let v: VecDeque<_> = vec![&1, &2, &3].into_iter().collect();
+            
+            let mut v_copied  = v.copied();
+
+            assert_eq!(v_copied.next().await, Some(1));
+            assert_eq!(v_copied.next().await, Some(2));
+            assert_eq!(v_copied.next().await, Some(3));
+            assert_eq!(v_copied.next().await, None);
+    
+
+            #
+            # }) }
+            ```
+        "#]
+        fn copied<'a,T>(self) -> Copied<Self>
+        where
+            Self: Sized + Stream<Item = &'a T>,
+            T : 'a + Copy,
+        {
+            Copied::new(self)
         }
 
         #[doc = r#"


### PR DESCRIPTION
ref #129, Implement Steam::copied.
# References
* https://doc.rust-lang.org/src/core/iter/adapters/mod.rs.html#136-171
* https://doc.rust-lang.org/src/core/iter/traits/iterator.rs.html#2298-2323