### PR TITLE
Add an implementation of pending stream

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -325,6 +325,7 @@ cfg_unstable! {
     mod fused_stream;
     mod interval;
     mod into_stream;
+    mod pending;
     mod product;
     mod successors;
     mod sum;
@@ -336,6 +337,7 @@ cfg_unstable! {
     pub use fused_stream::FusedStream;
     pub use interval::{interval, Interval};
     pub use into_stream::IntoStream;
+    pub use pending::{pending, Pending};
     pub use product::Product;
     pub use stream::Merge;
     pub use successors::{successors, Successors};

--- a/src/stream/pending.rs
+++ b/src/stream/pending.rs
@@ -28,10 +28,6 @@ impl<T> Stream for Pending<T> {
     fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<T>> {
         Poll::Pending
     }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, Some(0))
-    }
 }
 
 impl<T> DoubleEndedStream for Pending<T> {

--- a/src/stream/pending.rs
+++ b/src/stream/pending.rs
@@ -1,0 +1,49 @@
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::stream::{Stream, DoubleEndedStream, ExactSizeStream, FusedStream};
+
+/// A stream that never returns any items.
+/// 
+/// This stream is created by the [`pending`] function. See its
+/// documentation for more.
+/// 
+/// [`pending`]: fn.pending.html
+#[derive(Debug)]
+pub struct Pending<T> {
+    _marker: PhantomData<T>
+}
+
+/// Creates a stream that never returns any items.
+/// 
+/// The returned stream will always return `Pending` when polled.
+pub fn pending<T>() -> Pending<T> {
+    Pending { _marker: PhantomData }
+}
+
+impl<T> Stream for Pending<T> {
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<T>> {
+        Poll::Pending
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(0))
+    }
+}
+
+impl<T> DoubleEndedStream for Pending<T> {
+    fn poll_next_back(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<T>> {
+        Poll::Pending
+    }
+}
+
+impl<T> FusedStream for Pending<T> {}
+
+impl<T> ExactSizeStream for Pending<T> {
+    fn len(&self) -> usize {
+        0
+    }
+}

--- a/src/stream/pending.rs
+++ b/src/stream/pending.rs
@@ -18,6 +18,27 @@ pub struct Pending<T> {
 /// Creates a stream that never returns any items.
 ///
 /// The returned stream will always return `Pending` when polled.
+/// # Examples
+///
+/// ```
+/// # async_std::task::block_on(async {
+/// #
+/// use std::time::Duration;
+///
+/// use async_std::prelude::*;
+/// use async_std::stream;
+///
+/// let dur = Duration::from_millis(100);
+/// let mut s = stream::pending::<()>().timeout(dur);
+///
+/// let item = s.next().await;
+///
+/// assert!(item.is_some());
+/// assert!(item.unwrap().is_err());
+///
+/// #
+/// # })
+/// ```
 pub fn pending<T>() -> Pending<T> {
     Pending {
         _marker: PhantomData,

--- a/src/stream/pending.rs
+++ b/src/stream/pending.rs
@@ -2,24 +2,26 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::stream::{Stream, DoubleEndedStream, ExactSizeStream, FusedStream};
+use crate::stream::{DoubleEndedStream, ExactSizeStream, FusedStream, Stream};
 
 /// A stream that never returns any items.
-/// 
+///
 /// This stream is created by the [`pending`] function. See its
 /// documentation for more.
-/// 
+///
 /// [`pending`]: fn.pending.html
 #[derive(Debug)]
 pub struct Pending<T> {
-    _marker: PhantomData<T>
+    _marker: PhantomData<T>,
 }
 
 /// Creates a stream that never returns any items.
-/// 
+///
 /// The returned stream will always return `Pending` when polled.
 pub fn pending<T>() -> Pending<T> {
-    Pending { _marker: PhantomData }
+    Pending {
+        _marker: PhantomData,
+    }
 }
 
 impl<T> Stream for Pending<T> {


### PR DESCRIPTION
This pull request adds an implementation of pending stream, which always returns `Poll::Pending` and never completes. The implementation is largely copy-pasted from [`futures_util::stream::pending`](https://github.com/rust-lang/futures-rs/blob/master/futures-util/src/stream/pending.rs), with trait implementations for `DoubleEndedStream`, `FusedStream` and `ExactSizeStream` added.