### PR TITLE
Revert "upgrade log, remove kv-log-macro"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ default = [
   "crossbeam-channel",
   "crossbeam-deque",
   "futures-timer",
+  "kv-log-macro",
   "log",
   "mio",
   "mio-uds",
@@ -57,7 +58,8 @@ crossbeam-utils = { version = "0.7.0", optional = true }
 futures-core = { version = "0.3.1", optional = true }
 futures-io = { version = "0.3.1", optional = true }
 futures-timer = { version = "2.0.2", optional = true }
-log = { version = "0.4.10", features = ["kv_unstable"], optional = true }
+kv-log-macro = { version = "1.0.4", optional = true }
+log = { version = "0.4.8", features = ["kv_unstable"], optional = true }
 memchr = { version = "2.2.1", optional = true }
 mio = { version = "0.6.19", optional = true }
 mio-uds = { version = "0.6.7", optional = true }

--- a/src/task/block_on.rs
+++ b/src/task/block_on.rs
@@ -6,6 +6,7 @@ use std::task::{RawWaker, RawWakerVTable};
 use std::thread;
 
 use crossbeam_utils::sync::Parker;
+use kv_log_macro::trace;
 use log::log_enabled;
 
 use crate::task::{Context, Poll, Task, Waker};
@@ -42,7 +43,7 @@ where
 
     // Log this `block_on` operation.
     if log_enabled!(log::Level::Trace) {
-        log::trace!("block_on", {
+        trace!("block_on", {
             task_id: task.id().0,
             parent_task_id: Task::get_current(|t| t.id().0).unwrap_or(0),
         });
@@ -58,7 +59,7 @@ where
         defer! {
             if log_enabled!(log::Level::Trace) {
                 Task::get_current(|t| {
-                    log::trace!("completed", {
+                    trace!("completed", {
                         task_id: t.id().0,
                     });
                 });

--- a/src/task/builder.rs
+++ b/src/task/builder.rs
@@ -1,3 +1,4 @@
+use kv_log_macro::trace;
 use log::log_enabled;
 use std::future::Future;
 
@@ -37,7 +38,7 @@ impl Builder {
 
         // Log this `spawn` operation.
         if log_enabled!(log::Level::Trace) {
-            log::trace!("spawn", {
+            trace!("spawn", {
                 task_id: task.id().0,
                 parent_task_id: Task::get_current(|t| t.id().0).unwrap_or(0),
             });
@@ -53,7 +54,7 @@ impl Builder {
             defer! {
                 if log_enabled!(log::Level::Trace) {
                     Task::get_current(|t| {
-                        log::trace!("completed", {
+                        trace!("completed", {
                             task_id: t.id().0,
                         });
                     });


### PR DESCRIPTION
Reverts async-rs/async-std#629

Currently it seems to be a compile error.

```
error: failed to select a version for the requirement `log = "^0.4.10"`
  candidate versions found which didn't match: 0.4.8, 0.4.7, 0.4.6, ...
  location searched: crates.io index
required by package `async-std v1.3.0 (/Users/nasa/lab/oss/k-nasa/async-std)`
```

Isn't it because of being yanked?

<img width="241" alt="スクリーンショット 2019-12-18 8 03 02" src="https://user-images.githubusercontent.com/23740172/71041615-da3f7d80-216c-11ea-945e-3442eb263aab.png">
