### PR TITLE
Added support for configuring number of threads, and thread name, used by POOL in task::executor

### DIFF
--- a/examples/a-chat/server.rs
+++ b/examples/a-chat/server.rs
@@ -10,6 +10,7 @@ use async_std::{
     net::{TcpListener, TcpStream, ToSocketAddrs},
     prelude::*,
     task,
+    task::RuntimeConfig,
 };
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
@@ -20,6 +21,11 @@ type Receiver<T> = mpsc::UnboundedReceiver<T>;
 enum Void {}
 
 pub(crate) fn main() -> Result<()> {
+    let mut config = RuntimeConfig::new();
+    let num_threads = num_cpus::get() / 2;
+    config.num_thread(num_threads).thread_name("a-chat-server");
+    assert!(config.finalize().is_ok());
+
     task::block_on(accept_loop("127.0.0.1:8080"))
 }
 

--- a/src/task/executor/mod.rs
+++ b/src/task/executor/mod.rs
@@ -6,6 +6,7 @@
 //! * The only import is the `crate::task::Runnable` type.
 
 pub(crate) use pool::schedule;
+pub use pool::RuntimeConfig;
 
 use sleepers::Sleepers;
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -140,6 +140,7 @@ cfg_default! {
     pub use sleep::sleep;
     pub use spawn::spawn;
     pub use task_local::{AccessError, LocalKey};
+    pub use executor::RuntimeConfig;
 
     use builder::Runnable;
     use task_local::LocalsMap;


### PR DESCRIPTION
This update allows user of this library to, optionally, configure the number of threads, and thread names, used by `task::executor::pool::POOL`.

### example: 
```rust
/// execute this before calling 'task::block_on()'
let mut config = RuntimeConfig::new();
config.num_thread(4).thread_name("my-thread");
assert!(config.finalize().is_ok());

/// now only 4 worker threads will be created (named 'my-thread')
task::block_on(...)
```