### PR TITLE
mark windows fs APIs as "unstable"

### DIFF
--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -4,6 +4,6 @@ cfg_std! {
     pub mod io;
 }
 
-cfg_default! {
+cfg_unstable! {
     pub mod fs;
 }


### PR DESCRIPTION
Follow-up to https://github.com/async-rs/async-std/pull/552. Marks the new windows fs APIs as "unstable". Thanks!