### PR TITLE
Fix spawning blocking tasks with smol runtime.

### DIFF
--- a/src/task/spawn_blocking.rs
+++ b/src/task/spawn_blocking.rs
@@ -37,6 +37,6 @@ where
 {
     once_cell::sync::Lazy::force(&crate::rt::RUNTIME);
 
-    let handle = smol::Task::blocking(async move { f() }).into();
+    let handle = smol::Task::spawn(async move { f() }).into();
     JoinHandle::new(handle, Task::new(None))
 }


### PR DESCRIPTION
Use smol::Task::spawn() i.s.o smol::Task::blocking() when creating a
blocking task. The latter creates a blocking task within the smol
runtime which can't be converted to an `async_task::JoinHandle`.

Fixes #785.