### PR TITLE
update stream::Interval internal comments left over from migration

### DIFF
--- a/src/stream/interval.rs
+++ b/src/stream/interval.rs
@@ -85,7 +85,7 @@ impl Stream for Interval {
 /// While technically for large duration it's impossible to represent any
 /// duration as nanoseconds, the largest duration we can represent is about
 /// 427_000 years. Large enough for any interval we would use or calculate in
-/// tokio.
+/// async-std.
 fn duration_to_nanos(dur: Duration) -> Option<u64> {
     dur.as_secs()
         .checked_mul(1_000_000_000)


### PR DESCRIPTION
When we integrated the `Stream::interval` code from `futures-rs` into `async-std` as part of #298 I copied the `stream::Interval` impl as-is from `futures-timer`, which was originally built for Tokio. Was [informed about this today](https://twitter.com/cybertreiber/status/1209464687286460416), so figured we might as well update this. Thanks!

## Refs
- https://github.com/async-rs/futures-timer/blob/27e8bdacd9d600152c8e4e5e35e57890620202b1/src/interval.rs#L75-L82