### PR TITLE
add `Sync` constraint for RwLock to prevent memory unsafety

### DIFF
--- a/src/sync/rwlock.rs
+++ b/src/sync/rwlock.rs
@@ -57,7 +57,7 @@ pub struct RwLock<T> {
 }
 
 unsafe impl<T: Send> Send for RwLock<T> {}
-unsafe impl<T: Send> Sync for RwLock<T> {}
+unsafe impl<T: Send + Sync> Sync for RwLock<T> {}
 
 impl<T> RwLock<T> {
     /// Creates a new reader-writer lock.


### PR DESCRIPTION
without `Sync` constraint, interior mutability data `T`  can be modified concurrently by multiple threads  using `RwLock.read().await`