### PR TITLE
Unique stream extension

### DIFF
--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -1800,12 +1800,12 @@ extension_trait! {
             use async_std::stream;
 
             let s = stream::from_iter(
-                vec![\"a\", \"bb\", \"aa\", \"c\", \"ccc\"]
+                vec!["a", "bb", "aa", "c", "ccc"]
             ).unique_by(|x| x.len());
             
-            assert_eq!(s.next().await, \"a\");
-            assert_eq!(s.next().await, \"bb\");
-            assert_eq!(s.next().await, \"ccc\");
+            assert_eq!(s.next().await, "a\");
+            assert_eq!(s.next().await, "bb");
+            assert_eq!(s.next().await, "ccc");
             assert_eq!(s.next().await, None);
             #
             # }) }

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -1803,7 +1803,7 @@ extension_trait! {
                 vec!["a", "bb", "aa", "c", "ccc"]
             ).unique_by(|x| x.len());
             
-            assert_eq!(s.next().await, "a\");
+            assert_eq!(s.next().await, "a");
             assert_eq!(s.next().await, "bb");
             assert_eq!(s.next().await, "ccc");
             assert_eq!(s.next().await, None);

--- a/src/stream/stream/unique.rs
+++ b/src/stream/stream/unique.rs
@@ -1,0 +1,61 @@
+use std::pin::Pin;
+use std::hash::Hash;
+use std::collections::HashSet;
+
+use pin_project_lite::pin_project;
+
+use crate::stream::Stream;
+use crate::task::{Context, Poll};
+
+pin_project! {
+    /// A stream that filters out duplicate items.
+    ///
+    /// Duplicates are detected using hash and equality. Produced values are
+    /// stored in a hash set in the stream.
+    ///
+    /// This `struct` is created by the [`unique`] method on [`Stream`]. See its
+    /// documentation for more.
+    ///
+    /// [`unique`]: trait.Stream.html#method.unique
+    /// [`Stream`]: trait.Stream.html
+    #[cfg(feature="unstable")]
+    #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+    pub struct Unique<S: Stream> {
+        #[pin]
+        stream: S,
+        used: HashSet<S::Item>
+    }
+}
+
+impl<S> Unique<S>
+where
+    S: Stream,
+    S::Item: Eq + Hash
+{
+    pub(crate) fn new(stream: S) -> Self {
+        Self {
+            stream,
+            used: HashSet::new()
+        }
+    }
+}
+
+impl<S> Stream for Unique<S>
+where
+    S: Stream,
+    S::Item: Eq + Hash + Clone
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        while let Some(v) = futures_core::ready!(this.stream.as_mut().poll_next(cx)) {
+            if this.used.insert(v.clone()) {
+                return Poll::Ready(Some(v));
+            }
+        }
+        
+        Poll::Ready(None)
+    }
+}

--- a/src/stream/stream/unique_by.rs
+++ b/src/stream/stream/unique_by.rs
@@ -1,0 +1,65 @@
+use std::pin::Pin;
+use std::hash::Hash;
+use std::collections::HashSet;
+
+use pin_project_lite::pin_project;
+
+use crate::stream::Stream;
+use crate::task::{Context, Poll};
+
+pin_project! {
+    /// A stream that filters out duplicate items.
+    ///
+    /// Duplicates are detected by comparing the key they map to with the keying
+    /// function `f` by hash and equality. The keys are stored in a hash set in
+    /// the stream.
+    ///
+    /// This `struct` is created by the [`unique`] method on [`Stream`]. See its
+    /// documentation for more.
+    ///
+    /// [`unique`]: trait.Stream.html#method.unique
+    /// [`Stream`]: trait.Stream.html
+    #[cfg(feature="unstable")]
+    #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+    pub struct UniqueBy<S, V, F> {
+        #[pin]
+        stream: S,
+        used: HashSet<V>,
+        f: F,
+    }
+}
+
+impl<S, V, F> UniqueBy<S, V, F>
+where
+    V: Eq + Hash
+{
+    pub(crate) fn new(stream: S, f: F) -> Self {
+        Self {
+            stream,
+            used: HashSet::new(),
+            f
+        }
+    }
+}
+
+impl<S, V, F> Stream for UniqueBy<S, V, F>
+where
+    S: Stream,
+    V: Eq + Hash,
+    F: FnMut(&S::Item) -> V,
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        while let Some(v) = futures_core::ready!(this.stream.as_mut().poll_next(cx)) {
+            let key = (this.f)(&v);
+            if this.used.insert(key) {
+                return Poll::Ready(Some(v));
+            }
+        }
+        
+        Poll::Ready(None)
+    }
+}

--- a/src/stream/stream/unique_by.rs
+++ b/src/stream/stream/unique_by.rs
@@ -14,10 +14,10 @@ pin_project! {
     /// function `f` by hash and equality. The keys are stored in a hash set in
     /// the stream.
     ///
-    /// This `struct` is created by the [`unique`] method on [`Stream`]. See its
+    /// This `struct` is created by the [`unique_by`] method on [`Stream`]. See its
     /// documentation for more.
     ///
-    /// [`unique`]: trait.Stream.html#method.unique
+    /// [`unique_by`]: trait.Stream.html#method.unique_by
     /// [`Stream`]: trait.Stream.html
     #[cfg(feature="unstable")]
     #[cfg_attr(feature = "docs", doc(cfg(unstable)))]


### PR DESCRIPTION
This pull request adds `Stream::unique` and `Stream::unique_by` extension which filters out duplicate items in the stream. These extensions are similar to [`Itertools::unique`](https://docs.rs/itertools/0.7.8/itertools/trait.Itertools.html#method.unique) and [`Itertools::unique_by`](https://docs.rs/itertools/0.7.8/itertools/trait.Itertools.html#method.unique_by) and correspond to the ReactiveX [`Distinct`](http://reactivex.io/documentation/operators/distinct.html) operator.