### PR TITLE
Add context to more errors

### DIFF
--- a/src/fs/canonicalize.rs
+++ b/src/fs/canonicalize.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::{Path, PathBuf};
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Returns the canonical form of a path.
 ///
@@ -32,5 +33,10 @@ use crate::task::spawn_blocking;
 /// ```
 pub async fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref().to_owned();
-    spawn_blocking(move || std::fs::canonicalize(&path).map(Into::into)).await
+    spawn_blocking(move || {
+        std::fs::canonicalize(&path)
+            .map(Into::into)
+            .context(|| format!("could not canonicalize `{}`", path.display()))
+    })
+    .await
 }

--- a/src/fs/copy.rs
+++ b/src/fs/copy.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::Path;
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Copies the contents and permissions of a file to a new location.
 ///
@@ -41,5 +42,9 @@ use crate::task::spawn_blocking;
 pub async fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
     let from = from.as_ref().to_owned();
     let to = to.as_ref().to_owned();
-    spawn_blocking(move || std::fs::copy(&from, &to)).await
+    spawn_blocking(move || {
+        std::fs::copy(&from, &to)
+            .context(|| format!("could not copy `{}` to `{}`", from.display(), to.display()))
+    })
+    .await
 }

--- a/src/fs/create_dir.rs
+++ b/src/fs/create_dir.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::Path;
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Creates a new directory.
 ///
@@ -34,5 +35,9 @@ use crate::task::spawn_blocking;
 /// ```
 pub async fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    spawn_blocking(move || std::fs::create_dir(path)).await
+    spawn_blocking(move || {
+        std::fs::create_dir(&path)
+            .context(|| format!("could not create directory `{}`", path.display()))
+    })
+    .await
 }

--- a/src/fs/create_dir_all.rs
+++ b/src/fs/create_dir_all.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::Path;
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Creates a new directory and all of its parents if they are missing.
 ///
@@ -29,5 +30,9 @@ use crate::task::spawn_blocking;
 /// ```
 pub async fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    spawn_blocking(move || std::fs::create_dir_all(path)).await
+    spawn_blocking(move || {
+        std::fs::create_dir_all(&path)
+            .context(|| format!("could not create directory path `{}`", path.display()))
+    })
+    .await
 }

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -9,11 +9,11 @@ use std::sync::{Arc, Mutex};
 
 use crate::fs::{Metadata, Permissions};
 use crate::future;
-use crate::utils::Context as _;
 use crate::io::{self, Read, Seek, SeekFrom, Write};
 use crate::path::Path;
 use crate::prelude::*;
 use crate::task::{self, spawn_blocking, Context, Poll, Waker};
+use crate::utils::Context as _;
 
 /// An open file on the filesystem.
 ///
