### PR TITLE
Correct a typo on the async-std version

### DIFF
--- a/docs/src/tutorial/specification.md
+++ b/docs/src/tutorial/specification.md
@@ -51,5 +51,5 @@ Add the following lines to `Cargo.toml`:
 ```toml
 [dependencies]
 futures = "0.3.0"
-async-std = "1.00"
+async-std = "1.0.0"
 ```


### PR DESCRIPTION
Correct a typo on the async-std version in the Cargo.toml file of the documentation.