### PR TITLE
TcpStream: Shutdown write direction in poll_close.

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -356,6 +356,7 @@ impl Write for &TcpStream {
     }
 
     fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.shutdown(std::net::Shutdown::Write)?;
         Poll::Ready(Ok(()))
     }
 }


### PR DESCRIPTION
Fixes #599.