### PR TITLE
Add FromIterator and Extend trait implementations for PathBuf

### DIFF
--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -52,6 +52,10 @@
 //! path.push("system32");
 //!
 //! path.set_extension("dll");
+//!
+//! // ... but push is best used if you don't know everything up
+//! // front. If you do, this way is better:
+//! let path: PathBuf = ["c:\\", "windows", "system32.dll"].iter().collect();
 //! ```
 //!
 //! [`Component`]: enum.Component.html

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -280,3 +280,17 @@ impl<'b, P: AsRef<Path> + 'b> FromStream<P> for PathBuf {
         })
     }
 }
+
+impl<P: AsRef<Path>> std::iter::FromIterator<P> for PathBuf {
+    fn from_iter<I: IntoIterator<Item = P>>(iter: I) -> PathBuf {
+        let mut buf = PathBuf::new();
+        buf.extend(iter);
+        buf
+    }
+}
+
+impl<P: AsRef<Path>> std::iter::Extend<P> for PathBuf {
+    fn extend<I: IntoIterator<Item = P>>(&mut self, iter: I) {
+        iter.into_iter().for_each(move |p| self.push(p.as_ref()));
+    }
+}


### PR DESCRIPTION
Resolves #466

Added an implementation of `iter::FromIterator` for `PathBuf`. 

I also implemented `iter::Extend` for `PathBuf` to keep the implementation consistent with the `std` implementation.