### PR TITLE
Add tokio02 feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,17 @@ jobs:
         command:  check
         args: --no-default-features --features alloc --target thumbv7m-none-eabi -Z avoid-dev-deps
 
+  check_tokio_02_feature:
+    name: Check tokio02 feature
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: check tokio02
+      uses: actions-rs/cargo@v1
+      with:
+        command:  check
+        args: --all --features tokio02
+
   cross:
     name: Cross compile
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ alloc = [
   "futures-core/alloc",
   "pin-project-lite",
 ]
+tokio02 = ["smol/tokio02"]
 
 [dependencies]
 async-attributes = { version = "1.1.1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,15 @@
 //! features = ["attributes"]
 //! ```
 //!
+//! Compatibility with the `tokio` runtime is possible using the `tokio02`
+//! Cargo feature:
+//!
+//! ```toml
+//! [dependencies.async-std]
+//! version = "1.6.0"
+//! features = ["tokio02"]
+//! ```
+//!
 //! Additionally it's possible to only use the core traits and combinators by
 //! only enabling the `std` Cargo feature:
 //!


### PR DESCRIPTION
Adds the `tokio02` feature flag. This forwards to `smol`'s `tokio02` feature flag which runs `tokio::rt::enter` whenever a new thread is created. This should allow running `async_std::main` and having `tokio` crates _just work_ ™. Thanks!