### PR TITLE
Add ring benchmark example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,5 +83,9 @@ name = "stream"
 required-features = ["unstable"]
 
 [[example]]
+name = "ring-benchmark"
+required-features = ["unstable"]
+
+[[example]]
 name = "tcp-ipv4-and-6-echo"
 required-features = ["unstable"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,16 +1,17 @@
 # Examples
 
-This directory contains example code that makes use of `async-std`, each of which can be run from the command line.
+This directory contains example code that makes use of `async-std`, each of
+which can be run from the command line.
 
-##### [Hello World][hello-world]
+### [Hello World][hello-world]
 
 Spawns a task that says hello.
 
-```
+```shell
 cargo run --example hello-world
 ```
 
-##### [Line Count][line-count]
+### [Line Count][line-count]
 
 Counts the number of lines in a file given as an argument.
 
@@ -18,7 +19,7 @@ Counts the number of lines in a file given as an argument.
 cargo run --example line-count -- ./Cargo.toml
 ```
 
-##### [List Dir][list-dir]
+### [List Dir][list-dir]
 
 Lists files in a directory given as an argument.
 
@@ -26,7 +27,7 @@ Lists files in a directory given as an argument.
 cargo run --example list-dir -- .
 ```
 
-##### [Logging][logging]
+### [Logging][logging]
 
 Prints the runtime's execution log on the standard output.
 
@@ -34,7 +35,7 @@ Prints the runtime's execution log on the standard output.
 cargo run --example logging
 ```
 
-##### [Print File][print-file]
+### [Print File][print-file]
 
 Prints a file given as an argument to stdout.
 
@@ -42,7 +43,13 @@ Prints a file given as an argument to stdout.
 cargo run --example print-file ./Cargo.toml
 ```
 
-##### [Socket Timeouts][socket-timeouts]
+### [Ring Benchmark][ring-benchmark]
+
+```shell
+cargo run --release --features unstable --example ring-benchmark
+```
+
+### [Socket Timeouts][socket-timeouts]
 
 Prints response of GET request made to TCP server with 5 second socket timeout
 
@@ -50,7 +57,7 @@ Prints response of GET request made to TCP server with 5 second socket timeout
 cargo run --example socket-timeouts
 ```
 
-##### [Stdin Echo][stdin-echo]
+### [Stdin Echo][stdin-echo]
 
 Echoes lines read on stdin to stdout.
 
@@ -58,7 +65,7 @@ Echoes lines read on stdin to stdout.
 cargo run --example stdin-echo
 ```
 
-##### [Stdin Timeout][stdin-timeout]
+### [Stdin Timeout][stdin-timeout]
 
 Reads a line from stdin, or exits with an error if nothing is read in 5 seconds.
 
@@ -66,7 +73,7 @@ Reads a line from stdin, or exits with an error if nothing is read in 5 seconds.
 cargo run --example stdin-timeout
 ```
 
-##### [Surf Web][surf-web]
+### [Surf Web][surf-web]
 
 Sends an HTTP request to the Rust website.
 
@@ -74,7 +81,7 @@ Sends an HTTP request to the Rust website.
 cargo run --example surf-web
 ```
 
-##### [Task Local][task-local]
+### [Task Local][task-local]
 
 Creates a task-local value.
 
@@ -82,7 +89,7 @@ Creates a task-local value.
 cargo run --example task-local
 ```
 
-##### [Task Name][task-name]
+### [Task Name][task-name]
 
 Spawns a named task that prints its name.
 
@@ -90,9 +97,9 @@ Spawns a named task that prints its name.
 cargo run --example task-name
 ```
 
-##### [TCP Client][tcp-client]
+### [TCP Client][tcp-client]
 
-Connects to Localhost over TCP.
+Connects to localhost over TCP.
 
 First, start the echo server:
 
@@ -106,7 +113,7 @@ Then run the client:
 cargo run --example tcp-client
 ```
 
-##### [TCP Echo][tcp-echo]
+### [TCP Echo][tcp-echo]
 
 TCP echo server.
 
@@ -122,9 +129,25 @@ Make requests by running the client example:
 cargo run --example tcp-client
 ```
 
-##### [UDP Client][udp-client]
+### [TCP IPv4 and IPv6][tcp-ipv4-and-6-echo]
 
-Connects to Localhost over UDP.
+TCP echo server accepting connections both on both IPv4 and IPV6 sockets.
+
+Start the echo server:
+
+```shell
+cargo run --features unstable --example tcp-ipv4-and-6-echo
+```
+
+Make requests by running the client example:
+
+```shell
+cargo run --example tcp-client
+```
+
+### [UDP Client][udp-client]
+
+Connects to localhost over UDP.
 
 First, start the echo server:
 
@@ -138,7 +161,7 @@ Then run the client:
 cargo run --example udp-client
 ```
 
-##### [UDP Echo][udp-echo]
+### [UDP Echo][udp-echo]
 
 UDP echo server.
 
@@ -159,6 +182,7 @@ cargo run --example udp-client
 [list-dir]: https://github.com/async-rs/async-std/blob/master/examples/list-dir.rs
 [logging]: https://github.com/async-rs/async-std/blob/master/examples/logging.rs
 [print-file]: https://github.com/async-rs/async-std/blob/master/examples/print-file.rs
+[ring-benchmark]: https://github.com/async-rs/async-std/blob/master/examples/ring-benchmark.rs
 [socket-timeouts]: https://github.com/async-rs/async-std/blob/master/examples/socket-timeouts.rs
 [stdin-echo]: https://github.com/async-rs/async-std/blob/master/examples/stdin-echo.rs
 [stdin-timeout]: https://github.com/async-rs/async-std/blob/master/examples/stdin-timeout.rs
@@ -167,5 +191,6 @@ cargo run --example udp-client
 [task-name]: https://github.com/async-rs/async-std/blob/master/examples/task-name.rs
 [tcp-client]: https://github.com/async-rs/async-std/blob/master/examples/tcp-client.rs
 [tcp-echo]: https://github.com/async-rs/async-std/blob/master/examples/tcp-echo.rs
+[tcp-ipv4-and-6-echo]: https://github.com/async-rs/async-std/blob/master/examples/tcp-ipv4-and-6-echo.rs
 [udp-client]: https://github.com/async-rs/async-std/blob/master/examples/udp-client.rs
 [udp-echo]: https://github.com/async-rs/async-std/blob/master/examples/udp-echo.rs

--- a/examples/ring-benchmark.rs
+++ b/examples/ring-benchmark.rs
@@ -1,0 +1,88 @@
+//! Ring benchmark.
+//!
+//! Source: Programming Erlang: Software for a Concurrent World, by Joe Armstrong, Chapter 8.11.2
+//!
+//! "Create N processes in a ring. Send a message round the ring M times so that a total of N * M
+//! messages get sent. Time how long this takes for different values of N and M."
+
+use std::time::SystemTime;
+
+use async_std::sync::channel;
+use async_std::task;
+
+#[derive(Debug)]
+struct Payload(u64);
+struct End;
+
+fn main() {
+    task::block_on(async move {
+        let n = 1000000;
+        let m = 10;
+        let limit = m * n;
+
+        let full_now = SystemTime::now();
+        let mut senders = Vec::new();
+        let mut receivers = Vec::new();
+
+        for _ in 0..n {
+            let (s, r) = channel::<Payload>(1);
+            senders.push(s);
+            receivers.push(r);
+        }
+
+        let mut senders = senders.into_iter();
+        let mut receivers = receivers.into_iter();
+
+        let first_sender = senders.next().unwrap();
+        let (buz_send, buz_recv) = channel::<End>(1);
+
+        while let Some(r) = receivers.next() {
+            if let Some(s) = senders.next() {
+                task::spawn(async move {
+                    while let Some(mut p) = r.recv().await {
+                        p.0 += 1;
+                        s.send(p).await;
+                    }
+                });
+            } else {
+                let s = first_sender.clone();
+                let buz_send = buz_send.clone();
+
+                let mut entry_count = 0;
+
+                task::spawn(async move {
+                    while let Some(mut p) = r.recv().await {
+                        dbg!(entry_count);
+                        entry_count += 1;
+                        p.0 += 1;
+
+                        if p.0 >= limit {
+                            println!("Reached limit: {}, payload: {}", limit, p.0);
+                            break;
+                        }
+                        s.send(p).await;
+                    }
+                    buz_send.send(End).await;
+                });
+            }
+        }
+
+        let now = SystemTime::now();
+        first_sender.send(Payload(0)).await;
+        buz_recv.recv().await;
+        let elapsed = now.elapsed().unwrap();
+
+        println!(
+            "Time taken: {}.{:06} seconds",
+            elapsed.as_secs(),
+            elapsed.subsec_micros()
+        );
+        let elapsed = full_now.elapsed().unwrap();
+
+        println!(
+            "Time taken in full: {}.{:06} seconds",
+            elapsed.as_secs(),
+            elapsed.subsec_micros()
+        );
+    });
+}

--- a/examples/tcp-ipv4-and-6-echo.rs
+++ b/examples/tcp-ipv4-and-6-echo.rs
@@ -1,4 +1,4 @@
-//! TCP echo server, accepting connections both on both ipv4 and ipv6 sockets.
+//! TCP echo server, accepting connections both on both IPv4 and IPV6 sockets.
 //!
 //! To send messages, do:
 //!
@@ -25,12 +25,12 @@ fn main() -> io::Result<()> {
     task::block_on(async {
         let ipv4_listener = TcpListener::bind("127.0.0.1:8080").await?;
         println!("Listening on {}", ipv4_listener.local_addr()?);
+
         let ipv6_listener = TcpListener::bind("[::1]:8080").await?;
         println!("Listening on {}", ipv6_listener.local_addr()?);
 
         let ipv4_incoming = ipv4_listener.incoming();
         let ipv6_incoming = ipv6_listener.incoming();
-
         let mut incoming = ipv4_incoming.merge(ipv6_incoming);
 
         while let Some(stream) = incoming.next().await {


### PR DESCRIPTION
This is the code from https://github.com/stjepang/ring-benchmark

The list of examples is getting a bit unwieldy. I wonder if it would make sense to move the list into the book and just link to it from here. After all, the growing list of  examples is slowly becoming a cookbook already.

@skade, any ideas on how to integrate these examples with the book?