### PR TITLE
Add proof of concept serde support with PathBuf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,14 @@ default = [
   "mio-uds",
   "num_cpus",
   "pin-project-lite",
+  "serde-remotes",
 ]
 docs = ["attributes", "unstable"]
 unstable = ["default", "broadcaster"]
 attributes = ["async-attributes"]
+serde-support = [
+  "serde",
+]
 std = [
   "async-macros",
   "crossbeam-utils",
@@ -70,6 +74,7 @@ once_cell = { version = "1.2.0", optional = true }
 pin-project-lite = { version = "0.1", optional = true }
 pin-utils = { version = "0.1.0-alpha.4", optional = true }
 slab = { version = "0.4.2", optional = true }
+serde = { version = "1.0.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 femme = "1.2.0"

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -13,12 +13,16 @@ use crate::path::Path;
 use crate::prelude::*;
 #[cfg(feature = "unstable")]
 use crate::stream::{self, FromStream, IntoStream};
+#[cfg(feature = "serde-support")]
+use serde::{Serialize, Deserialize};
 
 /// This struct is an async version of [`std::path::PathBuf`].
 ///
 /// [`std::path::Path`]: https://doc.rust-lang.org/std/path/struct.PathBuf.html
+#[cfg_attr(feature = "serde-support", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PathBuf {
+    #[cfg_attr(feature = "serde-support", serde(flatten))]
     inner: std::path::PathBuf,
 }
 


### PR DESCRIPTION
This is a proof of concept for supporting types from `async_std` to be used with Serde. For now I have only implemented support for PathBuf, but if you like this, we can start rolling it out to all of the wrapped types.

```rust
// src/lib.rs:
use async_std;
use serde::{self, Serialize, Deserialize};

#[derive(Serialize, Deserialize)]
struct Hmmm {
    ex: async_std::path::PathBuf,
}

fn main() {
    println!("Hello, world!");
}
```

```toml
# Cargo.toml
[package]
name = "serde-ex"
version = "0.1.0"
authors = ["James Munns <james.munns@ferrous-systems.com>"]
edition = "2018"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[dependencies.async-std]
version = "1.0"
path = "../async-std"

[dependencies.serde]
features = ["derive"]
version = "1.0"
```
