### PR TITLE
expose try_recv and try_send on channels

### DIFF
--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -32,6 +32,7 @@ use crate::sync::WakerSet;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), async_std::sync::RecvError> {
 /// # async_std::task::block_on(async {
 /// #
 /// use std::time::Duration;
@@ -51,10 +52,11 @@ use crate::sync::WakerSet;
 /// });
 ///
 /// task::sleep(Duration::from_secs(1)).await;
-/// assert_eq!(r.recv().await, Some(1));
-/// assert_eq!(r.recv().await, Some(2));
+/// assert_eq!(r.recv().await?, 1);
+/// assert_eq!(r.recv().await?, 2);
+/// # Ok(())
 /// #
-/// # })
+/// # }) }
 /// ```
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
@@ -113,6 +115,7 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), async_std::sync::RecvError> {
     /// # async_std::task::block_on(async {
     /// #
     /// use async_std::sync::channel;
@@ -125,11 +128,12 @@ impl<T> Sender<T> {
     ///     s.send(2).await;
     /// });
     ///
-    /// assert_eq!(r.recv().await, Some(1));
-    /// assert_eq!(r.recv().await, Some(2));
-    /// assert_eq!(r.recv().await, None);
+    /// assert_eq!(r.recv().await?, 1);
+    /// assert_eq!(r.recv().await?, 2);
+    /// assert!(r.recv().await.is_err());
     /// #
-    /// # })
+    /// # Ok(())
+    /// # }) }
     /// ```
     pub async fn send(&self, msg: T) {
         struct SendFuture<'a, T> {
@@ -335,6 +339,7 @@ impl<T> fmt::Debug for Sender<T> {
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), async_std::sync::RecvError> {
 /// # async_std::task::block_on(async {
 /// #
 /// use std::time::Duration;
@@ -350,10 +355,11 @@ impl<T> fmt::Debug for Sender<T> {
 ///     s.send(2).await;
 /// });
 ///
-/// assert_eq!(r.recv().await, Some(1)); // Received immediately.
-/// assert_eq!(r.recv().await, Some(2)); // Received after 1 second.
+/// assert_eq!(r.recv().await?, 1); // Received immediately.
+/// assert_eq!(r.recv().await?, 2); // Received after 1 second.
 /// #
-/// # })
+/// # Ok(())
+/// # }) }
 /// ```
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
@@ -375,6 +381,7 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
+    /// # fn main() -> Result<(), async_std::sync::RecvError> {
     /// # async_std::task::block_on(async {
     /// #
     /// use async_std::sync::channel;
@@ -388,11 +395,12 @@ impl<T> Receiver<T> {
     ///     // Then we drop the sender
     /// });
     ///
-    /// assert_eq!(r.recv().await, Ok(1));
-    /// assert_eq!(r.recv().await, Ok(2));
+    /// assert_eq!(r.recv().await?, 1);
+    /// assert_eq!(r.recv().await?, 2);
     /// assert!(r.recv().await.is_err());
     /// #
-    /// # })
+    /// # Ok(())
+    /// # }) }
     /// ```
     pub async fn recv(&self) -> Result<T, RecvError> {
         struct RecvFuture<'a, T> {

--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -983,6 +983,8 @@ impl<T> Drop for Channel<T> {
 }
 
 /// An error returned from the `try_send` method.
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 pub enum TrySendError<T> {
     /// The channel is full but not disconnected.
     Full(T),
@@ -1012,6 +1014,8 @@ impl<T> Display for TrySendError<T> {
 }
 
 /// An error returned from the `try_recv` method.
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[derive(Debug)]
 pub enum TryRecvError {
     /// The channel is empty but not disconnected.

--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -1,6 +1,6 @@
 use std::cell::UnsafeCell;
 use std::error::Error;
-use std::fmt::{Debug, Display, self};
+use std::fmt::{self, Debug, Display};
 use std::future::Future;
 use std::isize;
 use std::marker::PhantomData;
@@ -388,22 +388,20 @@ impl<T> Receiver<T> {
     ///     // Then we drop the sender
     /// });
     ///
-    /// assert_eq!(r.recv().await, Some(1));
-    /// assert_eq!(r.recv().await, Some(2));
-    ///
-    /// // recv() returns `None`
-    /// assert_eq!(r.recv().await, None);
+    /// assert_eq!(r.recv().await, Ok(1));
+    /// assert_eq!(r.recv().await, Ok(2));
+    /// assert!(r.recv().await.is_err());
     /// #
     /// # })
     /// ```
-    pub async fn recv(&self) -> Option<T> {
+    pub async fn recv(&self) -> Result<T, RecvError> {
         struct RecvFuture<'a, T> {
             channel: &'a Channel<T>,
             opt_key: Option<usize>,
         }
 
         impl<T> Future for RecvFuture<'_, T> {
-            type Output = Option<T>;
+            type Output = Result<T, RecvError>;
 
             fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
                 poll_recv(
@@ -569,12 +567,13 @@ impl<T> Stream for Receiver<T> {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = &mut *self;
-        poll_recv(
+        let res = futures_core::ready!(poll_recv(
             &this.channel,
             &this.channel.stream_wakers,
             &mut this.opt_key,
             cx,
-        )
+        ));
+        Poll::Ready(res.ok())
     }
 }
 
@@ -593,7 +592,7 @@ fn poll_recv<T>(
     wakers: &WakerSet,
     opt_key: &mut Option<usize>,
     cx: &mut Context<'_>,
-) -> Poll<Option<T>> {
+) -> Poll<Result<T, RecvError>> {
     loop {
         // If the current task is in the set, remove it.
         if let Some(key) = opt_key.take() {
@@ -602,8 +601,8 @@ fn poll_recv<T>(
 
         // Try receiving a message.
         match channel.try_recv() {
-            Ok(msg) => return Poll::Ready(Some(msg)),
-            Err(TryRecvError::Disconnected) => return Poll::Ready(None),
+            Ok(msg) => return Poll::Ready(Ok(msg)),
+            Err(TryRecvError::Disconnected) => return Poll::Ready(Err(RecvError {})),
             Err(TryRecvError::Empty) => {
                 // Insert this receive operation.
                 *opt_key = Some(wakers.insert(cx));
@@ -1033,5 +1032,19 @@ impl Display for TryRecvError {
             Self::Empty => Display::fmt("The channel is empty.", f),
             Self::Disconnected => Display::fmt("The channel is empty and disconnected.", f),
         }
+    }
+}
+
+/// An error returned from the `recv` method.
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+#[derive(Debug)]
+pub struct RecvError;
+
+impl Error for RecvError {}
+
+impl Display for RecvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt("The channel is empty.", f)
     }
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -184,7 +184,7 @@ mod rwlock;
 
 cfg_unstable! {
     pub use barrier::{Barrier, BarrierWaitResult};
-    pub use channel::{channel, Sender, Receiver};
+    pub use channel::{channel, Sender, Receiver, TryRecvError, TrySendError};
 
     mod barrier;
     mod channel;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -184,7 +184,7 @@ mod rwlock;
 
 cfg_unstable! {
     pub use barrier::{Barrier, BarrierWaitResult};
-    pub use channel::{channel, Sender, Receiver, TryRecvError, TrySendError};
+    pub use channel::{channel, Sender, Receiver, RecvError, TryRecvError, TrySendError};
 
     mod barrier;
     mod channel;


### PR DESCRIPTION
Exposes `Receiver::try_recv` and `Sender::try_send` on channels. Closes #579. I'm proposing we put the types in the crate's top-level because we're still undecided. I'd like to move to unblock people first, and then consider how we might want to move types around. Thanks!

## Screenshot

![Screenshot_2019-11-26 async_std sync - Rust](https://user-images.githubusercontent.com/2467194/69619697-40d4ee00-103c-11ea-9321-5548a27dd518.png)

