### PR TITLE
add mutex benches vs std + parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ crossbeam-deque = { version = "0.7.1", optional = true }
 crossbeam-utils = { version = "0.6.6", optional = true }
 futures-core = { version = "0.3.0", optional = true }
 futures-io = { version = "0.3.0", optional = true }
-futures-timer = { version = "1.0.2", optional = true }
+futures-timer = { version = "2.0.0", optional = true }
 kv-log-macro = { version = "1.0.4", optional = true }
 log = { version = "0.4.8", features = ["kv_unstable"], optional = true }
 memchr = { version = "2.2.1", optional = true }
@@ -73,10 +73,11 @@ slab = { version = "0.4.2", optional = true }
 
 [dev-dependencies]
 femme = "1.2.0"
+futures = "0.3.0"
+parking_lot = "0.9.0"
 rand = "0.7.2"
 surf = "1.0.3"
 tempdir = "0.3.7"
-futures = "0.3.0"
 
 [[test]]
 name = "stream"

--- a/benches/mutex.rs
+++ b/benches/mutex.rs
@@ -41,7 +41,7 @@ mod async_std {
     }
 }
 
- mod std {
+mod std {
     extern crate test;
 
     use std::sync::{Arc, Mutex};
@@ -80,13 +80,13 @@ mod async_std {
             t.join().unwrap();
         }
     }
- }
+}
 
- mod parking_lot {
+mod parking_lot {
     extern crate test;
 
-    use std::sync::Arc;
     use parking_lot::Mutex;
+    use std::sync::Arc;
     use std::thread;
     use test::Bencher;
 
@@ -122,4 +122,4 @@ mod async_std {
             t.join().unwrap();
         }
     }
- }
+}

--- a/benches/mutex.rs
+++ b/benches/mutex.rs
@@ -1,40 +1,125 @@
 #![feature(test)]
 
-extern crate test;
+mod async_std {
+    extern crate test;
 
-use async_std::sync::{Arc, Mutex};
-use async_std::task;
-use test::Bencher;
+    use async_std::sync::{Arc, Mutex};
+    use async_std::task;
+    use test::Bencher;
 
-#[bench]
-fn create(b: &mut Bencher) {
-    b.iter(|| Mutex::new(()));
-}
-
-#[bench]
-fn contention(b: &mut Bencher) {
-    b.iter(|| task::block_on(run(10, 1000)));
-}
-
-#[bench]
-fn no_contention(b: &mut Bencher) {
-    b.iter(|| task::block_on(run(1, 10000)));
-}
-
-async fn run(task: usize, iter: usize) {
-    let m = Arc::new(Mutex::new(()));
-    let mut tasks = Vec::new();
-
-    for _ in 0..task {
-        let m = m.clone();
-        tasks.push(task::spawn(async move {
-            for _ in 0..iter {
-                let _ = m.lock().await;
-            }
-        }));
+    #[bench]
+    fn create(b: &mut Bencher) {
+        b.iter(|| Mutex::new(()));
     }
 
-    for t in tasks {
-        t.await;
+    #[bench]
+    fn contention(b: &mut Bencher) {
+        b.iter(|| task::block_on(run(10, 1000)));
+    }
+
+    #[bench]
+    fn no_contention(b: &mut Bencher) {
+        b.iter(|| task::block_on(run(1, 10000)));
+    }
+
+    async fn run(task: usize, iter: usize) {
+        let m = Arc::new(Mutex::new(()));
+        let mut tasks = Vec::new();
+
+        for _ in 0..task {
+            let m = m.clone();
+            tasks.push(task::spawn(async move {
+                for _ in 0..iter {
+                    let _ = m.lock().await;
+                }
+            }));
+        }
+
+        for t in tasks {
+            t.await;
+        }
     }
 }
+
+ mod std {
+    extern crate test;
+
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use test::Bencher;
+
+    #[bench]
+    fn create(b: &mut Bencher) {
+        b.iter(|| Mutex::new(()));
+    }
+
+    #[bench]
+    fn contention(b: &mut Bencher) {
+        b.iter(|| run(10, 1000));
+    }
+
+    #[bench]
+    fn no_contention(b: &mut Bencher) {
+        b.iter(|| run(1, 10000));
+    }
+
+    fn run(thread: usize, iter: usize) {
+        let m = Arc::new(Mutex::new(()));
+        let mut threads = Vec::new();
+
+        for _ in 0..thread {
+            let m = m.clone();
+            threads.push(thread::spawn(move || {
+                for _ in 0..iter {
+                    let _ = m.lock().unwrap();
+                }
+            }));
+        }
+
+        for t in threads {
+            t.join().unwrap();
+        }
+    }
+ }
+
+ mod parking_lot {
+    extern crate test;
+
+    use std::sync::Arc;
+    use parking_lot::Mutex;
+    use std::thread;
+    use test::Bencher;
+
+    #[bench]
+    fn create(b: &mut Bencher) {
+        b.iter(|| Mutex::new(()));
+    }
+
+    #[bench]
+    fn contention(b: &mut Bencher) {
+        b.iter(|| run(10, 1000));
+    }
+
+    #[bench]
+    fn no_contention(b: &mut Bencher) {
+        b.iter(|| run(1, 10000));
+    }
+
+    fn run(thread: usize, iter: usize) {
+        let m = Arc::new(Mutex::new(()));
+        let mut threads = Vec::new();
+
+        for _ in 0..thread {
+            let m = m.clone();
+            threads.push(thread::spawn(move || {
+                for _ in 0..iter {
+                    let _ = m.lock();
+                }
+            }));
+        }
+
+        for t in threads {
+            t.join().unwrap();
+        }
+    }
+ }


### PR DESCRIPTION
Entirely for fun, but sets us up against `std` and `parking_lot` mutexes, which will soon be the same thing. Figured it'd be nice to remind us of the baseline we're measuring against while benchmarking. Because it doesn't seem like perf will fluctuate much there.

Thanks!

## Sample Output

```txt
test async_std::contention      ... bench:     342,769 ns/iter (+/- 59,938)
test async_std::create          ... bench:           5 ns/iter (+/- 0)
test async_std::no_contention   ... bench:     576,119 ns/iter (+/- 9,641)
test parking_lot::contention    ... bench:     257,292 ns/iter (+/- 66,530)
test parking_lot::create        ... bench:           0 ns/iter (+/- 0)
test parking_lot::no_contention ... bench:     342,655 ns/iter (+/- 23,643)
test std::contention            ... bench:   1,560,041 ns/iter (+/- 733,017)
test std::create                ... bench:          24 ns/iter (+/- 1)
test std::no_contention         ... bench:     339,644 ns/iter (+/- 39,173)
test result: ok. 0 passed; 0 failed; 0 ignored; 9 measured; 0 filtered out
```
_note that "no contention" is never faster than "contention" because we're running 10x the amount of tasks. They cannot quite be compared (:_