### PR TITLE
Avoid doctest errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,8 @@
 //!
 //! Call an async function from the main function:
 //!
-//! ```
+#![cfg_attr(feature = "attributes", doc = "```")]
+#![cfg_attr(not(feature = "attributes"), doc = "```rust,ignore")]
 //! async fn say_hello() {
 //!     println!("Hello, world!");
 //! }
@@ -151,7 +152,8 @@
 //!
 //! Await two futures concurrently, and return a tuple of their output:
 //!
-//! ```
+#![cfg_attr(all(feature = "unstable", feature = "attributes"), doc = "```")]
+#![cfg_attr(not(all(feature = "unstable", feature = "attributes")), doc = "```rust,ignore")]
 //! use async_std::prelude::*;
 //!
 //! #[async_std::main]
@@ -164,7 +166,8 @@
 //!
 //! Create a UDP server that echoes back each received message to the sender:
 //!
-//! ```no_run
+#![cfg_attr(feature = "attributes", doc = "```no_run")]
+#![cfg_attr(not(feature = "attributes"), doc = "```rust,ignore")]
 //! use async_std::net::UdpSocket;
 //!
 //! #[async_std::main]


### PR DESCRIPTION
It seems like proc macros don't work in doctests:

```
test src/lib.rs -  (line 167) ... FAILED
test src/lib.rs -  (line 154) ... FAILED
test src/lib.rs -  (line 141) ... FAILED
```

> error[E0433]: failed to resolve: could not find `main` in `async_std`
> ```
> --> src/lib.rs:146:14
>   |
> 8 | #[async_std::main]
>   |              ^^^^ could not find `main` in `async_std`
> ```

The problem is visible when running `cargo test --all`. Tested on Rust 1.40 and 1.42 nightly.

