### PR TITLE
Cleanup stream module

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -19,8 +19,8 @@
 //! [`File`]s:
 //!
 //! ```no_run
-//! use async_std::prelude::*;
 //! use async_std::fs::File;
+//! use async_std::prelude::*;
 //!
 //! # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 //! #
@@ -47,9 +47,9 @@
 //! coming from:
 //!
 //! ```no_run
-//! use async_std::io::prelude::*;
-//! use async_std::io::SeekFrom;
 //! use async_std::fs::File;
+//! use async_std::io::SeekFrom;
+//! use async_std::prelude::*;
 //!
 //! # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 //! #
@@ -82,9 +82,9 @@
 //! methods to any reader:
 //!
 //! ```no_run
-//! use async_std::io::prelude::*;
-//! use async_std::io::BufReader;
 //! use async_std::fs::File;
+//! use async_std::io::BufReader;
+//! use async_std::prelude::*;
 //!
 //! # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 //! #
@@ -104,9 +104,9 @@
 //! to [`write`][`Write::write`]:
 //!
 //! ```no_run
-//! use async_std::io::prelude::*;
-//! use async_std::io::BufWriter;
 //! use async_std::fs::File;
+//! use async_std::io::BufWriter;
+//! use async_std::io::prelude::*;
 //!
 //! # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 //! #
@@ -179,9 +179,9 @@
 //! lines:
 //!
 //! ```no_run
-//! use async_std::prelude::*;
-//! use async_std::io::BufReader;
 //! use async_std::fs::File;
+//! use async_std::io::BufReader;
+//! use async_std::prelude::*;
 //!
 //! # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
 //! #

