### PR TITLE
Fix readme for BufRead

### DIFF
--- a/src/io/buf_read/mod.rs
+++ b/src/io/buf_read/mod.rs
@@ -29,7 +29,7 @@ extension_trait! {
 
         ```
         # #[allow(unused_imports)]
-        use async_std::prelude::*;
+        use async_std::io::prelude::*;
         ```
 
         [`std::io::BufRead`]: https://doc.rust-lang.org/std/io/trait.BufRead.html


### PR DESCRIPTION
The `BufRead` readme points to `BufReadExt` being in `async_std::prelude` while it currently lives in `async_std::io::prelude`