### PR TITLE
upgrade async-macros to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ std = [
 
 [dependencies]
 async-attributes = { version = "1.1.0", optional = true }
-async-macros = { version = "1.0.0", optional = true }
+async-macros = { version = "2.0.0", optional = true }
 async-task = { version = "1.0.0", optional = true }
 broadcaster = { version = "0.2.6", optional = true, default-features = false, features = ["default-channels"] }
 crossbeam-channel = { version = "0.3.9", optional = true }


### PR DESCRIPTION
Ref https://github.com/async-rs/async-macros/issues/8. Updates async-macros to v2.0.0, removing the last `futures-preview` deps from our tree. Thanks!

This is a patch-level change.