### PR TITLE
Minor documentation fix for race and try_race

### DIFF
--- a/src/future/future/mod.rs
+++ b/src/future/future/mod.rs
@@ -187,10 +187,8 @@ extension_trait! {
             futures to complete. If multiple futures are completed at the same time,
             resolution will occur in the order that they have been passed.
 
-            Note that this macro consumes all futures passed, and once a future is
+            Note that this function consumes all futures passed, and once a future is
             completed, all other futures are dropped.
-
-            This macro is only usable inside of async functions, closures, and blocks.
 
             # Examples
 


### PR DESCRIPTION
`race` was being referred to as a macro. Additionally is the comment

> Note that this function consumes all futures passed, and once a future is
            completed, all other futures are dropped.

required for a function since this fact is more clear from the signature of the function than for macros ?