--- a/src/stream/extend.rs
+++ b/src/stream/extend.rs
@@ -65,10 +65,10 @@ pub trait Extend<A> {
 /// ```
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
-pub async fn extend<'a, C, A, T>(collection: &mut C, stream: T)
+pub async fn extend<'a, C, T, S>(collection: &mut C, stream: S)
 where
-    C: Extend<A>,
-    T: IntoStream<Item = A> + 'a,
+    C: Extend<T>,
+    S: IntoStream<Item = T> + 'a,
 {
     Extend::extend(collection, stream).await
 }

--- a/src/stream/from_fn.rs
+++ b/src/stream/from_fn.rs
@@ -28,7 +28,6 @@ impl<F> Unpin for FromFn<F> {}
 /// #
 /// use async_std::prelude::*;
 /// use async_std::stream;
-/// use async_std::sync::{Arc, Mutex};
 ///
 /// let mut count = 0u8;
 /// let s = stream::from_fn(|| {

--- a/src/stream/from_iter.rs
+++ b/src/stream/from_iter.rs
@@ -6,7 +6,7 @@ use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
 pin_project! {
-    /// A stream that created from iterator
+    /// A stream that was created from iterator.
     ///
     /// This stream is created by the [`from_iter`] function.
     /// See it documentation for more.

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -306,9 +306,7 @@ pub use from_iter::{from_iter, FromIter};
 pub use once::{once, Once};
 pub use repeat::{repeat, Repeat};
 pub use repeat_with::{repeat_with, RepeatWith};
-pub use stream::{
-    Chain, Filter, Fuse, Inspect, Scan, Skip, SkipWhile, StepBy, Stream, Take, TakeWhile, Zip,
-};
+pub use stream::*;
 
 pub(crate) mod stream;
 

--- a/src/stream/once.rs
+++ b/src/stream/once.rs
@@ -33,7 +33,7 @@ pin_project! {
     /// documentation for more.
     ///
     /// [`once`]: fn.once.html
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     pub struct Once<T> {
         value: Option<T>,
     }

--- a/src/stream/repeat.rs
+++ b/src/stream/repeat.rs
@@ -33,7 +33,7 @@ where
 /// documentation for more.
 ///
 /// [`repeat`]: fn.repeat.html
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Repeat<T> {
     item: T,
 }

--- a/src/stream/repeat_with.rs
+++ b/src/stream/repeat_with.rs
@@ -1,27 +1,20 @@
-use std::marker::PhantomData;
 use std::pin::Pin;
-use std::future::Future;
-
-use pin_project_lite::pin_project;
 
 use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
-pin_project! {
-    /// A stream that repeats elements of type `T` endlessly by applying a provided closure.
-    ///
-    /// This stream is created by the [`repeat_with`] function. See its
-    /// documentation for more.
-    ///
-    /// [`repeat_with`]: fn.repeat_with.html
-    #[derive(Debug)]
-    pub struct RepeatWith<F, Fut, A> {
-        f: F,
-        #[pin]
-        future: Option<Fut>,
-        __a: PhantomData<A>,
-    }
+/// A stream that repeats elements of type `T` endlessly by applying a provided closure.
+///
+/// This stream is created by the [`repeat_with`] function. See its
+/// documentation for more.
+///
+/// [`repeat_with`]: fn.repeat_with.html
+#[derive(Clone, Debug)]
+pub struct RepeatWith<F> {
+    f: F,
 }
+
+impl<F> Unpin for RepeatWith<F> {}
 
 /// Creates a new stream that repeats elements of type `A` endlessly by applying the provided closure.
 ///
@@ -35,7 +28,7 @@ pin_project! {
 /// use async_std::prelude::*;
 /// use async_std::stream;
 ///
-/// let s = stream::repeat_with(|| async { 1 });
+/// let s = stream::repeat_with(|| 1);
 ///
 /// pin_utils::pin_mut!(s);
 ///
@@ -54,48 +47,38 @@ pin_project! {
 /// use async_std::prelude::*;
 /// use async_std::stream;
 ///
-/// let s = stream::repeat_with(|| async { 1u8 }).take(2);
+/// let mut n = 1;
+/// let s = stream::repeat_with(|| {
+///     let item = n;
+///     n *= 2;
+///     item
+/// })
+/// .take(4);
 ///
 /// pin_utils::pin_mut!(s);
 ///
 /// assert_eq!(s.next().await, Some(1));
-/// assert_eq!(s.next().await, Some(1));
+/// assert_eq!(s.next().await, Some(2));
+/// assert_eq!(s.next().await, Some(4));
+/// assert_eq!(s.next().await, Some(8));
 /// assert_eq!(s.next().await, None);
 /// # })
 /// ```
-pub fn repeat_with<F, Fut, A>(repeater: F) -> RepeatWith<F, Fut, A>
+pub fn repeat_with<T, F>(repeater: F) -> RepeatWith<F>
 where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = A>,
+    F: FnMut() -> T,
 {
-    RepeatWith {
-        f: repeater,
-        future: None,
-        __a: PhantomData,
-    }
+    RepeatWith { f: repeater }
 }
 
-impl<F, Fut, A> Stream for RepeatWith<F, Fut, A>
+impl<T, F> Stream for RepeatWith<F>
 where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = A>,
+    F: FnMut() -> T,
 {
-    type Item = A;
+    type Item = T;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut this = self.project();
-        loop {
-            if this.future.is_some() {
-                let res = futures_core::ready!(this.future.as_mut().as_pin_mut().unwrap().poll(cx));
-
-                this.future.set(None);
-
-                return Poll::Ready(Some(res));
-            } else {
-                let fut = (this.f)();
-
-                this.future.set(Some(fut));
-            }
-        }
+    fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let item = (&mut self.f)();
+        Poll::Ready(Some(item))
     }
 }

--- a/src/stream/stream/chain.rs
+++ b/src/stream/stream/chain.rs
@@ -7,7 +7,7 @@ use crate::prelude::*;
 use crate::task::{Context, Poll};
 
 pin_project! {
-    /// Chains two streams one after another.
+    /// A stream that chains two streams one after another.
     ///
     /// This `struct` is created by the [`chain`] method on [`Stream`]. See its
     /// documentation for more.

--- a/src/stream/stream/cloned.rs
+++ b/src/stream/stream/cloned.rs
@@ -4,6 +4,7 @@ use pin_project_lite::pin_project;
 use std::pin::Pin;
 
 pin_project! {
+    /// A stream that clones the elements of an underlying stream.
     #[derive(Debug)]
     pub struct Cloned<S> {
         #[pin]

--- a/src/stream/stream/copied.rs
+++ b/src/stream/stream/copied.rs
@@ -4,8 +4,8 @@ use pin_project_lite::pin_project;
 use std::pin::Pin;
 
 pin_project! {
-    #[doc(hidden)]
-    #[allow(missing_debug_implementations)]
+    /// A stream that copies the elements of an underlying stream.
+    #[derive(Debug)]
     pub struct Copied<S> {
         #[pin]
         stream: S,

--- a/src/stream/stream/enumerate.rs
+++ b/src/stream/stream/enumerate.rs
@@ -6,8 +6,7 @@ use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
 pin_project! {
-    #[doc(hidden)]
-    #[allow(missing_debug_implementations)]
+    #[derive(Debug)]
     pub struct Enumerate<S> {
         #[pin]
         stream: S,

--- a/src/stream/stream/filter.rs
+++ b/src/stream/stream/filter.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::pin::Pin;
 
 use pin_project_lite::pin_project;
@@ -15,25 +14,23 @@ pin_project! {
     /// [`filter`]: trait.Stream.html#method.filter
     /// [`Stream`]: trait.Stream.html
     #[derive(Debug)]
-    pub struct Filter<S, P, T> {
+    pub struct Filter<S, P> {
         #[pin]
         stream: S,
         predicate: P,
-        __t: PhantomData<T>,
     }
 }
 
-impl<S, P, T> Filter<S, P, T> {
+impl<S, P> Filter<S, P> {
     pub(super) fn new(stream: S, predicate: P) -> Self {
         Filter {
             stream,
             predicate,
-            __t: PhantomData,
         }
     }
 }
 
-impl<S, P> Stream for Filter<S, P, S::Item>
+impl<S, P> Stream for Filter<S, P>
 where
     S: Stream,
     P: FnMut(&S::Item) -> bool,

--- a/src/stream/stream/filter_map.rs
+++ b/src/stream/stream/filter_map.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -7,29 +6,21 @@ use pin_project_lite::pin_project;
 use crate::stream::Stream;
 
 pin_project! {
-    #[doc(hidden)]
-    #[allow(missing_debug_implementations)]
-    pub struct FilterMap<S, F, T, B> {
+    #[derive(Debug)]
+    pub struct FilterMap<S, F> {
         #[pin]
         stream: S,
         f: F,
-        __from: PhantomData<T>,
-        __to: PhantomData<B>,
     }
 }
 
-impl<S, F, T, B> FilterMap<S, F, T, B> {
+impl<S, F> FilterMap<S, F> {
     pub(crate) fn new(stream: S, f: F) -> Self {
-        FilterMap {
-            stream,
-            f,
-            __from: PhantomData,
-            __to: PhantomData,
-        }
+        FilterMap { stream, f }
     }
 }
 
-impl<S, F, B> Stream for FilterMap<S, F, S::Item, B>
+impl<S, F, B> Stream for FilterMap<S, F>
 where
     S: Stream,
     F: FnMut(S::Item) -> Option<B>,

--- a/src/stream/stream/find.rs
+++ b/src/stream/stream/find.rs
@@ -1,31 +1,25 @@
-use std::marker::PhantomData;
-use std::pin::Pin;
 use std::future::Future;
+use std::pin::Pin;
 
 use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]
-pub struct FindFuture<'a, S, P, T> {
+pub struct FindFuture<'a, S, P> {
     stream: &'a mut S,
     p: P,
-    __t: PhantomData<T>,
 }
 
-impl<'a, S, P, T> FindFuture<'a, S, P, T> {
+impl<'a, S, P> FindFuture<'a, S, P> {
     pub(super) fn new(stream: &'a mut S, p: P) -> Self {
-        FindFuture {
-            stream,
-            p,
-            __t: PhantomData,
-        }
+        FindFuture { stream, p }
     }
 }
 
-impl<S: Unpin, P, T> Unpin for FindFuture<'_, S, P, T> {}
+impl<S: Unpin, P> Unpin for FindFuture<'_, S, P> {}
 
-impl<'a, S, P> Future for FindFuture<'a, S, P, S::Item>
+impl<'a, S, P> Future for FindFuture<'a, S, P>
 where
     S: Stream + Unpin + Sized,
     P: FnMut(&S::Item) -> bool,

--- a/src/stream/stream/find_map.rs
+++ b/src/stream/stream/find_map.rs
@@ -1,33 +1,25 @@
-use std::marker::PhantomData;
+use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::future::Future;
 
 use crate::stream::Stream;
 
 #[doc(hidden)]
 #[allow(missing_debug_implementations)]
-pub struct FindMapFuture<'a, S, F, T, B> {
+pub struct FindMapFuture<'a, S, F> {
     stream: &'a mut S,
     f: F,
-    __b: PhantomData<B>,
-    __t: PhantomData<T>,
 }
 
-impl<'a, S, B, F, T> FindMapFuture<'a, S, F, T, B> {
+impl<'a, S, F> FindMapFuture<'a, S, F> {
     pub(super) fn new(stream: &'a mut S, f: F) -> Self {
-        FindMapFuture {
-            stream,
-            f,
-            __b: PhantomData,
-            __t: PhantomData,
-        }
+        FindMapFuture { stream, f }
     }
 }
 
-impl<S: Unpin, F, T, B> Unpin for FindMapFuture<'_, S, F, T, B> {}
+impl<S: Unpin, F> Unpin for FindMapFuture<'_, S, F> {}
 
-impl<'a, S, B, F> Future for FindMapFuture<'a, S, F, S::Item, B>
+impl<'a, S, B, F> Future for FindMapFuture<'a, S, F>
 where
     S: Stream + Unpin + Sized,
     F: FnMut(S::Item) -> Option<B>,

--- a/src/stream/stream/flat_map.rs
+++ b/src/stream/stream/flat_map.rs
@@ -1,5 +1,6 @@
-use pin_project_lite::pin_project;
 use std::pin::Pin;
+
+use pin_project_lite::pin_project;
 
 use crate::prelude::*;
 use crate::stream::stream::map::Map;
@@ -7,27 +8,29 @@ use crate::stream::{IntoStream, Stream};
 use crate::task::{Context, Poll};
 
 pin_project! {
+    /// A stream that maps each element to a stream, and yields the elements of the produced
+    /// streams.
+    ///
     /// This `struct` is created by the [`flat_map`] method on [`Stream`]. See its
     /// documentation for more.
     ///
     /// [`flat_map`]: trait.Stream.html#method.flat_map
     /// [`Stream`]: trait.Stream.html
-    #[allow(missing_debug_implementations)]
-    pub struct FlatMap<S, U, T, F> {
+    pub struct FlatMap<S, U, F> {
         #[pin]
-        stream: Map<S, F, T, U>,
+        stream: Map<S, F>,
         #[pin]
         inner_stream: Option<U>,
     }
 }
 
-impl<S, U, F> FlatMap<S, U, S::Item, F>
+impl<S, U, F> FlatMap<S, U, F>
 where
     S: Stream,
     U: IntoStream,
     F: FnMut(S::Item) -> U,
 {
-    pub(super) fn new(stream: S, f: F) -> FlatMap<S, U, S::Item, F> {
+    pub(super) fn new(stream: S, f: F) -> FlatMap<S, U, F> {
         FlatMap {
             stream: stream.map(f),
             inner_stream: None,
@@ -35,7 +38,7 @@ where
     }
 }
 
-impl<S, U, F> Stream for FlatMap<S, U, S::Item, F>
+impl<S, U, F> Stream for FlatMap<S, U, F>
 where
     S: Stream,
     S::Item: IntoStream<IntoStream = U, Item = U::Item>,

--- a/src/stream/stream/fold.rs
+++ b/src/stream/stream/fold.rs
@@ -1,6 +1,5 @@
-use std::marker::PhantomData;
-use std::pin::Pin;
 use std::future::Future;
+use std::pin::Pin;
 
 use pin_project_lite::pin_project;
 
@@ -8,29 +7,26 @@ use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
 pin_project! {
-    #[doc(hidden)]
-    #[allow(missing_debug_implementations)]
-    pub struct FoldFuture<S, F, T, B> {
+    #[derive(Debug)]
+    pub struct FoldFuture<S, F, B> {
         #[pin]
         stream: S,
         f: F,
         acc: Option<B>,
-        __t: PhantomData<T>,
     }
 }
 
-impl<S, F, T, B> FoldFuture<S, F, T, B> {
+impl<S, F, B> FoldFuture<S, F, B> {
     pub(super) fn new(stream: S, init: B, f: F) -> Self {
         FoldFuture {
             stream,
             f,
             acc: Some(init),
-            __t: PhantomData,
         }
     }
 }
 
-impl<S, F, B> Future for FoldFuture<S, F, S::Item, B>
+impl<S, F, B> Future for FoldFuture<S, F, B>
 where
     S: Stream + Sized,
     F: FnMut(B, S::Item) -> B,

--- a/src/stream/stream/for_each.rs
+++ b/src/stream/stream/for_each.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::future::Future;
 
@@ -10,25 +9,23 @@ use crate::task::{Context, Poll};
 pin_project! {
     #[doc(hidden)]
     #[allow(missing_debug_implementations)]
-    pub struct ForEachFuture<S, F, T> {
+    pub struct ForEachFuture<S, F> {
         #[pin]
         stream: S,
         f: F,
-        __t: PhantomData<T>,
     }
 }
 
-impl<S, F, T> ForEachFuture<S, F, T> {
+impl<S, F> ForEachFuture<S, F> {
     pub(super) fn new(stream: S, f: F) -> Self {
         ForEachFuture {
             stream,
             f,
-            __t: PhantomData,
         }
     }
 }
 
-impl<S, F> Future for ForEachFuture<S, F, S::Item>
+impl<S, F> Future for ForEachFuture<S, F>
 where
     S: Stream + Sized,
     F: FnMut(S::Item),

--- a/src/stream/stream/inspect.rs
+++ b/src/stream/stream/inspect.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::pin::Pin;
 
 use pin_project_lite::pin_project;
@@ -15,25 +14,23 @@ pin_project! {
     /// [`inspect`]: trait.Stream.html#method.inspect
     /// [`Stream`]: trait.Stream.html
     #[derive(Debug)]
-    pub struct Inspect<S, F, T> {
+    pub struct Inspect<S, F> {
         #[pin]
         stream: S,
         f: F,
-        __t: PhantomData<T>,
     }
 }
 
-impl<S, F, T> Inspect<S, F, T> {
+impl<S, F> Inspect<S, F> {
     pub(super) fn new(stream: S, f: F) -> Self {
         Inspect {
             stream,
             f,
-            __t: PhantomData,
         }
     }
 }
 
-impl<S, F> Stream for Inspect<S, F, S::Item>
+impl<S, F> Stream for Inspect<S, F>
 where
     S: Stream,
     F: FnMut(&S::Item),

--- a/src/stream/stream/map.rs
+++ b/src/stream/stream/map.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::pin::Pin;
 
 use pin_project_lite::pin_project;
@@ -7,29 +6,25 @@ use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
 pin_project! {
-    #[doc(hidden)]
-    #[allow(missing_debug_implementations)]
-    pub struct Map<S, F, T, B> {
+    /// A stream that maps value of another stream with a function.
+    #[derive(Debug)]
+    pub struct Map<S, F> {
         #[pin]
         stream: S,
         f: F,
-        __from: PhantomData<T>,
-        __to: PhantomData<B>,
     }
 }
 
-impl<S, F, T, B> Map<S, F, T, B> {
+impl<S, F> Map<S, F> {
     pub(crate) fn new(stream: S, f: F) -> Self {
         Map {
             stream,
             f,
-            __from: PhantomData,
-            __to: PhantomData,
         }
     }
 }
 
-impl<S, F, B> Stream for Map<S, F, S::Item, B>
+impl<S, F, B> Stream for Map<S, F>
 where
     S: Stream,
     F: FnMut(S::Item) -> B,

--- a/src/stream/stream/skip_while.rs
+++ b/src/stream/stream/skip_while.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::pin::Pin;
 
 use pin_project_lite::pin_project;
@@ -15,25 +14,23 @@ pin_project! {
     /// [`skip_while`]: trait.Stream.html#method.skip_while
     /// [`Stream`]: trait.Stream.html
     #[derive(Debug)]
-    pub struct SkipWhile<S, P, T> {
+    pub struct SkipWhile<S, P> {
         #[pin]
         stream: S,
         predicate: Option<P>,
-        __t: PhantomData<T>,
     }
 }
 
-impl<S, P, T> SkipWhile<S, P, T> {
+impl<S, P> SkipWhile<S, P> {
     pub(crate) fn new(stream: S, predicate: P) -> Self {
         SkipWhile {
             stream,
             predicate: Some(predicate),
-            __t: PhantomData,
         }
     }
 }
 
-impl<S, P> Stream for SkipWhile<S, P, S::Item>
+impl<S, P> Stream for SkipWhile<S, P>
 where
     S: Stream,
     P: FnMut(&S::Item) -> bool,

--- a/src/stream/stream/take_while.rs
+++ b/src/stream/stream/take_while.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::pin::Pin;
 
 use pin_project_lite::pin_project;
@@ -15,25 +14,23 @@ pin_project! {
     /// [`take_while`]: trait.Stream.html#method.take_while
     /// [`Stream`]: trait.Stream.html
     #[derive(Debug)]
-    pub struct TakeWhile<S, P, T> {
+    pub struct TakeWhile<S, P> {
         #[pin]
         stream: S,
         predicate: P,
-        __t: PhantomData<T>,
     }
 }
 
-impl<S, P, T> TakeWhile<S, P, T> {
+impl<S, P> TakeWhile<S, P> {
     pub(super) fn new(stream: S, predicate: P) -> Self {
         TakeWhile {
             stream,
             predicate,
-            __t: PhantomData,
         }
     }
 }
 
-impl<S, P> Stream for TakeWhile<S, P, S::Item>
+impl<S, P> Stream for TakeWhile<S, P>
 where
     S: Stream,
     P: FnMut(&S::Item) -> bool,

--- a/src/stream/stream/timeout.rs
+++ b/src/stream/stream/timeout.rs
@@ -22,7 +22,7 @@ pin_project! {
 }
 
 impl<S: Stream> Timeout<S> {
-    pub fn new(stream: S, dur: Duration) -> Timeout<S> {
+    pub(crate) fn new(stream: S, dur: Duration) -> Timeout<S> {
         let delay = Delay::new(dur);
 
         Timeout { stream, delay }

--- a/src/stream/stream/try_fold.rs
+++ b/src/stream/stream/try_fold.rs
@@ -1,58 +1,51 @@
-use std::marker::PhantomData;
 use std::pin::Pin;
-use std::future::Future;
 
-use pin_project_lite::pin_project;
-
+use crate::future::Future;
 use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
-pin_project! {
-    #[doc(hidden)]
-    #[allow(missing_debug_implementations)]
-    pub struct TryFoldFuture<S, F, T> {
-        #[pin]
-        stream: S,
-        f: F,
-        acc: Option<T>,
-        __t: PhantomData<T>,
-    }
+#[doc(hidden)]
+#[allow(missing_debug_implementations)]
+pub struct TryFoldFuture<'a, S, F, T> {
+    stream: &'a mut S,
+    f: F,
+    acc: Option<T>,
 }
 
-impl<S, F, T> TryFoldFuture<S, F, T> {
-    pub(super) fn new(stream: S, init: T, f: F) -> Self {
+impl<'a, S, F, T> Unpin for TryFoldFuture<'a, S, F, T> {}
+
+impl<'a, S, F, T> TryFoldFuture<'a, S, F, T> {
+    pub(super) fn new(stream: &'a mut S, init: T, f: F) -> Self {
         TryFoldFuture {
             stream,
             f,
             acc: Some(init),
-            __t: PhantomData,
         }
     }
 }
 
-impl<S, F, T, E> Future for TryFoldFuture<S, F, T>
+impl<'a, S, F, T, E> Future for TryFoldFuture<'a, S, F, T>
 where
-    S: Stream + Sized,
+    S: Stream + Unpin,
     F: FnMut(T, S::Item) -> Result<T, E>,
 {
     type Output = Result<T, E>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut this = self.project();
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
-            let next = futures_core::ready!(this.stream.as_mut().poll_next(cx));
+            let next = futures_core::ready!(Pin::new(&mut self.stream).poll_next(cx));
 
             match next {
                 Some(v) => {
-                    let old = this.acc.take().unwrap();
-                    let new = (this.f)(old, v);
+                    let old = self.acc.take().unwrap();
+                    let new = (&mut self.f)(old, v);
 
                     match new {
-                        Ok(o) => *this.acc = Some(o),
+                        Ok(o) => self.acc = Some(o),
                         Err(e) => return Poll::Ready(Err(e)),
                     }
                 }
-                None => return Poll::Ready(Ok(this.acc.take().unwrap())),
+                None => return Poll::Ready(Ok(self.acc.take().unwrap())),
             }
         }
     }

--- a/src/stream/stream/try_for_each.rs
+++ b/src/stream/stream/try_for_each.rs
@@ -1,52 +1,39 @@
 use std::future::Future;
-use std::marker::PhantomData;
 use std::pin::Pin;
-
-use pin_project_lite::pin_project;
 
 use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
-pin_project! {
-    #[doc(hidden)]
-    #[allow(missing_debug_implementations)]
-    pub struct TryForEachFuture<S, F, T, R> {
-        #[pin]
-        stream: S,
-        f: F,
-        __from: PhantomData<T>,
-        __to: PhantomData<R>,
+#[doc(hidden)]
+#[allow(missing_debug_implementations)]
+pub struct TryForEachFuture<'a, S, F> {
+    stream: &'a mut S,
+    f: F,
+}
+
+impl<'a, S, F> Unpin for TryForEachFuture<'a, S, F> {}
+
+impl<'a, S, F> TryForEachFuture<'a, S, F> {
+    pub(crate) fn new(stream: &'a mut S, f: F) -> Self {
+        TryForEachFuture { stream, f }
     }
 }
 
-impl<S, F, T, R> TryForEachFuture<S, F, T, R> {
-    pub(crate) fn new(stream: S, f: F) -> Self {
-        TryForEachFuture {
-            stream,
-            f,
-            __from: PhantomData,
-            __to: PhantomData,
-        }
-    }
-}
-
-impl<S, F, E> Future for TryForEachFuture<S, F, S::Item, E>
+impl<'a, S, F, E> Future for TryForEachFuture<'a, S, F>
 where
-    S: Stream,
-    S::Item: std::fmt::Debug,
+    S: Stream + Unpin,
     F: FnMut(S::Item) -> Result<(), E>,
 {
     type Output = Result<(), E>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut this = self.project();
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
-            let item = futures_core::ready!(this.stream.as_mut().poll_next(cx));
+            let item = futures_core::ready!(Pin::new(&mut self.stream).poll_next(cx));
 
             match item {
                 None => return Poll::Ready(Ok(())),
                 Some(v) => {
-                    let res = (this.f)(v);
+                    let res = (&mut self.f)(v);
                     if let Err(e) = res {
                         return Poll::Ready(Err(e));
                     }

--- a/src/stream/stream/zip.rs
+++ b/src/stream/stream/zip.rs
@@ -7,7 +7,7 @@ use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
 pin_project! {
-    /// An iterator that iterates two other iterators simultaneously.
+    /// A stream that takes items from two other streams simultaneously.
     ///
     /// This `struct` is created by the [`zip`] method on [`Stream`]. See its
     /// documentation for more.


### PR DESCRIPTION
* Changed `from_fn` and `repeat_with` to take regular closures.
* Changed some stream methods to take `&mut self` rather than `self` in order to match `Iterator`.
* Added missing `Clone` and `Debug` impls.
* Added missing stream struct exports.
* Simplified stream types and changed them to match iterator types.
* Changed the implementation of `cycle()` to match how iterators work.
* Doc fixes, formatting, etc.