### PR TITLE
Remove unused macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ docs = ["attributes", "unstable"]
 unstable = ["default", "broadcaster"]
 attributes = ["async-attributes"]
 std = [
-  "async-macros",
   "crossbeam-utils",
   "futures-core",
   "futures-io",
@@ -51,7 +50,6 @@ std = [
 
 [dependencies]
 async-attributes = { version = "1.1.1", optional = true }
-async-macros = { version = "2.0.0", optional = true }
 async-task = { version = "1.0.0", optional = true }
 broadcaster = { version = "0.2.6", optional = true, default-features = false, features = ["default-channels"] }
 crossbeam-channel = { version = "0.4.0", optional = true }

--- a/src/future/future/join.rs
+++ b/src/future/future/join.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-use async_macros::MaybeDone;
+use crate::future::MaybeDone;
 use pin_project_lite::pin_project;
 
 use crate::task::{Context, Poll};

--- a/src/future/future/race.rs
+++ b/src/future/future/race.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
-use async_macros::MaybeDone;
+use crate::future::MaybeDone;
 use pin_project_lite::pin_project;
 
 use crate::task::{Context, Poll};

--- a/src/future/future/try_join.rs
+++ b/src/future/future/try_join.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-use async_macros::MaybeDone;
+use crate::future::MaybeDone;
 use pin_project_lite::pin_project;
 
 use crate::task::{Context, Poll};

--- a/src/future/future/try_race.rs
+++ b/src/future/future/try_race.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-use async_macros::MaybeDone;
+use crate::future::MaybeDone;
 use pin_project_lite::pin_project;
 
 use crate::task::{Context, Poll};

--- a/src/future/maybe_done.rs
+++ b/src/future/maybe_done.rs
@@ -1,0 +1,94 @@
+//! A type that wraps a future to keep track of its completion status.
+//!
+//! This implementation was taken from the original `macro_rules` `join/try_join`
+//! macros in the `futures-preview` crate.
+
+use std::future::Future;
+use std::mem;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures_core::ready;
+
+/// A future that may have completed.
+#[derive(Debug)]
+pub(crate) enum MaybeDone<Fut: Future> {
+    /// A not-yet-completed future
+    Future(Fut),
+    /// The output of the completed future
+    Done(Fut::Output),
+    /// The empty variant after the result of a [`MaybeDone`] has been
+    /// taken using the [`take`](MaybeDone::take) method.
+    Gone,
+}
+
+impl<Fut: Future> MaybeDone<Fut> {
+    /// Create a new instance of `MaybeDone`.
+    pub(crate) fn new(future: Fut) -> MaybeDone<Fut> {
+        Self::Future(future)
+    }
+
+    /// Returns an [`Option`] containing a reference to the output of the future.
+    /// The output of this method will be [`Some`] if and only if the inner
+    /// future has been completed and [`take`](MaybeDone::take)
+    /// has not yet been called.
+    #[inline]
+    pub(crate) fn output(self: Pin<&Self>) -> Option<&Fut::Output> {
+        let this = self.get_ref();
+        match this {
+            MaybeDone::Done(res) => Some(res),
+            _ => None,
+        }
+    }
+
+    /// Returns an [`Option`] containing a mutable reference to the output of the future.
+    /// The output of this method will be [`Some`] if and only if the inner
+    /// future has been completed and [`take`](MaybeDone::take)
+    /// has not yet been called.
+    #[inline]
+    pub(crate) fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            match this {
+                MaybeDone::Done(res) => Some(res),
+                _ => None,
+            }
+        }
+    }
+
+    /// Attempt to take the output of a `MaybeDone` without driving it
+    /// towards completion.
+    #[inline]
+    pub(crate) fn take(self: Pin<&mut Self>) -> Option<Fut::Output> {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            match this {
+                MaybeDone::Done(_) => {}
+                MaybeDone::Future(_) | MaybeDone::Gone => return None,
+            };
+            if let MaybeDone::Done(output) = mem::replace(this, MaybeDone::Gone) {
+                Some(output)
+            } else {
+                unreachable!()
+            }
+        }
+    }
+
+    // fn ok(self) -> Option<Fut::Output> {}
+}
+
+impl<Fut: Future> Future for MaybeDone<Fut> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let res = unsafe {
+            match Pin::as_mut(&mut self).get_unchecked_mut() {
+                MaybeDone::Future(a) => ready!(Pin::new_unchecked(a).poll(cx)),
+                MaybeDone::Done(_) => return Poll::Ready(()),
+                MaybeDone::Gone => panic!("MaybeDone polled after value taken"),
+            }
+        };
+        self.set(MaybeDone::Done(res));
+        Poll::Ready(())
+    }
+}

