### PR TITLE
Remove usage of unstable format_code_in_doc_comments option

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
 version = "Two"
-format_code_in_doc_comments = true


### PR DESCRIPTION
fix build fail in #677

based on: https://github.com/async-rs/async-std/pull/677#issuecomment-575083054

> * this option is unstable
> * (AFAIK) many docs with examples of this crate are in macros and rustfmt doesn't format code in macros, so are the benefits of using this option in this crate should not be very big.

related: https://github.com/async-rs/async-std/pull/515#pullrequestreview-315682327

> I'm (pleasantly) surprised that only two tests had to be reformatted :)

this may be because of the few places where it can be applied... 
