### PR TITLE
Refactor join type

### DIFF
--- a/src/future/future/join.rs
+++ b/src/future/future/join.rs
@@ -12,7 +12,7 @@ pin_project! {
     pub struct Join<L, R>
     where
         L: Future,
-        R: Future<Output = L::Output>
+        R: Future,
     {
         #[pin] left: MaybeDone<L>,
         #[pin] right: MaybeDone<R>,
@@ -22,7 +22,7 @@ pin_project! {
 impl<L, R> Join<L, R>
 where
     L: Future,
-    R: Future<Output = L::Output>,
+    R: Future,
 {
     pub(crate) fn new(left: L, right: R) -> Self {
         Self {
@@ -35,7 +35,7 @@ where
 impl<L, R> Future for Join<L, R>
 where
     L: Future,
-    R: Future<Output = L::Output>,
+    R: Future,
 {
     type Output = (L::Output, R::Output);
 

--- a/src/future/future/mod.rs
+++ b/src/future/future/mod.rs
@@ -328,30 +328,30 @@ extension_trait! {
             use async_std::prelude::*;
             use async_std::future;
 
-            let a = future::ready(Err("Error"));
+            let a = future::ready(Err::<u8, &str>("Error"));
             let b = future::ready(Ok(1u8));
 
             let f = a.try_join(b);
             assert_eq!(f.await, Err("Error"));
 
             let a = future::ready(Ok::<u8, String>(1u8));
-            let b = future::ready(Ok::<u8, String>(2u8));
+            let b = future::ready(Ok::<u16, String>(2u16));
 
             let f = a.try_join(b);
-            assert_eq!(f.await, Ok((1u8, 2u8)));
+            assert_eq!(f.await, Ok((1u8, 2u16)));
             #
             # Ok(()) }) }
             ```
         "#]
         #[cfg(any(feature = "unstable", feature = "docs"))]
         #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
-        fn try_join<F, T, E>(
+        fn try_join<F, A, B, E>(
             self,
             other: F
-        ) -> impl Future<Output = Result<(T, T), E>> [TryJoin<Self, F>]
+        ) -> impl Future<Output = Result<(A, B), E>> [TryJoin<Self, F>]
         where
-            Self: std::future::Future<Output = Result<T, E>> + Sized,
-            F: std::future::Future<Output = <Self as std::future::Future>::Output>,
+            Self: std::future::Future<Output = Result<A, E>> + Sized,
+            F: std::future::Future<Output = Result<B, E>>,
         {
             TryJoin::new(self, other)
         }

--- a/src/future/future/mod.rs
+++ b/src/future/future/mod.rs
@@ -304,7 +304,7 @@ extension_trait! {
         ) -> impl Future<Output = (<Self as std::future::Future>::Output, <F as std::future::Future>::Output)> [Join<Self, F>]
         where
             Self: std::future::Future + Sized,
-            F: std::future::Future<Output = <Self as std::future::Future>::Output>,
+            F: std::future::Future,
         {
             Join::new(self, other)
         }

--- a/src/future/future/mod.rs
+++ b/src/future/future/mod.rs
@@ -289,10 +289,10 @@ extension_trait! {
             use async_std::future;
 
             let a = future::ready(1u8);
-            let b = future::ready(2u8);
+            let b = future::ready(2u16);
 
             let f = a.join(b);
-            assert_eq!(f.await, (1u8, 2u8));
+            assert_eq!(f.await, (1u8, 2u16));
             # });
             ```
         "#]

--- a/src/future/future/try_join.rs
+++ b/src/future/future/try_join.rs
@@ -12,7 +12,7 @@ pin_project! {
     pub struct TryJoin<L, R>
     where
         L: Future,
-        R: Future<Output = L::Output>
+        R: Future,
     {
         #[pin] left: MaybeDone<L>,
         #[pin] right: MaybeDone<R>,
@@ -22,7 +22,7 @@ pin_project! {
 impl<L, R> TryJoin<L, R>
 where
     L: Future,
-    R: Future<Output = L::Output>,
+    R: Future,
 {
     pub(crate) fn new(left: L, right: R) -> Self {
         Self {
@@ -32,12 +32,12 @@ where
     }
 }
 
-impl<L, R, T, E> Future for TryJoin<L, R>
+impl<L, R, A, B, E> Future for TryJoin<L, R>
 where
-    L: Future<Output = Result<T, E>>,
-    R: Future<Output = L::Output>,
+    L: Future<Output = Result<A, E>>,
+    R: Future<Output = Result<B, E>>,
 {
-    type Output = Result<(T, T), E>;
+    type Output = Result<(A, B), E>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();


### PR DESCRIPTION
I think the `future :: join` type constraint is strong.
How about making it possible to `join` different future types?