### PR TITLE
update futures-timer & other deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,33 +50,33 @@ std = [
 ]
 
 [dependencies]
-async-attributes = { version = "1.1.0", optional = true }
+async-attributes = { version = "1.1.1", optional = true }
 async-macros = { version = "2.0.0", optional = true }
 async-task = { version = "1.0.0", optional = true }
 broadcaster = { version = "0.2.6", optional = true, default-features = false, features = ["default-channels"] }
-crossbeam-channel = { version = "0.3.9", optional = true }
-crossbeam-deque = { version = "0.7.1", optional = true }
-crossbeam-utils = { version = "0.6.6", optional = true }
-futures-core = { version = "0.3.0", optional = true }
-futures-io = { version = "0.3.0", optional = true }
+crossbeam-channel = { version = "0.4.0", optional = true }
+crossbeam-deque = { version = "0.7.2", optional = true }
+crossbeam-utils = { version = "0.7.0", optional = true }
+futures-core = { version = "0.3.1", optional = true }
+futures-io = { version = "0.3.1", optional = true }
 futures-timer = { version = "2.0.2", optional = true }
 kv-log-macro = { version = "1.0.4", optional = true }
 log = { version = "0.4.8", features = ["kv_unstable"], optional = true }
 memchr = { version = "2.2.1", optional = true }
 mio = { version = "0.6.19", optional = true }
 mio-uds = { version = "0.6.7", optional = true }
-num_cpus = { version = "1.10.1", optional = true }
+num_cpus = { version = "1.11.1", optional = true }
 once_cell = { version = "1.2.0", optional = true }
-pin-project-lite = { version = "0.1", optional = true }
+pin-project-lite = { version = "0.1.1", optional = true }
 pin-utils = { version = "0.1.0-alpha.4", optional = true }
 slab = { version = "0.4.2", optional = true }
 
 [dev-dependencies]
-femme = "1.2.0"
+femme = "1.3.0"
 rand = "0.7.2"
 surf = "1.0.3"
 tempdir = "0.3.7"
-futures = "0.3.0"
+futures = "0.3.1"
 
 [[test]]
 name = "stream"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ crossbeam-deque = { version = "0.7.1", optional = true }
 crossbeam-utils = { version = "0.6.6", optional = true }
 futures-core = { version = "0.3.0", optional = true }
 futures-io = { version = "0.3.0", optional = true }
-futures-timer = { version = "1.0.2", optional = true }
+futures-timer = { version = "2.0.2", optional = true }
 kv-log-macro = { version = "1.0.4", optional = true }
 log = { version = "0.4.8", features = ["kv_unstable"], optional = true }
 memchr = { version = "2.2.1", optional = true }


### PR DESCRIPTION
Updates futures-timer to `2.x`, removing some unneeded deps which should improve compile times. Also for good measure ran `cargo upgrade` to upgrade all other deps. Thanks!