### PR TITLE
DO NOT MERGE: Upgrade futures rs to latest master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,10 @@ broadcaster = { version = "0.2.6", optional = true, default-features = false, fe
 crossbeam-channel = "0.3.9"
 crossbeam-deque = "0.7.1"
 crossbeam-utils = "0.6.6"
-futures-core-preview = "=0.3.0-alpha.19"
-futures-io-preview = "=0.3.0-alpha.19"
+futures-core-preview = { git = "https://github.com/rust-lang-nursery/futures-rs.git" }
+futures-io-preview = { git = "https://github.com/rust-lang-nursery/futures-rs.git" }
+# futures-core-preview = "=0.3.0-alpha.19"
+# futures-io-preview = "=0.3.0-alpha.19"
 futures-timer = "1.0.2"
 kv-log-macro = "1.0.4"
 log = { version = "0.4.8", features = ["kv_unstable"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,11 +53,14 @@ femme = "1.2.0"
 rand = "0.7.2"
 # surf = "1.0.2"
 tempdir = "0.3.7"
-futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
+# futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
+futures-preview = { git = "https://github.com/rust-lang-nursery/futures-rs.git", features = ["async-await"]}
 
 # These are used by the book for examples
-futures-channel-preview = "=0.3.0-alpha.19"
-futures-util-preview = "=0.3.0-alpha.19"
+futures-channel-preview = { git = "https://github.com/rust-lang-nursery/futures-rs.git" }
+futures-util-preview = { git = "https://github.com/rust-lang-nursery/futures-rs.git" }
+# futures-channel-preview = "=0.3.0-alpha.19"
+# futures-util-preview = "=0.3.0-alpha.19"
 
 [[test]]
 name = "stream"


### PR DESCRIPTION
All tests passed locally, but want to do https://github.com/rust-lang-nursery/futures-rs/pull/1954 justice and run it on CI once too.

__do not merge this patch__ it's for testing purposes only.