### PR TITLE
Make the split struct public

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -275,7 +275,7 @@ cfg_std! {
     #[doc(inline)]
     pub use std::io::{Error, ErrorKind, IoSlice, IoSliceMut, Result, SeekFrom};
 
-    pub use buf_read::{BufRead, Lines};
+    pub use buf_read::{BufRead, Lines, Split};
     pub use buf_reader::BufReader;
     pub use buf_writer::{BufWriter, IntoInnerError};
     pub use copy::copy;


### PR DESCRIPTION
Noticed the `Split` struct wasn't public. This fixes that. Thanks!