### PR TITLE
Use `take_while` instead of `scan` in `impl` of `Product`, `Sum` and `FromStream` for `Option` and `Result`

### DIFF
--- a/src/option/from_stream.rs
+++ b/src/option/from_stream.rs
@@ -2,7 +2,7 @@ use std::pin::Pin;
 
 use crate::prelude::*;
 use crate::stream::{FromStream, IntoStream};
-use crate::utils::identity;
+use std::convert::identity;
 
 impl<T, V> FromStream<Option<T>> for Option<V>
 where
@@ -33,11 +33,7 @@ where
                 .collect()
                 .await;
 
-            if found_none {
-                None
-            } else {
-                Some(out)
-            }
+            if found_none { None } else { Some(out) }
         })
     }
 }

--- a/src/option/from_stream.rs
+++ b/src/option/from_stream.rs
@@ -24,6 +24,7 @@ where
                 .take_while(|elem| {
                     elem.is_some() || {
                         found_none = true;
+                        // Stop processing the stream on `None`
                         false
                     }
                 })

--- a/src/option/from_stream.rs
+++ b/src/option/from_stream.rs
@@ -2,6 +2,7 @@ use std::pin::Pin;
 
 use crate::prelude::*;
 use crate::stream::{FromStream, IntoStream};
+use crate::utils::identity;
 
 impl<T, V> FromStream<Option<T>> for Option<V>
 where
@@ -28,7 +29,7 @@ where
                         false
                     }
                 })
-                .map(Option::unwrap)
+                .filter_map(identity)
                 .collect()
                 .await;
 

--- a/src/option/product.rs
+++ b/src/option/product.rs
@@ -48,6 +48,7 @@ where
                     .take_while(|elem| {
                         elem.is_some() || {
                             found_none = true;
+                            // Stop processing the stream on `None`
                             false
                         }
                     })

--- a/src/option/product.rs
+++ b/src/option/product.rs
@@ -2,6 +2,7 @@ use std::pin::Pin;
 
 use crate::prelude::*;
 use crate::stream::{Product, Stream};
+use crate::utils::identity;
 
 impl<T, U> Product<Option<U>> for Option<T>
 where
@@ -52,7 +53,7 @@ where
                             false
                         }
                     })
-                    .map(Option::unwrap),
+                    .filter_map(identity),
             )
             .await;
 

--- a/src/option/product.rs
+++ b/src/option/product.rs
@@ -2,7 +2,7 @@ use std::pin::Pin;
 
 use crate::prelude::*;
 use crate::stream::{Product, Stream};
-use crate::utils::identity;
+use std::convert::identity;
 
 impl<T, U> Product<Option<U>> for Option<T>
 where
@@ -57,11 +57,7 @@ where
             )
             .await;
 
-            if found_none {
-                None
-            } else {
-                Some(out)
-            }
+            if found_none { None } else { Some(out) }
         })
     }
 }

--- a/src/option/product.rs
+++ b/src/option/product.rs
@@ -1,7 +1,7 @@
 use std::pin::Pin;
 
 use crate::prelude::*;
-use crate::stream::{Stream, Product};
+use crate::stream::{Product, Stream};
 
 impl<T, U> Product<Option<U>> for Option<T>
 where
