### PR TITLE
Make ToSocketAddrsFuture available for pub use.

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -61,7 +61,7 @@ pub use std::net::Shutdown;
 pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 pub use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 
-pub use addr::ToSocketAddrs;
+pub use addr::{ToSocketAddrs, ToSocketAddrsFuture};
 pub use tcp::{Incoming, TcpListener, TcpStream};
 pub use udp::UdpSocket;
 


### PR DESCRIPTION
If we want to implement ToSocketAddrs for a custom type,
the ToSocketAddrsFuture should be pub use.

Signed-off-by: Hosun Zhu <hosun@linux.com>