### PR TITLE
feat: add env vars to configure the runtime threadpool size and name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,21 @@
 //! default-features = false
 //! features = ["alloc"]
 //! ```
+//!
+//! # Runtime configuration
+//!
+//! Several environment variables are available to tune the async-std
+//! runtime:
+//!
+//! * `ASYNC_STD_THREAD_COUNT`: The number of threads that the
+//! async-std runtime will start. By default, this is one per logical
+//! cpu as reported by the [num_cpus](num_cpus) crate, which may be
+//! different than the number of physical cpus. Async-std _will panic_
+//! if this is set to any value other than a positive integer.
+//! * `ASYNC_STD_THREAD_NAME`: The name that async-std's runtime
+//! threads report to the operating system. The default value is
+//! `"async-std/runtime"`.
+//!
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "docs", feature(doc_cfg))]

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -1,5 +1,6 @@
 //! The runtime.
 
+use std::env;
 use std::thread;
 
 use once_cell::sync::Lazy;
@@ -12,10 +13,20 @@ pub struct Runtime {}
 /// The global runtime.
 pub static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
     // Create an executor thread pool.
-    let num_threads = num_cpus::get().max(1);
-    for _ in 0..num_threads {
+
+    let thread_count = env::var("ASYNC_STD_THREAD_COUNT")
+        .map(|env| {
+            env.parse()
+                .expect("ASYNC_STD_THREAD_COUNT must be a number")
+        })
+        .unwrap_or_else(|_| num_cpus::get())
+        .max(1);
+
+    let thread_name = env::var("ASYNC_STD_THREAD_NAME").unwrap_or("async-std/runtime".to_string());
+
+    for _ in 0..thread_count {
         thread::Builder::new()
-            .name("async-std/runtime".to_string())
+            .name(thread_name.clone())
             .spawn(|| smol::run(future::pending::<()>()))
             .expect("cannot start a runtime thread");
     }


### PR DESCRIPTION
I read the thread at #690 and this seemed like an easy change to make.

I tried to find a good balance between accurate-but-verbose (ASYNC_STD_RT_POOL_SIZE, ASYNC_STD_RT_THREAD_NAME) and concise-but-generic (RT_THREADS, RT_NAME).

Would people want to be able to optionally include the thread number in the thread name? I'm not certain why they would want to, but I believe I've seen that in other threadpools.  If so, the thread name variable might include some substitution placeholder.

# docs:
![image](https://user-images.githubusercontent.com/13301/81866197-b61d7800-9523-11ea-9852-a3c68f23a1c0.png)