@@ -36,23 +36,24 @@ where
         ```
     "#]
     fn product<'a, S>(stream: S) -> Pin<Box<dyn Future<Output = Option<T>> + 'a>>
-        where S: Stream<Item = Option<U>> + 'a
+    where
+        S: Stream<Item = Option<U>> + 'a,
     {
         Box::pin(async move {
-            // Using `scan` here because it is able to stop the stream early
+            // Using `take_while` here because it is able to stop the stream early
             // if a failure occurs
             let mut found_none = false;
-            let out = <T as Product<U>>::product(stream
-                .scan((), |_, elem| {
-                    match elem {
-                        Some(elem) => Some(elem),
-                        None => {
+            let out = <T as Product<U>>::product(
+                stream
+                    .take_while(|elem| {
+                        elem.is_some() || {
                             found_none = true;
-                            // Stop processing the stream on error
-                            None
+                            false
                         }
-                    }
-                })).await;
+                    })
+                    .map(Option::unwrap),
+            )
+            .await;
 
             if found_none {
                 None

--- a/src/option/sum.rs
+++ b/src/option/sum.rs
@@ -2,7 +2,7 @@ use std::pin::Pin;
 
 use crate::prelude::*;
 use crate::stream::{Stream, Sum};
-use crate::utils::identity;
+use std::convert::identity;
 
 impl<T, U> Sum<Option<U>> for Option<T>
 where
@@ -52,11 +52,7 @@ where
             )
             .await;
 
-            if found_none {
-                None
-            } else {
-                Some(out)
-            }
+            if found_none { None } else { Some(out) }
         })
     }
 }

--- a/src/option/sum.rs
+++ b/src/option/sum.rs
@@ -43,6 +43,7 @@ where
                     .take_while(|elem| {
                         elem.is_some() || {
                             found_none = true;
+                            // Stop processing the stream on error
                             false
                         }
                     })

--- a/src/option/sum.rs
+++ b/src/option/sum.rs
@@ -2,6 +2,7 @@ use std::pin::Pin;
 
 use crate::prelude::*;
 use crate::stream::{Stream, Sum};
+use crate::utils::identity;
 
 impl<T, U> Sum<Option<U>> for Option<T>
 where
@@ -43,11 +44,11 @@ where
                     .take_while(|elem| {
                         elem.is_some() || {
                             found_none = true;
-                            // Stop processing the stream on error
+                            // Stop processing the stream on `None`
                             false
                         }
                     })
-                    .map(Option::unwrap),
+                    .filter_map(identity),
             )
             .await;
 

--- a/src/result/from_stream.rs
+++ b/src/result/from_stream.rs
@@ -21,7 +21,7 @@ where
             // if a failure occurs
             let mut found_error = None;
             let out: V = stream
-                .scan((), |_, elem| {
+                .scan((), |(), elem| {
                     match elem {
                         Ok(elem) => Some(elem),
                         Err(err) => {

--- a/src/result/from_stream.rs
+++ b/src/result/from_stream.rs
@@ -21,11 +21,11 @@ where
             // if a failure occurs
             let mut found_error = None;
             let out: V = stream
-                .scan((), |(), elem| {
+                .scan(&mut found_error, |error, elem| {
                     match elem {
                         Ok(elem) => Some(elem),
                         Err(err) => {
-                            found_error = Some(err);
+                            **error = Some(err);
                             // Stop processing the stream on error
                             None
                         }

--- a/src/result/product.rs
+++ b/src/result/product.rs
@@ -40,24 +40,35 @@ where
         S: Stream<Item = Result<U, E>> + 'a,
     {
         Box::pin(async move {
-            // Using `scan` here because it is able to stop the stream early
+            // Using `take_while` here because it is able to stop the stream early
             // if a failure occurs
+            let mut is_error = false;
             let mut found_error = None;
-            let out = <T as Product<U>>::product(stream.scan(&mut found_error, |error, elem| {
-                match elem {
-                    Ok(elem) => Some(elem),
-                    Err(err) => {
-                        **error = Some(err);
-                        // Stop processing the stream on error
-                        None
-                    }
-                }
-            }))
+            let out = <T as Product<U>>::product(
+                stream
+                    .take_while(|elem| {
+                        // Stop processing the stream on `Err`
+                        !is_error
+                            && (elem.is_ok() || {
+                                is_error = true;
+                                // Capture first `Err`
+                                true
+                            })
+                    })
+                    .filter_map(|elem| match elem {
+                        Ok(value) => Some(value),
+                        Err(err) => {
+                            found_error = Some(err);
+                            None
+                        }
+                    }),
+            )
             .await;
 
-            match found_error {
-                Some(err) => Err(err),
-                None => Ok(out),
+            if is_error {
+                Err(found_error.unwrap())
+            } else {
+                Ok(out)
             }
         })
     }

--- a/src/result/product.rs
+++ b/src/result/product.rs
@@ -43,11 +43,11 @@ where
             // Using `scan` here because it is able to stop the stream early
             // if a failure occurs
             let mut found_error = None;
-            let out = <T as Product<U>>::product(stream.scan((), |(), elem| {
+            let out = <T as Product<U>>::product(stream.scan(&mut found_error, |error, elem| {
                 match elem {
                     Ok(elem) => Some(elem),
                     Err(err) => {
-                        found_error = Some(err);
+                        **error = Some(err);
                         // Stop processing the stream on error
                         None
                     }

--- a/src/result/sum.rs
+++ b/src/result/sum.rs
@@ -43,11 +43,11 @@ where
             // Using `scan` here because it is able to stop the stream early
             // if a failure occurs
             let mut found_error = None;
-            let out = <T as Sum<U>>::sum(stream.scan((), |(), elem| {
+            let out = <T as Sum<U>>::sum(stream.scan(&mut found_error, |error, elem| {
                 match elem {
                     Ok(elem) => Some(elem),
                     Err(err) => {
-                        found_error = Some(err);
+                        **error = Some(err);
                         // Stop processing the stream on error
                         None
                     }

--- a/src/result/sum.rs
+++ b/src/result/sum.rs
@@ -40,24 +40,35 @@ where
         S: Stream<Item = Result<U, E>> + 'a,
     {
         Box::pin(async move {
-            // Using `scan` here because it is able to stop the stream early
+            // Using `take_while` here because it is able to stop the stream early
             // if a failure occurs
+            let mut is_error = false;
             let mut found_error = None;
-            let out = <T as Sum<U>>::sum(stream.scan(&mut found_error, |error, elem| {
-                match elem {
-                    Ok(elem) => Some(elem),
-                    Err(err) => {
-                        **error = Some(err);
-                        // Stop processing the stream on error
-                        None
-                    }
-                }
-            }))
+            let out = <T as Sum<U>>::sum(
+                stream
+                    .take_while(|elem| {
+                        // Stop processing the stream on `Err`
+                        !is_error
+                            && (elem.is_ok() || {
+                                is_error = true;
+                                // Capture first `Err`
+                                true
+                            })
+                    })
+                    .filter_map(|elem| match elem {
+                        Ok(value) => Some(value),
+                        Err(err) => {
+                            found_error = Some(err);
+                            None
+                        }
+                    }),
+            )
             .await;
 
-            match found_error {
-                Some(err) => Err(err),
-                None => Ok(out),
+            if is_error {
+                Err(found_error.unwrap())
+            } else {
+                Ok(out)
             }
         })
     }

--- a/src/unit/from_stream.rs
+++ b/src/unit/from_stream.rs
@@ -8,6 +8,6 @@ impl FromStream<()> for () {
     fn from_stream<'a, S: IntoStream<Item = ()> + 'a>(
         stream: S,
     ) -> Pin<Box<dyn Future<Output = Self> + 'a>> {
-        Box::pin(stream.into_stream().for_each(|_| ()))
+        Box::pin(stream.into_stream().for_each(drop))
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,6 +52,14 @@ pub fn random(n: u32) -> u32 {
     })
 }
 
+/// Returns given argument without changes.
+#[allow(dead_code)]
+#[doc(hidden)]
+#[inline(always)]
+pub(crate) fn identity<T>(arg: T) -> T {
+    arg
+}
+
 /// Add additional context to errors
 pub(crate) trait Context {
     fn context(self, message: impl Fn() -> String) -> Self;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,14 +52,6 @@ pub fn random(n: u32) -> u32 {
     })
 }
 
-/// Returns given argument without changes.
-#[allow(dead_code)]
-#[doc(hidden)]
-#[inline(always)]
-pub(crate) fn identity<T>(arg: T) -> T {
-    arg
-}
-
 /// Add additional context to errors
 pub(crate) trait Context {
     fn context(self, message: impl Fn() -> String) -> Self;


### PR DESCRIPTION
Use of `take_while` instead of `scan` is much clear because
- `take_while` is designed for this kind of tasks
- Current implementation doesn't use `scan` state