### PR TITLE
Enforce non zero capacity for channel

### DIFF
--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -58,7 +58,7 @@ use crate::sync::WakerSet;
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 pub fn channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
-    assert!(cap >= 1);
+    debug_assert!(cap >= 1);
     let channel = Arc::new(Channel::with_capacity(cap));
     let s = Sender {
         channel: channel.clone(),

--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -58,6 +58,7 @@ use crate::sync::WakerSet;
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 pub fn channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
+    assert!(cap >= 1);
     let channel = Arc::new(Channel::with_capacity(cap));
     let s = Sender {
         channel: channel.clone(),


### PR DESCRIPTION
This aligns the function with it's documentation and will result in easier to resolve errors for problems such as #712. 

closes #712 

