### PR TITLE
upgrade log, remove kv-log-macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ default = [
   "crossbeam-channel",
   "crossbeam-deque",
   "futures-timer",
-  "kv-log-macro",
   "log",
   "mio",
   "mio-uds",
@@ -58,8 +57,7 @@ crossbeam-utils = { version = "0.7.0", optional = true }
 futures-core = { version = "0.3.1", optional = true }
 futures-io = { version = "0.3.1", optional = true }
 futures-timer = { version = "2.0.2", optional = true }
-kv-log-macro = { version = "1.0.4", optional = true }
-log = { version = "0.4.8", features = ["kv_unstable"], optional = true }
+log = { version = "0.4.10", features = ["kv_unstable"], optional = true }
 memchr = { version = "2.2.1", optional = true }
 mio = { version = "0.6.19", optional = true }
 mio-uds = { version = "0.6.7", optional = true }

--- a/src/task/block_on.rs
+++ b/src/task/block_on.rs
@@ -6,7 +6,6 @@ use std::task::{RawWaker, RawWakerVTable};
 use std::thread;
 
 use crossbeam_utils::sync::Parker;
-use kv_log_macro::trace;
 use log::log_enabled;
 
 use crate::task::{Context, Poll, Task, Waker};
@@ -43,7 +42,7 @@ where
 
     // Log this `block_on` operation.
     if log_enabled!(log::Level::Trace) {
-        trace!("block_on", {
+        log::trace!("block_on", {
             task_id: task.id().0,
             parent_task_id: Task::get_current(|t| t.id().0).unwrap_or(0),
         });
@@ -59,7 +58,7 @@ where
         defer! {
             if log_enabled!(log::Level::Trace) {
                 Task::get_current(|t| {
-                    trace!("completed", {
+                    log::trace!("completed", {
                         task_id: t.id().0,
                     });
                 });

--- a/src/task/builder.rs
+++ b/src/task/builder.rs
@@ -1,4 +1,3 @@
-use kv_log_macro::trace;
 use log::log_enabled;
 use std::future::Future;
 
@@ -38,7 +37,7 @@ impl Builder {
 
         // Log this `spawn` operation.
         if log_enabled!(log::Level::Trace) {
-            trace!("spawn", {
+            log::trace!("spawn", {
                 task_id: task.id().0,
                 parent_task_id: Task::get_current(|t| t.id().0).unwrap_or(0),
             });
@@ -54,7 +53,7 @@ impl Builder {
             defer! {
                 if log_enabled!(log::Level::Trace) {
                     Task::get_current(|t| {
-                        trace!("completed", {
+                        log::trace!("completed", {
                             task_id: t.id().0,
                         });
                     });


### PR DESCRIPTION
Removes `kv-log-macro`, upgrades the `log` crate. Kv logging is now allowed by the macros so this gets rid of an extra dependency. Thanks!