--- a/src/future/maybe_done.rs
+++ b/src/future/maybe_done.rs
@@ -15,8 +15,10 @@ use futures_core::ready;
 pub(crate) enum MaybeDone<Fut: Future> {
     /// A not-yet-completed future
     Future(Fut),
+
     /// The output of the completed future
     Done(Fut::Output),
+
     /// The empty variant after the result of a [`MaybeDone`] has been
     /// taken using the [`take`](MaybeDone::take) method.
     Gone,
@@ -41,20 +43,20 @@ impl<Fut: Future> MaybeDone<Fut> {
         }
     }
 
-    /// Returns an [`Option`] containing a mutable reference to the output of the future.
-    /// The output of this method will be [`Some`] if and only if the inner
-    /// future has been completed and [`take`](MaybeDone::take)
-    /// has not yet been called.
-    #[inline]
-    pub(crate) fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
-        unsafe {
-            let this = self.get_unchecked_mut();
-            match this {
-                MaybeDone::Done(res) => Some(res),
-                _ => None,
-            }
-        }
-    }
+//     /// Returns an [`Option`] containing a mutable reference to the output of the future.
+//     /// The output of this method will be [`Some`] if and only if the inner
+//     /// future has been completed and [`take`](MaybeDone::take)
+//     /// has not yet been called.
+//     #[inline]
+//     pub(crate) fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
+//         unsafe {
+//             let this = self.get_unchecked_mut();
+//             match this {
+//                 MaybeDone::Done(res) => Some(res),
+//                 _ => None,
+//             }
+//         }
+//     }
 
     /// Attempt to take the output of a `MaybeDone` without driving it
     /// towards completion.
@@ -73,8 +75,6 @@ impl<Fut: Future> MaybeDone<Fut> {
             }
         }
     }
-
-    // fn ok(self) -> Option<Fut::Output> {}
 }
 
 impl<Fut: Future> Future for MaybeDone<Fut> {

--- a/src/future/maybe_done.rs
+++ b/src/future/maybe_done.rs
@@ -43,21 +43,6 @@ impl<Fut: Future> MaybeDone<Fut> {
         }
     }
 
-//     /// Returns an [`Option`] containing a mutable reference to the output of the future.
-//     /// The output of this method will be [`Some`] if and only if the inner
-//     /// future has been completed and [`take`](MaybeDone::take)
-//     /// has not yet been called.
-//     #[inline]
-//     pub(crate) fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
-//         unsafe {
-//             let this = self.get_unchecked_mut();
-//             match this {
-//                 MaybeDone::Done(res) => Some(res),
-//                 _ => None,
-//             }
-//         }
-//     }
-
     /// Attempt to take the output of a `MaybeDone` without driving it
     /// towards completion.
     #[inline]

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -47,11 +47,13 @@
 //! [`Future::try_race`]: trait.Future.html#method.try_race
 
 pub use future::Future;
+pub(crate) use maybe_done::MaybeDone;
 pub use pending::pending;
 pub use poll_fn::poll_fn;
 pub use ready::ready;
 
 pub(crate) mod future;
+mod maybe_done;
 mod pending;
 mod poll_fn;
 mod ready;

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -47,13 +47,11 @@
 //! [`Future::try_race`]: trait.Future.html#method.try_race
 
 pub use future::Future;
-pub(crate) use maybe_done::MaybeDone;
 pub use pending::pending;
 pub use poll_fn::poll_fn;
 pub use ready::ready;
 
 pub(crate) mod future;
-mod maybe_done;
 mod pending;
 mod poll_fn;
 mod ready;
@@ -65,5 +63,7 @@ cfg_default! {
 
 cfg_unstable! {
     pub use into_future::IntoFuture;
+    pub(crate) use maybe_done::MaybeDone;
     mod into_future;
+    mod maybe_done;
 }

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -122,10 +122,9 @@ cfg_std! {
     #[doc(inline)]
     pub use std::task::{Context, Poll, Waker};
 
-    #[doc(inline)]
-    pub use futures_core::ready;
-
+    pub use ready::ready;
     pub use yield_now::yield_now;
+    mod ready;
     mod yield_now;
 }
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -123,7 +123,7 @@ cfg_std! {
     pub use std::task::{Context, Poll, Waker};
 
     #[doc(inline)]
-    pub use async_macros::ready;
+    pub use futures_core::ready;
 
     pub use yield_now::yield_now;
     mod yield_now;

--- a/src/task/ready.rs
+++ b/src/task/ready.rs
@@ -1,0 +1,4 @@
+/// Extracts the successful type of a `Poll<T>`.
+///
+/// This macro bakes in propagation of `Pending` signals by returning early.
+pub use futures_core::ready;


### PR DESCRIPTION
Removes our `async-macros` dependency entirely, and inlines all remaining code. Even managed to maintain our current docs when re-exporting `task::ready!` from `futures-core`. This patch should strictly speed up compilation. Thanks!