### PR TITLE
Fixing inaccurate function description in udp::recv

### DIFF
--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -288,7 +288,7 @@ impl UdpSocket {
 
     /// Receives data from the socket.
     ///
-    /// On success, returns the number of bytes read and the origin.
+    /// On success, returns the number of bytes read.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The recv function only returns the number of bytes. The current
documentation makes the destiction between recv and recv_from
a bit confusing.