### PR TITLE
Switches `wasm-timer` for `futures-timer`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 
 ## [Unreleased]
 
+## Changed
+
+- For `wasm`, switched underlying `Timer` implementation to [`futures-timer`](https://github.com/async-rs/futures-timer). ([#776](https://github.com/async-rs/async-std/pull/776))
+
 # [1.6.0-beta.1] - 2020-05-07
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ std = [
   "pin-utils",
   "slab",
   "smol",
-  "wasm-timer",
+  "futures-timer",
   "wasm-bindgen-futures",
   "futures-channel",
 ]
@@ -74,7 +74,7 @@ surf = { version = "1.0.3", optional = true }
 smol = { version = "0.1.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-timer = { version = "0.2.4", optional = true }
+futures-timer = { version = "3.0.2", optional = true, features = ["wasm-bindgen"] }
 wasm-bindgen-futures = { version = "0.4.10", optional = true }
 futures-channel = { version = "0.3.4", optional = true }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -64,12 +64,12 @@ pub(crate) type Timer = smol::Timer;
 
 #[cfg(all(target_arch = "wasm32", feature = "default"))]
 #[derive(Debug)]
-pub(crate) struct Timer(wasm_timer::Delay);
+pub(crate) struct Timer(futures_timer::Delay);
 
 #[cfg(all(target_arch = "wasm32", feature = "default"))]
 impl Timer {
     pub(crate) fn after(dur: std::time::Duration) -> Self {
-        Timer(wasm_timer::Delay::new(dur))
+        Timer(futures_timer::Delay::new(dur))
     }
 }
 

--- a/tests/condvar.rs
+++ b/tests/condvar.rs
@@ -29,7 +29,7 @@ fn wait_timeout_with_lock() {
 
         let (m, c) = &*pair;
         let (_, wait_result) = c
-            .wait_timeout(m.lock().await, Duration::from_millis(100))
+            .wait_timeout(m.lock().await, Duration::from_millis(50))
             .await;
         assert!(wait_result.timed_out());
     })


### PR DESCRIPTION
Fixes #775.
