### PR TITLE
Add try_clone for TcpStream

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -261,6 +261,29 @@ impl TcpStream {
         self.watcher.get_ref().set_nodelay(nodelay)
     }
 
+    /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// The returned TcpStream is a reference to the same stream that this object references.
+    /// Both handles will read and write the same stream of data, and options set on one stream
+    /// will be propagated to the other stream.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # fn main() -> std::io::Result<()> { async_std::task::block_on(async {
+    /// #
+    /// use async_std::net::TcpStream;
+    ///
+    /// let stream = TcpStream::connect("127.0.0.1:8080").await?;
+    /// let cloned_stream = stream.try_clone()?;
+    /// #
+    /// # Ok(()) }) }
+    pub fn try_clone(&self) -> io::Result<TcpStream> {
+        Ok(TcpStream {
+            watcher: Watcher::new(self.watcher.get_ref().try_clone()?)
+        })
+    }
+
     /// Shuts down the read, write, or both halves of this connection.
     ///
     /// This method will cause all pending and future I/O on the specified portions to return

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -94,3 +94,25 @@ fn smoke_async_stream_to_std_listener() -> io::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn cloned_streams() -> io::Result<()> {
+    task::block_on(async {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+
+        let mut stream = TcpStream::connect(&addr).await?;
+        let mut cloned_stream = stream.try_clone()?;
+        let mut incoming = listener.incoming();
+        let mut write_stream = incoming.next().await.unwrap()?;
+        write_stream.write_all(b"Each your doing").await?;
+
+        let mut buf = [0; 15];
+        stream.read_exact(&mut buf[..8]).await?;
+        cloned_stream.read_exact(&mut buf[8..]).await?;
+
+        assert_eq!(&buf[..15], b"Each your doing");
+
+        Ok(())
+    })
+}


### PR DESCRIPTION
From the discussion in #553 

I also updated the client/server example to use `try_clone` instead of `Arc`, as well as added a small test.