@@ -114,8 +114,7 @@ impl File {
     pub async fn open<P: AsRef<Path>>(path: P) -> io::Result<File> {
         let path = path.as_ref().to_owned();
         let file = spawn_blocking(move || {
-            std::fs::File::open(&path)
-                .context(|| format!("Could not open {}", path.display()))
+            std::fs::File::open(&path).context(|| format!("Could not open `{}`", path.display()))
         })
         .await?;
         Ok(File::new(file, true))
@@ -154,7 +153,7 @@ impl File {
         let path = path.as_ref().to_owned();
         let file = spawn_blocking(move || {
             std::fs::File::create(&path)
-                .context(|| format!("Could not create {}", path.display()))
+                .context(|| format!("Could not create `{}`", path.display()))
         })
         .await?;
         Ok(File::new(file, true))

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -114,7 +114,7 @@ impl File {
     pub async fn open<P: AsRef<Path>>(path: P) -> io::Result<File> {
         let path = path.as_ref().to_owned();
         let file = spawn_blocking(move || {
-            std::fs::File::open(&path).context(|| format!("Could not open `{}`", path.display()))
+            std::fs::File::open(&path).context(|| format!("could not open `{}`", path.display()))
         })
         .await?;
         Ok(File::new(file, true))
@@ -153,7 +153,7 @@ impl File {
         let path = path.as_ref().to_owned();
         let file = spawn_blocking(move || {
             std::fs::File::create(&path)
-                .context(|| format!("Could not create `{}`", path.display()))
+                .context(|| format!("could not create `{}`", path.display()))
         })
         .await?;
         Ok(File::new(file, true))

--- a/src/fs/hard_link.rs
+++ b/src/fs/hard_link.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::Path;
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Creates a hard link on the filesystem.
 ///
@@ -32,5 +33,14 @@ use crate::task::spawn_blocking;
 pub async fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
     let from = from.as_ref().to_owned();
     let to = to.as_ref().to_owned();
-    spawn_blocking(move || std::fs::hard_link(&from, &to)).await
+    spawn_blocking(move || {
+        std::fs::hard_link(&from, &to).context(|| {
+            format!(
+                "could not create a hard link from `{}` to `{}`",
+                from.display(),
+                to.display()
+            )
+        })
+    })
+    .await
 }

--- a/src/fs/read.rs
+++ b/src/fs/read.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::Path;
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Reads the entire contents of a file as raw bytes.
 ///
@@ -36,5 +37,8 @@ use crate::task::spawn_blocking;
 /// ```
 pub async fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
     let path = path.as_ref().to_owned();
-    spawn_blocking(move || std::fs::read(path)).await
+    spawn_blocking(move || {
+        std::fs::read(&path).context(|| format!("could not read file `{}`", path.display()))
+    })
+    .await
 }

--- a/src/fs/read_link.rs
+++ b/src/fs/read_link.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::{Path, PathBuf};
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Reads a symbolic link and returns the path it points to.
 ///
@@ -28,5 +29,10 @@ use crate::task::spawn_blocking;
 /// ```
 pub async fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref().to_owned();
-    spawn_blocking(move || std::fs::read_link(path).map(Into::into)).await
+    spawn_blocking(move || {
+        std::fs::read_link(&path)
+            .map(Into::into)
+            .context(|| format!("could not read link `{}`", path.display()))
+    })
+    .await
 }

--- a/src/fs/read_to_string.rs
+++ b/src/fs/read_to_string.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::Path;
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Reads the entire contents of a file as a string.
 ///
@@ -37,5 +38,9 @@ use crate::task::spawn_blocking;
 /// ```
 pub async fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     let path = path.as_ref().to_owned();
-    spawn_blocking(move || std::fs::read_to_string(path)).await
+    spawn_blocking(move || {
+        std::fs::read_to_string(&path)
+            .context(|| format!("could not read file `{}`", path.display()))
+    })
+    .await
 }

--- a/src/fs/remove_dir.rs
+++ b/src/fs/remove_dir.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::Path;
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Removes an empty directory.
 ///
@@ -29,5 +30,9 @@ use crate::task::spawn_blocking;
 /// ```
 pub async fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    spawn_blocking(move || std::fs::remove_dir(path)).await
+    spawn_blocking(move || {
+        std::fs::remove_dir(&path)
+            .context(|| format!("could not remove directory `{}`", path.display()))
+    })
+    .await
 }

--- a/src/fs/remove_dir_all.rs
+++ b/src/fs/remove_dir_all.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::Path;
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Removes a directory and all of its contents.
 ///
@@ -29,5 +30,9 @@ use crate::task::spawn_blocking;
 /// ```
 pub async fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    spawn_blocking(move || std::fs::remove_dir_all(path)).await
+    spawn_blocking(move || {
+        std::fs::remove_dir_all(&path)
+            .context(|| format!("could not remove directory `{}`", path.display()))
+    })
+    .await
 }

--- a/src/fs/remove_file.rs
+++ b/src/fs/remove_file.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::Path;
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Removes a file.
 ///
@@ -29,5 +30,9 @@ use crate::task::spawn_blocking;
 /// ```
 pub async fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    spawn_blocking(move || std::fs::remove_file(path)).await
