### PR TITLE
stabilize task::yield_now

### DIFF
--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -124,6 +124,9 @@ cfg_std! {
 
     #[doc(inline)]
     pub use async_macros::ready;
+
+    pub use yield_now::yield_now;
+    mod yield_now;
 }
 
 cfg_default! {
@@ -156,9 +159,4 @@ cfg_default! {
     pub use spawn_blocking::spawn_blocking;
     #[cfg(not(any(feature = "unstable", test)))]
     pub(crate) use spawn_blocking::spawn_blocking;
-}
-
-cfg_unstable! {
-    pub use yield_now::yield_now;
-    mod yield_now;
 }

--- a/src/task/yield_now.rs
+++ b/src/task/yield_now.rs
@@ -26,8 +26,6 @@ use crate::task::{Context, Poll};
 /// #
 /// # })
 /// ```
-#[cfg(feature = "unstable")]
-#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[inline]
 pub async fn yield_now() {
     YieldNow(false).await


### PR DESCRIPTION
Stabilize `task::yield_now`. It doesn't perform any io, and doesn't rely on any reactor implementations either, so it can be stabilized as part of the `std` feature. Thanks!