### PR TITLE
Use non-blocking connect for TcpStream.

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -4,10 +4,9 @@ use std::pin::Pin;
 
 use crate::future;
 use crate::io::{self, Read, Write};
-use crate::net::driver::Watcher;
+use crate::net::driver::{Interest, Watcher};
 use crate::net::ToSocketAddrs;
-use crate::task::{spawn_blocking, Context, Poll};
-use crate::utils::Context as _;
+use crate::task::{Context, Poll};
 
 /// A TCP stream between a local and a remote socket.
 ///
@@ -77,20 +76,51 @@ impl TcpStream {
             .await?;
 
         for addr in addrs {
-            let res = spawn_blocking(move || {
-                let std_stream = std::net::TcpStream::connect(addr)
-                    .context(|| format!("could not connect to {}", addr))?;
-                let mio_stream = mio::net::TcpStream::from_stream(std_stream)
-                    .context(|| format!("could not open async connection to {}", addr))?;
-                Ok(TcpStream {
-                    watcher: Watcher::new(mio_stream),
-                })
+            let mut watcher = None;
+            let connected = future::poll_fn(|cx| {
+                match &mut watcher {
+                    None => {
+                        // mio's connect is non-blocking and may just be in progress when
+                        // it returns with `Ok`. We therefore register our write interest
+                        // and once writable we know the connection is either established
+                        // or there was an error which we check for afterwards.
+                        match mio::net::TcpStream::connect(&addr) {
+                            Ok(s) => {
+                                let waker = cx.waker().clone();
+                                watcher = Some(Watcher::new_with(s, Interest::Write, None, Some(waker)))
+                            }
+                            Err(e) => return Poll::Ready(Err(e))
+                        }
+                        Poll::Pending
+                    }
+                    Some(w) =>
+                        if let Err(e) = w.reconfigure(Interest::All) {
+                            Poll::Ready(Err(e))
+                        } else {
+                            Poll::Ready(Ok(()))
+                        }
+                }
             })
             .await;
 
-            match res {
-                Ok(stream) => return Ok(stream),
-                Err(err) => last_err = Some(err),
+            if let Err(e) = connected {
+                last_err = Some(e);
+                continue
+            }
+
+            debug_assert!(watcher.is_some());
+
+            let watcher =
+                if let Some(w) = watcher {
+                    w
+                } else {
+                    continue
+                };
+
+            match watcher.get_ref().take_error() {
+                Ok(None) => return Ok(TcpStream { watcher }),
+                Ok(Some(e)) => last_err = Some(e),
+                Err(e) => last_err = Some(e)
             }
         }
 


### PR DESCRIPTION
Instead of spawning a background thread which is unaware of any timeouts but continues to run until the TCP stack decides that the remote is not reachable we use mio's non-blocking connect.

mio's `TcpStream::connect` returns immediately but the actual connection is usually just in progress and we have to be sure the socket is writeable before we can consider the connection as established.

~The `Watcher` and `Reactor` APIs have changed a bit to (a) allow registration together with an initial set of `Waker`s in order to avoid missing any wakeups that may occur before we even registered a `Waker` with `Watcher::{poll_read_with, poll_write_with}`, and (b) to allow registration with readiness interests other than `PollOpt::all()`.~

**Update**: Following a suggestion of @stjepang we offer methods to check for read/write readiness of a `Watcher` instead of the approach in the previous paragraph to accept a set of `Waker`s when registering an event source. The changes relative to master are smaller and both methods look more useful in other contexts. Also the code is more robust w.r.t. wakeups of the `Waker` from clones outside the `Reactor`.

I am not sure if we need to add protection mechanisms against spurious wakeups from mio. Currently we treat the `Poll::Ready(())` from `Watcher::poll_write_ready` as proof that the non-blocking connect has finished, but if the event from mio was a spurious one, it might still be ongoing.

Context: #678.