+    spawn_blocking(move || {
+        std::fs::remove_file(&path)
+            .context(|| format!("could not remove file `{}`", path.display()))
+    })
+    .await
 }

--- a/src/fs/rename.rs
+++ b/src/fs/rename.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::Path;
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Renames a file or directory to a new location.
 ///
@@ -34,5 +35,14 @@ use crate::task::spawn_blocking;
 pub async fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
     let from = from.as_ref().to_owned();
     let to = to.as_ref().to_owned();
-    spawn_blocking(move || std::fs::rename(&from, &to)).await
+    spawn_blocking(move || {
+        std::fs::rename(&from, &to).context(|| {
+            format!(
+                "could not rename `{}` to `{}`",
+                from.display(),
+                to.display()
+            )
+        })
+    })
+    .await
 }

--- a/src/fs/write.rs
+++ b/src/fs/write.rs
@@ -1,6 +1,7 @@
 use crate::io;
 use crate::path::Path;
 use crate::task::spawn_blocking;
+use crate::utils::Context as _;
 
 /// Writes a slice of bytes as the new contents of a file.
 ///
@@ -33,5 +34,9 @@ use crate::task::spawn_blocking;
 pub async fn write<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     let contents = contents.as_ref().to_owned();
-    spawn_blocking(move || std::fs::write(path, contents)).await
+    spawn_blocking(move || {
+        std::fs::write(&path, contents)
+            .context(|| format!("could not write to file `{}`", path.display()))
+    })
+    .await
 }

--- a/src/io/copy.rs
+++ b/src/io/copy.rs
@@ -1,10 +1,11 @@
-use std::pin::Pin;
 use std::future::Future;
+use std::pin::Pin;
 
 use pin_project_lite::pin_project;
 
 use crate::io::{self, BufRead, BufReader, Read, Write};
 use crate::task::{Context, Poll};
+use crate::utils::Context as _;
 
 /// Copies the entire contents of a reader into a writer.
 ///
@@ -90,7 +91,7 @@ where
         writer,
         amt: 0,
     };
-    future.await
+    future.await.context(|| String::from("io::copy failed"))
 }
 
 /// Copies the entire contents of a reader into a writer.
@@ -177,5 +178,5 @@ where
         writer,
         amt: 0,
     };
-    future.await
+    future.await.context(|| String::from("io::copy failed"))
 }

--- a/src/io/stdin.rs
+++ b/src/io/stdin.rs
@@ -1,10 +1,11 @@
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Mutex;
-use std::future::Future;
 
 use crate::future;
 use crate::io::{self, Read};
 use crate::task::{spawn_blocking, Context, JoinHandle, Poll};
+use crate::utils::Context as _;
 
 cfg_unstable! {
     use once_cell::sync::Lazy;
@@ -162,6 +163,7 @@ impl Stdin {
             }
         })
         .await
+        .context(|| String::from("Could not read line on stdin"))
     }
 
     /// Locks this handle to the standard input stream, returning a readable guard.

--- a/src/io/stdin.rs
+++ b/src/io/stdin.rs
@@ -163,7 +163,7 @@ impl Stdin {
             }
         })
         .await
-        .context(|| String::from("Could not read line on stdin"))
+        .context(|| String::from("could not read line on stdin"))
     }
 
     /// Locks this handle to the standard input stream, returning a readable guard.

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -8,7 +8,6 @@ use crate::net::driver::Watcher;
 use crate::net::{TcpStream, ToSocketAddrs};
 use crate::stream::Stream;
 use crate::task::{Context, Poll};
-use crate::utils::Context as _;
 
 /// A TCP socket server, listening for connections.
 ///
