### PR TITLE
fix: stream::take_while

### DIFF
--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -303,6 +303,7 @@ extension_trait! {
 
             #
             # }) }
+            ```
         "#]
         fn take_while<P>(self, predicate: P) -> TakeWhile<Self, P, Self::Item>
         where
@@ -397,9 +398,9 @@ extension_trait! {
             use async_std::stream;
 
             let v = stream::from_iter(vec![&1, &2, &3]);
-                
+
             let mut v_cloned = v.cloned();
-            
+
             assert_eq!(v_cloned.next().await, Some(1));
             assert_eq!(v_cloned.next().await, Some(2));
             assert_eq!(v_cloned.next().await, Some(3));

--- a/src/stream/stream/take_while.rs
+++ b/src/stream/stream/take_while.rs
@@ -45,10 +45,12 @@ where
         let next = futures_core::ready!(this.stream.poll_next(cx));
 
         match next {
-            Some(v) if (this.predicate)(&v) => Poll::Ready(Some(v)),
-            Some(_) => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
+            Some(v) => {
+                if (this.predicate)(&v) {
+                    Poll::Ready(Some(v))
+                } else {
+                    Poll::Ready(None)
+                }
             }
             None => Poll::Ready(None),
         }


### PR DESCRIPTION
When the predicate is false, the stream should be ended.

cc @yoshuawuyts 