### PR TITLE
Improve thread startup/shutdown algorithm in spawn_blocking

### DIFF
--- a/src/task/spawn_blocking.rs
+++ b/src/task/spawn_blocking.rs
@@ -68,7 +68,7 @@ static POOL: Lazy<Pool> = Lazy::new(|| {
 
 fn start_thread() {
     SLEEPING.fetch_add(1, Ordering::SeqCst);
-    let timeout = Duration::from_secs(10);
+    let timeout = Duration::from_secs(1);
 
     thread::Builder::new()
         .name("async-std/blocking".to_string())

--- a/src/task/spawn_blocking.rs
+++ b/src/task/spawn_blocking.rs
@@ -6,7 +6,7 @@ use crossbeam_channel::{unbounded, Receiver, Sender};
 use once_cell::sync::Lazy;
 
 use crate::task::{JoinHandle, Task};
-use crate::utils::{abort_on_panic, random};
+use crate::utils::abort_on_panic;
 
 /// Spawns a blocking task.
 ///


### PR DESCRIPTION
This PR changes the algorithm so that we don't accidentally end up with a lot of long-running threads. The new strategy is to aggressively shut down blocking threads if there are many of them waiting for work.