@@ -78,8 +77,7 @@ impl TcpListener {
         let mut last_err = None;
         let addrs = addrs
             .to_socket_addrs()
-            .await
-            .context(|| String::from("could not resolve addresses"))?;
+            .await?;
 
         for addr in addrs {
             match mio::net::TcpListener::bind(&addr) {

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -74,8 +74,7 @@ impl TcpStream {
         let mut last_err = None;
         let addrs = addrs
             .to_socket_addrs()
-            .await
-            .context(|| String::from("could not resolve addresses"))?;
+            .await?;
 
         for addr in addrs {
             let res = spawn_blocking(move || {

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -71,8 +71,7 @@ impl UdpSocket {
         let mut last_err = None;
         let addrs = addrs
             .to_socket_addrs()
-            .await
-            .context(|| String::from("could not resolve addresses"))?;
+            .await?;
 
         for addr in addrs {
             match mio::net::UdpSocket::bind(&addr) {

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -159,7 +159,7 @@ impl UdpSocket {
                 .poll_write_with(cx, |inner| inner.send_to(buf, &addr))
         })
         .await
-        .context(|| format!("Could not send packet to {}", addr))
+        .context(|| format!("could not send packet to {}", addr))
     }
 
     /// Receives data from the socket.
@@ -190,7 +190,7 @@ impl UdpSocket {
         .context(|| {
             use std::fmt::Write;
 
-            let mut error = String::from("Could not receive data on ");
+            let mut error = String::from("could not receive data on ");
             if let Ok(addr) = self.local_addr() {
                 let _ = write!(&mut error, "{}", addr);
             } else {
@@ -277,7 +277,7 @@ impl UdpSocket {
             .context(|| {
                 use std::fmt::Write;
 
-                let mut error = String::from("Could not send data on ");
+                let mut error = String::from("could not send data on ");
                 if let Ok(addr) = self.local_addr() {
                     let _ = write!(&mut error, "{}", addr);
                 } else {
@@ -312,7 +312,7 @@ impl UdpSocket {
             .context(|| {
                 use std::fmt::Write;
 
-                let mut error = String::from("Could not receive data on ");
+                let mut error = String::from("could not receive data on ");
                 if let Ok(addr) = self.local_addr() {
                     let _ = write!(&mut error, "{}", addr);
                 } else {

--- a/tests/verbose_errors.rs
+++ b/tests/verbose_errors.rs
@@ -1,4 +1,4 @@
-use async_std::{fs, task};
+use async_std::{fs, io, net::ToSocketAddrs, task};
 
 #[test]
 fn open_file() {
@@ -9,6 +9,21 @@ fn open_file() {
             Ok(_) => panic!("Found file with random name: We live in a simulation"),
             Err(e) => assert_eq!(
                 "Could not open `/ashjudlkahasdasdsikdhajik/asdasdasdasdasdasd/fjuiklashdbflasas`",
+                &format!("{}", e)
+            ),
+        }
+    })
+}
+
+#[test]
+fn resolve_address() {
+    task::block_on(async {
+        let non_existing_addr = "ashjudlkahasdasdsikdhajik.asdasdasdasdasdasd.fjuiklashdbflasas:80";
+        let res: Result<_, io::Error> = non_existing_addr.to_socket_addrs().await;
+        match res {
+            Ok(_) => panic!("Found address with random name: We live in a simulation"),
+            Err(e) => assert_eq!(
+                "could not resolve address `\"ashjudlkahasdasdsikdhajik.asdasdasdasdasdasd.fjuiklashdbflasas:80\"`",
                 &format!("{}", e)
             ),
         }

--- a/tests/verbose_errors.rs
+++ b/tests/verbose_errors.rs
@@ -8,7 +8,7 @@ fn open_file() {
         match res {
             Ok(_) => panic!("Found file with random name: We live in a simulation"),
             Err(e) => assert_eq!(
-                "Could not open /ashjudlkahasdasdsikdhajik/asdasdasdasdasdasd/fjuiklashdbflasas",
+                "Could not open `/ashjudlkahasdasdsikdhajik/asdasdasdasdasdasd/fjuiklashdbflasas`",
                 &format!("{}", e)
             ),
         }


### PR DESCRIPTION
Pretty mechanical additions and by no means exhaustive: I bascially just wanted to cover the APIs I end up using quite often :)

For a future PR it might be interesting to add a test that shows that our errors include the correct sources, and that they might even work well with std backtraces.

cc #569