### PR TITLE
remove remaining instances of VecDeque stream

### DIFF
--- a/src/option/product.rs
+++ b/src/option/product.rs
@@ -20,10 +20,10 @@ where
         ```
         # fn main() { async_std::task::block_on(async {
         #
-        use std::collections::VecDeque;
         use async_std::prelude::*;
+        use async_std::stream;
 
-        let v: VecDeque<_> = vec![1, 2, 4].into_iter().collect();
+        let v = stream::from_iter(vec![1, 2, 4]);
         let prod: Option<i32> = v.map(|x|
             if x < 0 {
                 None

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -2012,10 +2012,10 @@ extension_trait! {
             # fn main() { async_std::task::block_on(async {
             #
             async fn factorial(n: u32) -> u32 {
-                use std::collections::VecDeque;
                 use async_std::prelude::*;
+                use async_std::stream;
 
-                let s: VecDeque<_> = (1..=n).collect();
+                let s = stream::from_iter(1..=n);
                 s.product().await
             }
 


### PR DESCRIPTION
Removes remaining instances of VecDeque streams. Follow up to #430. Thanks!