### PR TITLE
feat: do not require default feature for unstable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ default = [
   "num_cpus",
   "pin-project-lite",
 ]
-docs = ["attributes", "unstable"]
-unstable = ["default", "broadcaster"]
+docs = ["attributes", "unstable", "default"]
+unstable = ["std", "broadcaster", "futures-timer"]
 attributes = ["async-attributes"]
 std = [
   "crossbeam-utils",

--- a/src/future/future/mod.rs
+++ b/src/future/future/mod.rs
@@ -7,7 +7,6 @@ cfg_unstable! {
     mod try_join;
 
     use std::time::Duration;
-
     use delay::DelayFuture;
     use flatten::FlattenFuture;
     use crate::future::IntoFuture;
@@ -15,6 +14,9 @@ cfg_unstable! {
     use try_race::TryRace;
     use join::Join;
     use try_join::TryJoin;
+}
+
+cfg_unstable_default! {
     use crate::future::timeout::TimeoutFuture;
 }
 
@@ -149,7 +151,7 @@ extension_trait! {
         /// dbg!(a.await);
         /// # })
         /// ```
-        #[cfg(all(feature = "default", feature = "unstable"))]
+        #[cfg(feature = "unstable")]
         #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
         fn delay(self, dur: Duration) -> impl Future<Output = Self::Output> [DelayFuture<Self>]
         where
@@ -363,13 +365,13 @@ extension_trait! {
 
             # Example
             ```
-            # async_std::task::block_on(async {  
+            # async_std::task::block_on(async {
             #
             use std::time::Duration;
 
             use async_std::prelude::*;
             use async_std::future;
-            
+
             let fut = future::ready(0);
             let dur = Duration::from_millis(100);
             let res = fut.timeout(dur).await;
@@ -383,7 +385,7 @@ extension_trait! {
             # });
             ```
         "#]
-        #[cfg(any(feature = "unstable", feature = "docs"))]
+        #[cfg(any(all(feature = "default", feature = "unstable"), feature = "docs"))]
         #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
         fn timeout(self, dur: Duration) -> impl Future<Output = Self::Output> [TimeoutFuture<Self>]
             where Self: Sized

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -321,7 +321,7 @@ cfg_default! {
     mod stdout;
 }
 
-cfg_unstable! {
+cfg_unstable_default! {
     pub use stderr::StderrLock;
     pub use stdin::StdinLock;
     pub use stdout::StdoutLock;

--- a/src/io/read/bytes.rs
+++ b/src/io/read/bytes.rs
@@ -32,7 +32,7 @@ impl<T: Read + Unpin> Stream for Bytes<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, default))]
 mod tests {
     use crate::io;
     use crate::prelude::*;

--- a/src/io/read/chain.rs
+++ b/src/io/read/chain.rs
@@ -165,7 +165,7 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, default))]
 mod tests {
     use crate::io;
     use crate::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,9 @@ cfg_unstable! {
     mod option;
     mod string;
     mod collections;
+}
 
+cfg_unstable_default! {
     #[doc(inline)]
     pub use std::{write, writeln};
 }

--- a/src/stream/stream/count.rs
+++ b/src/stream/stream/count.rs
@@ -9,7 +9,7 @@ use crate::task::{Context, Poll};
 pin_project! {
     #[doc(hidden)]
     #[allow(missing_debug_implementations)]
-    #[cfg(all(feature = "default", feature = "unstable"))]
+    #[cfg(feature = "unstable")]
     #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
     pub struct CountFuture<S> {
         #[pin]

--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -355,7 +355,7 @@ extension_trait! {
             # }) }
             ```
         "#]
-        #[cfg(all(feature = "default", feature = "unstable"))]
+        #[cfg(feature = "unstable")]
         #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
         fn throttle(self, d: Duration) -> Throttle<Self>
         where
@@ -1507,7 +1507,7 @@ extension_trait! {
             # }) }
             ```
         "#]
-        #[cfg(all(feature = "default", feature = "unstable"))]
+        #[cfg(feature = "unstable")]
         #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
         fn by_ref(&mut self) -> &mut Self {
             self

--- a/src/stream/stream/partition.rs
+++ b/src/stream/stream/partition.rs
@@ -8,7 +8,7 @@ use crate::task::{Context, Poll};
 
 pin_project! {
     #[derive(Debug)]
-    #[cfg(all(feature = "default", feature = "unstable"))]
+    #[cfg(feature = "unstable")]
     #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
     pub struct PartitionFuture<S, F, B> {
         #[pin]

--- a/src/stream/stream/unzip.rs
+++ b/src/stream/stream/unzip.rs
@@ -8,7 +8,7 @@ use crate::task::{Context, Poll};
 
 pin_project! {
     #[derive(Clone, Debug)]
-    #[cfg(all(feature = "default", feature = "unstable"))]
+    #[cfg(feature = "unstable")]
     #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
     pub struct UnzipFuture<S, FromA, FromB> {
         #[pin]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ pub fn abort_on_panic<T>(f: impl FnOnce() -> T) -> T {
 }
 
 /// Generates a random number in `0..n`.
-#[cfg(feature = "unstable")]
+#[cfg(any(feature = "unstable", feature = "default"))]
 pub fn random(n: u32) -> u32 {
     use std::cell::Cell;
     use std::num::Wrapping;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,6 @@ pub fn abort_on_panic<T>(f: impl FnOnce() -> T) -> T {
 }
 
 /// Generates a random number in `0..n`.
-#[cfg(feature = "default")]
 pub fn random(n: u32) -> u32 {
     use std::cell::Cell;
     use std::num::Wrapping;
@@ -85,6 +84,18 @@ macro_rules! cfg_unstable {
         $(
             #[cfg(feature = "unstable")]
             #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+            $item
+        )*
+    }
+}
+
+/// Declares unstable and default items.
+#[doc(hidden)]
+macro_rules! cfg_unstable_default {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(feature = "default", feature = "unstable"))]
+            #[cfg_attr(feature = "docs", doc(unstable))]
             $item
         )*
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,6 +19,7 @@ pub fn abort_on_panic<T>(f: impl FnOnce() -> T) -> T {
 }
 
 /// Generates a random number in `0..n`.
+#[cfg(feature = "unstable")]
 pub fn random(n: u32) -> u32 {
     use std::cell::Cell;
     use std::num::Wrapping;


### PR DESCRIPTION
This allows using the unstable features, without accidentally enabling the runtime. 