### PR TITLE
Fix typo in stream documentation

### DIFF
--- a/src/stream/stream/mod.rs
+++ b/src/stream/stream/mod.rs
@@ -695,7 +695,7 @@ extension_trait! {
             # }) }
             ```
 
-            An empty stream will return `None:
+            An empty stream will return `None`:
             ```
             # fn main() { async_std::task::block_on(async {
             #


### PR DESCRIPTION
Fix typo in stream documentation. Insert missing `` ` ``.