### PR TITLE
Add missing ? operator after handle.await

### DIFF
--- a/docs/src/tutorial/receiving_messages.md
+++ b/docs/src/tutorial/receiving_messages.md
@@ -111,7 +111,7 @@ We can "fix" it by waiting for the task to be joined, like this:
 #
 # async move |stream| {
 let handle = task::spawn(connection_loop(stream));
-handle.await
+handle.await?
 # };
 ```
 


### PR DESCRIPTION
According to line#118 (https://github.com/async-rs/async-std/blob/master/docs/src/tutorial/receiving_messages.md), there should be a `?` operator after `await`.