### PR TITLE
hide future::Flatten::new

### DIFF
--- a/src/future/future/flatten.rs
+++ b/src/future/future/flatten.rs
@@ -18,7 +18,7 @@ enum State<Fut1, Fut2> {
 }
 
 impl<Fut1, Fut2> FlattenFuture<Fut1, Fut2> {
-    pub fn new(future: Fut1) -> FlattenFuture<Fut1, Fut2> {
+    pub(crate) fn new(future: Fut1) -> FlattenFuture<Fut1, Fut2> {
         FlattenFuture {
             state: State::First(future),
         }


### PR DESCRIPTION
As per https://github.com/async-rs/async-std/pull/443#discussion_r342576240 hides `fn new` from `future::Flatten`. Thanks!