### PR TITLE
Rename stream_extend to extend

### DIFF
--- a/src/collections/binary_heap/extend.rs
+++ b/src/collections/binary_heap/extend.rs
@@ -2,10 +2,10 @@ use std::collections::BinaryHeap;
 use std::pin::Pin;
 
 use crate::prelude::*;
-use crate::stream::{Extend, IntoStream};
+use crate::stream::{self, IntoStream};
 
-impl<T: Ord> Extend<T> for BinaryHeap<T> {
-    fn stream_extend<'a, S: IntoStream<Item = T> + 'a>(
+impl<T: Ord> stream::Extend<T> for BinaryHeap<T> {
+    fn extend<'a, S: IntoStream<Item = T> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {

--- a/src/collections/binary_heap/from_stream.rs
+++ b/src/collections/binary_heap/from_stream.rs
@@ -1,7 +1,7 @@
 use std::collections::BinaryHeap;
 use std::pin::Pin;
 
-use crate::stream::{Extend, FromStream, IntoStream};
+use crate::stream::{self, FromStream, IntoStream};
 
 impl<T: Ord> FromStream<T> for BinaryHeap<T> {
     #[inline]
@@ -17,7 +17,7 @@ impl<T: Ord> FromStream<T> for BinaryHeap<T> {
             pin_utils::pin_mut!(stream);
 
             let mut out = BinaryHeap::new();
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/binary_heap/from_stream.rs
+++ b/src/collections/binary_heap/from_stream.rs
@@ -17,7 +17,7 @@ impl<T: Ord> FromStream<T> for BinaryHeap<T> {
             pin_utils::pin_mut!(stream);
 
             let mut out = BinaryHeap::new();
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/btree_map/extend.rs
+++ b/src/collections/btree_map/extend.rs
@@ -2,10 +2,10 @@ use std::collections::BTreeMap;
 use std::pin::Pin;
 
 use crate::prelude::*;
-use crate::stream::{Extend, IntoStream};
+use crate::stream::{self, IntoStream};
 
-impl<K: Ord, V> Extend<(K, V)> for BTreeMap<K, V> {
-    fn stream_extend<'a, S: IntoStream<Item = (K, V)> + 'a>(
+impl<K: Ord, V> stream::Extend<(K, V)> for BTreeMap<K, V> {
+    fn extend<'a, S: IntoStream<Item = (K, V)> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {

--- a/src/collections/btree_map/from_stream.rs
+++ b/src/collections/btree_map/from_stream.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::pin::Pin;
 
-use crate::stream::{Extend, FromStream, IntoStream};
+use crate::stream::{self, FromStream, IntoStream};
 
 impl<K: Ord, V> FromStream<(K, V)> for BTreeMap<K, V> {
     #[inline]
@@ -17,7 +17,7 @@ impl<K: Ord, V> FromStream<(K, V)> for BTreeMap<K, V> {
             pin_utils::pin_mut!(stream);
 
             let mut out = BTreeMap::new();
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/btree_map/from_stream.rs
+++ b/src/collections/btree_map/from_stream.rs
@@ -17,7 +17,7 @@ impl<K: Ord, V> FromStream<(K, V)> for BTreeMap<K, V> {
             pin_utils::pin_mut!(stream);
 
             let mut out = BTreeMap::new();
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/btree_set/extend.rs
+++ b/src/collections/btree_set/extend.rs
@@ -2,10 +2,10 @@ use std::collections::BTreeSet;
 use std::pin::Pin;
 
 use crate::prelude::*;
-use crate::stream::{Extend, IntoStream};
+use crate::stream::{self, IntoStream};
 
-impl<T: Ord> Extend<T> for BTreeSet<T> {
-    fn stream_extend<'a, S: IntoStream<Item = T> + 'a>(
+impl<T: Ord> stream::Extend<T> for BTreeSet<T> {
+    fn extend<'a, S: IntoStream<Item = T> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {

--- a/src/collections/btree_set/from_stream.rs
+++ b/src/collections/btree_set/from_stream.rs
@@ -17,7 +17,7 @@ impl<T: Ord> FromStream<T> for BTreeSet<T> {
             pin_utils::pin_mut!(stream);
 
             let mut out = BTreeSet::new();
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/btree_set/from_stream.rs
+++ b/src/collections/btree_set/from_stream.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::pin::Pin;
 
-use crate::stream::{Extend, FromStream, IntoStream};
+use crate::stream::{self, FromStream, IntoStream};
 
 impl<T: Ord> FromStream<T> for BTreeSet<T> {
     #[inline]
@@ -17,7 +17,7 @@ impl<T: Ord> FromStream<T> for BTreeSet<T> {
             pin_utils::pin_mut!(stream);
 
             let mut out = BTreeSet::new();
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/hash_map/extend.rs
+++ b/src/collections/hash_map/extend.rs
@@ -3,14 +3,14 @@ use std::hash::{BuildHasher, Hash};
 use std::pin::Pin;
 
 use crate::prelude::*;
-use crate::stream::{Extend, IntoStream};
+use crate::stream::{self, IntoStream};
 
-impl<K, V, H> Extend<(K, V)> for HashMap<K, V, H>
+impl<K, V, H> stream::Extend<(K, V)> for HashMap<K, V, H>
 where
     K: Eq + Hash,
     H: BuildHasher + Default,
 {
-    fn stream_extend<'a, S: IntoStream<Item = (K, V)> + 'a>(
+    fn extend<'a, S: IntoStream<Item = (K, V)> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {

--- a/src/collections/hash_map/from_stream.rs
+++ b/src/collections/hash_map/from_stream.rs
@@ -22,7 +22,7 @@ where
             pin_utils::pin_mut!(stream);
 
             let mut out = HashMap::with_hasher(Default::default());
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/hash_map/from_stream.rs
+++ b/src/collections/hash_map/from_stream.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::hash::{BuildHasher, Hash};
 use std::pin::Pin;
 
-use crate::stream::{Extend, FromStream, IntoStream};
+use crate::stream::{self, FromStream, IntoStream};
 
 impl<K, V, H> FromStream<(K, V)> for HashMap<K, V, H>
 where
@@ -22,7 +22,7 @@ where
             pin_utils::pin_mut!(stream);
 
             let mut out = HashMap::with_hasher(Default::default());
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/hash_set/extend.rs
+++ b/src/collections/hash_set/extend.rs
@@ -3,14 +3,14 @@ use std::hash::{BuildHasher, Hash};
 use std::pin::Pin;
 
 use crate::prelude::*;
-use crate::stream::{Extend, IntoStream};
+use crate::stream::{self, IntoStream};
 
-impl<T, H> Extend<T> for HashSet<T, H>
+impl<T, H> stream::Extend<T> for HashSet<T, H>
 where
     T: Eq + Hash,
     H: BuildHasher + Default,
 {
-    fn stream_extend<'a, S: IntoStream<Item = T> + 'a>(
+    fn extend<'a, S: IntoStream<Item = T> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {

--- a/src/collections/hash_set/from_stream.rs
+++ b/src/collections/hash_set/from_stream.rs
@@ -22,7 +22,7 @@ where
             pin_utils::pin_mut!(stream);
 
             let mut out = HashSet::with_hasher(Default::default());
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/hash_set/from_stream.rs
+++ b/src/collections/hash_set/from_stream.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::hash::{BuildHasher, Hash};
 use std::pin::Pin;
 
-use crate::stream::{Extend, FromStream, IntoStream};
+use crate::stream::{self, FromStream, IntoStream};
 
 impl<T, H> FromStream<T> for HashSet<T, H>
 where
@@ -22,7 +22,7 @@ where
             pin_utils::pin_mut!(stream);
 
             let mut out = HashSet::with_hasher(Default::default());
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/linked_list/extend.rs
+++ b/src/collections/linked_list/extend.rs
@@ -2,10 +2,10 @@ use std::collections::LinkedList;
 use std::pin::Pin;
 
 use crate::prelude::*;
-use crate::stream::{Extend, IntoStream};
+use crate::stream::{self, IntoStream};
 
-impl<T> Extend<T> for LinkedList<T> {
-    fn stream_extend<'a, S: IntoStream<Item = T> + 'a>(
+impl<T> stream::Extend<T> for LinkedList<T> {
+    fn extend<'a, S: IntoStream<Item = T> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {

--- a/src/collections/linked_list/from_stream.rs
+++ b/src/collections/linked_list/from_stream.rs
@@ -1,7 +1,7 @@
 use std::collections::LinkedList;
 use std::pin::Pin;
 
-use crate::stream::{Extend, FromStream, IntoStream};
+use crate::stream::{self, FromStream, IntoStream};
 
 impl<T> FromStream<T> for LinkedList<T> {
     #[inline]
@@ -17,7 +17,7 @@ impl<T> FromStream<T> for LinkedList<T> {
             pin_utils::pin_mut!(stream);
 
             let mut out = LinkedList::new();
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/linked_list/from_stream.rs
+++ b/src/collections/linked_list/from_stream.rs
@@ -17,7 +17,7 @@ impl<T> FromStream<T> for LinkedList<T> {
             pin_utils::pin_mut!(stream);
 
             let mut out = LinkedList::new();
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/vec_deque/extend.rs
+++ b/src/collections/vec_deque/extend.rs
@@ -2,10 +2,10 @@ use std::collections::VecDeque;
 use std::pin::Pin;
 
 use crate::prelude::*;
-use crate::stream::{Extend, IntoStream};
+use crate::stream::{self, IntoStream};
 
-impl<T> Extend<T> for VecDeque<T> {
-    fn stream_extend<'a, S: IntoStream<Item = T> + 'a>(
+impl<T> stream::Extend<T> for VecDeque<T> {
+    fn extend<'a, S: IntoStream<Item = T> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {

--- a/src/collections/vec_deque/from_stream.rs
+++ b/src/collections/vec_deque/from_stream.rs
@@ -17,7 +17,7 @@ impl<T> FromStream<T> for VecDeque<T> {
             pin_utils::pin_mut!(stream);
 
             let mut out = VecDeque::new();
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/collections/vec_deque/from_stream.rs
+++ b/src/collections/vec_deque/from_stream.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::pin::Pin;
 
-use crate::stream::{Extend, FromStream, IntoStream};
+use crate::stream::{self, FromStream, IntoStream};
 
 impl<T> FromStream<T> for VecDeque<T> {
     #[inline]
@@ -17,7 +17,7 @@ impl<T> FromStream<T> for VecDeque<T> {
             pin_utils::pin_mut!(stream);
 
             let mut out = VecDeque::new();
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -6,7 +6,7 @@ use crate::path::Path;
 #[cfg(feature = "unstable")]
 use crate::prelude::*;
 #[cfg(feature = "unstable")]
-use crate::stream::{Extend, FromStream, IntoStream};
+use crate::stream::{self, FromStream, IntoStream};
 
 /// This struct is an async version of [`std::path::PathBuf`].
 ///
@@ -241,8 +241,8 @@ impl AsRef<std::path::Path> for PathBuf {
 }
 
 #[cfg(feature = "unstable")]
-impl<P: AsRef<Path>> Extend<P> for PathBuf {
-    fn stream_extend<'a, S: IntoStream<Item = P>>(
+impl<P: AsRef<Path>> stream::Extend<P> for PathBuf {
+    fn extend<'a, S: IntoStream<Item = P>>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>>
@@ -275,7 +275,7 @@ impl<'b, P: AsRef<Path> + 'b> FromStream<P> for PathBuf {
             pin_utils::pin_mut!(stream);
 
             let mut out = Self::new();
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -275,7 +275,7 @@ impl<'b, P: AsRef<Path> + 'b> FromStream<P> for PathBuf {
             pin_utils::pin_mut!(stream);
 
             let mut out = Self::new();
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -44,6 +44,4 @@ cfg_unstable! {
     pub use crate::stream::DoubleEndedStream;
     #[doc(no_inline)]
     pub use crate::stream::ExactSizeStream;
-    #[doc(no_inline)]
-    pub use crate::stream::Extend;
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -44,4 +44,6 @@ cfg_unstable! {
     pub use crate::stream::DoubleEndedStream;
     #[doc(no_inline)]
     pub use crate::stream::ExactSizeStream;
+    #[doc(no_inline)]
+    pub use crate::stream::Extend;
 }

--- a/src/stream/extend.rs
+++ b/src/stream/extend.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use crate::prelude::*;
 use crate::stream::IntoStream;
 
-/// Extend a collection with the contents of a stream.
+/// Extends a collection with the contents of a stream.
 ///
 /// Streams produce a series of values asynchronously, and collections can also be thought of as a
 /// series of values. The `Extend` trait bridges this gap, allowing you to extend a collection
@@ -39,15 +39,37 @@ pub trait Extend<A> {
         A: 'a;
 }
 
-impl Extend<()> for () {
-    fn extend<'a, T: IntoStream<Item = ()> + 'a>(
-        &'a mut self,
-        stream: T,
-    ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {
-        let stream = stream.into_stream();
-        Box::pin(async move {
-            pin_utils::pin_mut!(stream);
-            while let Some(_) = stream.next().await {}
-        })
-    }
+/// Extends a collection with the contents of a stream.
+///
+/// Streams produce a series of values asynchronously, and collections can also be thought of as a
+/// series of values. The [`Extend`] trait bridges this gap, allowing you to extend a collection
+/// asynchronously by including the contents of that stream. When extending a collection with an
+/// already existing key, that entry is updated or, in the case of collections that permit multiple
+/// entries with equal keys, that entry is inserted.
+///
+/// [`Extend`]: trait.Extend.html
+///
+/// ## Examples
+///
+/// ```
+/// # async_std::task::block_on(async {
+/// #
+/// use async_std::prelude::*;
+/// use async_std::stream;
+///
+/// let mut v: Vec<usize> = vec![1, 2];
+/// let s = stream::repeat(3usize).take(3);
+/// stream::extend(&mut v, s).await;
+///
+/// assert_eq!(v, vec![1, 2, 3, 3, 3]);
+/// #
+/// # })
+/// ```
+pub async fn extend<'a, C, A, T>(collection: &mut C, stream: T)
+where
+    C: Extend<A>,
+    A: 'a,
+    T: IntoStream<Item = A> + 'a,
+{
+    Extend::extend(collection, stream).await
 }

--- a/src/stream/extend.rs
+++ b/src/stream/extend.rs
@@ -17,11 +17,11 @@ use crate::stream::IntoStream;
 /// # async_std::task::block_on(async {
 /// #
 /// use async_std::prelude::*;
-/// use async_std::stream::{self, Extend};
+/// use async_std::stream;
 ///
 /// let mut v: Vec<usize> = vec![1, 2];
 /// let s = stream::repeat(3usize).take(3);
-/// v.stream_extend(s).await;
+/// stream::Extend::extend(&mut v, s).await;
 ///
 /// assert_eq!(v, vec![1, 2, 3, 3, 3]);
 /// #
@@ -31,7 +31,7 @@ use crate::stream::IntoStream;
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 pub trait Extend<A> {
     /// Extends a collection with the contents of a stream.
-    fn stream_extend<'a, T: IntoStream<Item = A> + 'a>(
+    fn extend<'a, T: IntoStream<Item = A> + 'a>(
         &'a mut self,
         stream: T,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>>
@@ -40,7 +40,7 @@ pub trait Extend<A> {
 }
 
 impl Extend<()> for () {
-    fn stream_extend<'a, T: IntoStream<Item = ()> + 'a>(
+    fn extend<'a, T: IntoStream<Item = ()> + 'a>(
         &'a mut self,
         stream: T,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {

--- a/src/stream/from_stream.rs
+++ b/src/stream/from_stream.rs
@@ -76,7 +76,7 @@ use std::pin::Pin;
 ///             let mut c = MyCollection::new();
 ///
 ///             let mut v = vec![];
-///             stream::Extend::extend(&mut v, stream).await;
+///             stream::extend(&mut v, stream).await;
 ///
 ///             for i in v {
 ///                 c.add(i);

--- a/src/stream/from_stream.rs
+++ b/src/stream/from_stream.rs
@@ -46,8 +46,7 @@ use std::pin::Pin;
 ///
 /// ```
 /// use async_std::prelude::*;
-/// use async_std::stream::{Extend, FromStream, IntoStream};
-/// use async_std::stream;
+/// use async_std::stream::{self, FromStream, IntoStream};
 /// use std::pin::Pin;
 ///
 /// // A sample collection, that's just a wrapper over Vec<T>
@@ -77,7 +76,7 @@ use std::pin::Pin;
 ///             let mut c = MyCollection::new();
 ///
 ///             let mut v = vec![];
-///             v.stream_extend(stream).await;
+///             stream::Extend::extend(&mut v, stream).await;
 ///
 ///             for i in v {
 ///                 c.add(i);

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -332,7 +332,7 @@ cfg_unstable! {
 
     pub use double_ended_stream::DoubleEndedStream;
     pub use exact_size_stream::ExactSizeStream;
-    pub use extend::Extend;
+    pub use extend::{extend, Extend};
     pub use from_stream::FromStream;
     pub use fused_stream::FusedStream;
     pub use interval::{interval, Interval};

--- a/src/string/extend.rs
+++ b/src/string/extend.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 use std::pin::Pin;
 
 use crate::prelude::*;
-use crate::stream::{Extend, IntoStream};
+use crate::stream::{self, IntoStream};
 
-impl Extend<char> for String {
-    fn stream_extend<'a, S: IntoStream<Item = char> + 'a>(
+impl stream::Extend<char> for String {
+    fn extend<'a, S: IntoStream<Item = char> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {
@@ -17,8 +17,8 @@ impl Extend<char> for String {
     }
 }
 
-impl<'b> Extend<&'b char> for String {
-    fn stream_extend<'a, S: IntoStream<Item = &'b char> + 'a>(
+impl<'b> stream::Extend<&'b char> for String {
+    fn extend<'a, S: IntoStream<Item = &'b char> + 'a>(
         &'a mut self,
         //TODO: Remove the underscore when uncommenting the body of this impl
         _stream: S,
@@ -32,8 +32,8 @@ impl<'b> Extend<&'b char> for String {
     }
 }
 
-impl<'b> Extend<&'b str> for String {
-    fn stream_extend<'a, S: IntoStream<Item = &'b str> + 'a>(
+impl<'b> stream::Extend<&'b str> for String {
+    fn extend<'a, S: IntoStream<Item = &'b str> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>>
@@ -44,8 +44,8 @@ impl<'b> Extend<&'b str> for String {
     }
 }
 
-impl Extend<String> for String {
-    fn stream_extend<'a, S: IntoStream<Item = String> + 'a>(
+impl stream::Extend<String> for String {
+    fn extend<'a, S: IntoStream<Item = String> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {
@@ -53,8 +53,8 @@ impl Extend<String> for String {
     }
 }
 
-impl<'b> Extend<Cow<'b, str>> for String {
-    fn stream_extend<'a, S: IntoStream<Item = Cow<'b, str>> + 'a>(
+impl<'b> stream::Extend<Cow<'b, str>> for String {
+    fn extend<'a, S: IntoStream<Item = Cow<'b, str>> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>>

--- a/src/string/from_stream.rs
+++ b/src/string/from_stream.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::pin::Pin;
 
-use crate::stream::{Extend, FromStream, IntoStream};
+use crate::stream::{self, FromStream, IntoStream};
 
 impl FromStream<char> for String {
     #[inline]
@@ -17,7 +17,7 @@ impl FromStream<char> for String {
             pin_utils::pin_mut!(stream);
 
             let mut out = String::new();
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }
@@ -37,7 +37,7 @@ impl<'b> FromStream<&'b char> for String {
             pin_utils::pin_mut!(stream);
 
             let mut out = String::new();
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }
@@ -57,7 +57,7 @@ impl<'b> FromStream<&'b str> for String {
             pin_utils::pin_mut!(stream);
 
             let mut out = String::new();
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }
@@ -77,7 +77,7 @@ impl FromStream<String> for String {
             pin_utils::pin_mut!(stream);
 
             let mut out = String::new();
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }
@@ -97,7 +97,7 @@ impl<'b> FromStream<Cow<'b, str>> for String {
             pin_utils::pin_mut!(stream);
 
             let mut out = String::new();
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/string/from_stream.rs
+++ b/src/string/from_stream.rs
@@ -17,7 +17,7 @@ impl FromStream<char> for String {
             pin_utils::pin_mut!(stream);
 
             let mut out = String::new();
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }
@@ -37,7 +37,7 @@ impl<'b> FromStream<&'b char> for String {
             pin_utils::pin_mut!(stream);
 
             let mut out = String::new();
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }
@@ -57,7 +57,7 @@ impl<'b> FromStream<&'b str> for String {
             pin_utils::pin_mut!(stream);
 
             let mut out = String::new();
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }
@@ -77,7 +77,7 @@ impl FromStream<String> for String {
             pin_utils::pin_mut!(stream);
 
             let mut out = String::new();
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }
@@ -97,7 +97,7 @@ impl<'b> FromStream<Cow<'b, str>> for String {
             pin_utils::pin_mut!(stream);
 
             let mut out = String::new();
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/unit/extend.rs
+++ b/src/unit/extend.rs
@@ -1,0 +1,17 @@
+use std::pin::Pin;
+
+use crate::prelude::*;
+use crate::stream::{self, IntoStream};
+
+impl stream::Extend<()> for () {
+    fn extend<'a, T: IntoStream<Item = ()> + 'a>(
+        &'a mut self,
+        stream: T,
+    ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {
+        let stream = stream.into_stream();
+        Box::pin(async move {
+            pin_utils::pin_mut!(stream);
+            while let Some(_) = stream.next().await {}
+        })
+    }
+}

--- a/src/unit/mod.rs
+++ b/src/unit/mod.rs
@@ -4,3 +4,4 @@
 //! asynchronously with values of type `()`.
 
 mod from_stream;
+mod extend;

--- a/src/vec/extend.rs
+++ b/src/vec/extend.rs
@@ -1,10 +1,10 @@
 use std::pin::Pin;
 
 use crate::prelude::*;
-use crate::stream::{Extend, IntoStream};
+use crate::stream::{self, IntoStream};
 
-impl<T> Extend<T> for Vec<T> {
-    fn stream_extend<'a, S: IntoStream<Item = T> + 'a>(
+impl<T> stream::Extend<T> for Vec<T> {
+    fn extend<'a, S: IntoStream<Item = T> + 'a>(
         &'a mut self,
         stream: S,
     ) -> Pin<Box<dyn Future<Output = ()> + 'a>> {

--- a/src/vec/from_stream.rs
+++ b/src/vec/from_stream.rs
@@ -19,7 +19,7 @@ impl<T> FromStream<T> for Vec<T> {
             pin_utils::pin_mut!(stream);
 
             let mut out = vec![];
-            stream::Extend::extend(&mut out, stream).await;
+            stream::extend(&mut out, stream).await;
             out
         })
     }

--- a/src/vec/from_stream.rs
+++ b/src/vec/from_stream.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use crate::stream::{Extend, FromStream, IntoStream};
+use crate::stream::{self, FromStream, IntoStream};
 
 impl<T> FromStream<T> for Vec<T> {
     #[inline]
@@ -19,7 +19,7 @@ impl<T> FromStream<T> for Vec<T> {
             pin_utils::pin_mut!(stream);
 
             let mut out = vec![];
-            out.stream_extend(stream).await;
+            stream::Extend::extend(&mut out, stream).await;
             out
         })
     }


### PR DESCRIPTION
I've renamed this method to be more consistent with the standard library and re-exported the `Extend` trait in our prelude.