### PR TITLE
Upgrade to mio 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,9 @@ default = [
   "kv-log-macro",
   "log",
   "mio",
-  "mio-uds",
+  "mio/tcp",
+  "mio/udp",
+  "mio/uds",
   "num_cpus",
   "pin-project-lite",
 ]
@@ -67,8 +69,7 @@ futures-timer = { version = "3.0.2", optional = true }
 kv-log-macro = { version = "1.0.4", optional = true }
 log = { version = "0.4.8", features = ["kv_unstable"], optional = true }
 memchr = { version = "2.3.3", optional = true }
-mio = { version = "0.6.19", optional = true }
-mio-uds = { version = "0.6.7", optional = true }
+mio = { version = "0.7.0", optional = true }
 num_cpus = { version = "1.12.0", optional = true }
 once_cell = { version = "1.3.1", optional = true }
 pin-project-lite = { version = "0.1.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ default = [
   "kv-log-macro",
   "log",
   "mio",
+  "mio/os-poll",
   "mio/tcp",
   "mio/udp",
   "mio/uds",

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -204,6 +204,11 @@ impl<'a> Stream for Incoming<'a> {
 impl From<std::net::TcpListener> for TcpListener {
     /// Converts a `std::net::TcpListener` into its asynchronous equivalent.
     fn from(listener: std::net::TcpListener) -> TcpListener {
+        // Make sure we are in nonblocking mode.
+        listener
+            .set_nonblocking(true)
+            .expect("failed to set nonblocking mode");
+
         let mio_listener = mio::net::TcpListener::from_std(listener);
         TcpListener {
             watcher: Watcher::new(mio_listener),

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -343,6 +343,7 @@ impl Write for TcpStream {
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.shutdown(std::net::Shutdown::Write)?;
         Pin::new(&mut &*self).poll_close(cx)
     }
 }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 
 use crate::future;
 use crate::io::{self, Read, Write};
-use crate::rt::Watcher;
 use crate::net::ToSocketAddrs;
+use crate::rt::Watcher;
 use crate::task::{Context, Poll};
 
 /// A TCP stream between a local and a remote socket.
@@ -79,7 +79,7 @@ impl TcpStream {
             // when it returns with `Ok`. We therefore wait for write readiness to
             // be sure the connection has either been established or there was an
             // error which we check for afterwards.
-            let watcher = match mio::net::TcpStream::connect(&addr) {
+            let watcher = match mio::net::TcpStream::connect(addr) {
                 Ok(s) => Watcher::new(s),
                 Err(e) => {
                     last_err = Some(e);
@@ -370,7 +370,7 @@ impl Write for &TcpStream {
 impl From<std::net::TcpStream> for TcpStream {
     /// Converts a `std::net::TcpStream` into its asynchronous equivalent.
     fn from(stream: std::net::TcpStream) -> TcpStream {
-        let mio_stream = mio::net::TcpStream::from_stream(stream).unwrap();
+        let mio_stream = mio::net::TcpStream::from_std(stream);
         TcpStream {
             watcher: Arc::new(Watcher::new(mio_stream)),
         }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -370,6 +370,11 @@ impl Write for &TcpStream {
 impl From<std::net::TcpStream> for TcpStream {
     /// Converts a `std::net::TcpStream` into its asynchronous equivalent.
     fn from(stream: std::net::TcpStream) -> TcpStream {
+        // Make sure we are in nonblocking mode.
+        stream
+            .set_nonblocking(true)
+            .expect("failed to set nonblocking mode");
+
         let mio_stream = mio::net::TcpStream::from_std(stream);
         TcpStream {
             watcher: Arc::new(Watcher::new(mio_stream)),

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -496,6 +496,11 @@ impl UdpSocket {
 impl From<std::net::UdpSocket> for UdpSocket {
     /// Converts a `std::net::UdpSocket` into its asynchronous equivalent.
     fn from(socket: std::net::UdpSocket) -> UdpSocket {
+        // Make sure we are in nonblocking mode.
+        socket
+            .set_nonblocking(true)
+            .expect("failed to set nonblocking mode");
+
         let mio_socket = mio::net::UdpSocket::from_std(socket);
         UdpSocket {
             watcher: Watcher::new(mio_socket),

--- a/src/os/unix/net/datagram.rs
+++ b/src/os/unix/net/datagram.rs
@@ -3,7 +3,6 @@
 use std::fmt;
 use std::net::Shutdown;
 
-use super::SocketAddr;
 use crate::future;
 use crate::io;
 use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};

--- a/src/os/unix/net/datagram.rs
+++ b/src/os/unix/net/datagram.rs
@@ -9,7 +9,6 @@ use crate::io;
 use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use crate::path::Path;
 use crate::rt::Watcher;
-use crate::task::spawn_blocking;
 
 /// A Unix datagram socket.
 ///
@@ -65,8 +64,8 @@ impl UnixDatagram {
     /// ```
     pub async fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixDatagram> {
         let path = path.as_ref().to_owned();
-        let socket = spawn_blocking(move || mio::net::UnixDatagram::bind(path)).await?;
-        Ok(UnixDatagram::new(socket))
+        let mio_socket = mio::net::UnixDatagram::bind(path)?;
+        Ok(UnixDatagram::new(mio_socket))
     }
 
     /// Creates a Unix datagram which is not bound to any address.

--- a/src/os/unix/net/datagram.rs
+++ b/src/os/unix/net/datagram.rs
@@ -313,6 +313,11 @@ impl fmt::Debug for UnixDatagram {
 impl From<std::os::unix::net::UnixDatagram> for UnixDatagram {
     /// Converts a `std::os::unix::net::UnixDatagram` into its asynchronous equivalent.
     fn from(datagram: std::os::unix::net::UnixDatagram) -> UnixDatagram {
+        // Make sure we are in nonblocking mode.
+        datagram
+            .set_nonblocking(true)
+            .expect("failed to set nonblocking mode");
+
         let mio_datagram = mio::net::UnixDatagram::from_std(datagram);
         UnixDatagram {
             watcher: Watcher::new(mio_datagram),

--- a/src/os/unix/net/listener.rs
+++ b/src/os/unix/net/listener.rs
@@ -195,6 +195,11 @@ impl Stream for Incoming<'_> {
 impl From<std::os::unix::net::UnixListener> for UnixListener {
     /// Converts a `std::os::unix::net::UnixListener` into its asynchronous equivalent.
     fn from(listener: std::os::unix::net::UnixListener) -> UnixListener {
+        // Make sure we are in nonblocking mode.
+        listener
+            .set_nonblocking(true)
+            .expect("failed to set nonblocking mode");
+
         let mio_listener = mio::net::UnixListener::from_std(listener);
         UnixListener {
             watcher: Watcher::new(mio_listener),

--- a/src/os/unix/net/listener.rs
+++ b/src/os/unix/net/listener.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 
-use super::SocketAddr;
 use super::UnixStream;
 use crate::future;
 use crate::io;

--- a/src/os/unix/net/stream.rs
+++ b/src/os/unix/net/stream.rs
@@ -235,6 +235,11 @@ impl fmt::Debug for UnixStream {
 impl From<std::os::unix::net::UnixStream> for UnixStream {
     /// Converts a `std::os::unix::net::UnixStream` into its asynchronous equivalent.
     fn from(stream: std::os::unix::net::UnixStream) -> UnixStream {
+        // Make sure we are in nonblocking mode.
+        stream
+            .set_nonblocking(true)
+            .expect("failed to set nonblocking mode");
+
         let mio_stream = mio::net::UnixStream::from_std(stream);
         UnixStream {
             watcher: Watcher::new(mio_stream),

--- a/src/os/unix/net/stream.rs
+++ b/src/os/unix/net/stream.rs
@@ -5,7 +5,6 @@ use std::io::{Read as _, Write as _};
 use std::net::Shutdown;
 use std::pin::Pin;
 
-use super::SocketAddr;
 use crate::future;
 use crate::io::{self, Read, Write};
 use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};

--- a/src/os/unix/net/stream.rs
+++ b/src/os/unix/net/stream.rs
@@ -192,6 +192,7 @@ impl Write for UnixStream {
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.shutdown(std::net::Shutdown::Write)?;
         Pin::new(&mut &*self).poll_close(cx)
     }
 }

--- a/src/os/unix/net/stream.rs
+++ b/src/os/unix/net/stream.rs
@@ -211,6 +211,7 @@ impl Write for &UnixStream {
     }
 
     fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.shutdown(std::net::Shutdown::Write)?;
         Poll::Ready(Ok(()))
     }
 }


### PR DESCRIPTION
Compiles, but seems something about handling socket connections has changed that needs further debugging. 

Mio returns now `mio::net::SocketAddr`s, which can not be converted easily to `std` versions, this needs some more investigation.

**Update** TCP tests are passing now, still one issue with UDS. 

Closes #717 