### PR TITLE
fix: do not require the runtime to use unstable features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,13 @@ default = [
   "log",
   "num_cpus",
   "pin-project-lite",
+  "smol",
 ]
 docs = ["attributes", "unstable", "default"]
-unstable = ["std"]
+unstable = [
+  "std",
+  "futures-timer",  
+]
 attributes = ["async-attributes"]
 std = [
   "alloc",
@@ -42,8 +46,6 @@ std = [
   "once_cell",
   "pin-utils",
   "slab",
-  "smol",
-  "futures-timer",
   "wasm-bindgen-futures",
   "futures-channel",
 ]
@@ -66,6 +68,7 @@ once_cell = { version = "1.3.1", optional = true }
 pin-project-lite = { version = "0.1.4", optional = true }
 pin-utils = { version = "0.1.0-alpha.4", optional = true }
 slab = { version = "0.4.2", optional = true }
+futures-timer = { version = "3.0.2", optional = true }
 
 # Devdepencency, but they are not allowed to be optional :/
 surf = { version = "1.0.3", optional = true }

--- a/src/future/mod.rs
+++ b/src/future/mod.rs
@@ -61,10 +61,10 @@ cfg_std! {
     mod ready;
 }
 
-cfg_default! {
-    pub use timeout::{timeout, TimeoutError};
-    mod timeout;
-}
+#[cfg(any(feature = "unstable", feature = "default"))]
+pub use timeout::{timeout, TimeoutError};
+#[cfg(any(feature = "unstable", feature = "default"))]
+mod timeout;
 
 cfg_unstable! {
     pub use into_future::IntoFuture;

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -168,7 +168,9 @@ cfg_default! {
 }
 
 cfg_unstable! {
+    #[cfg(feature = "default")]
     pub use spawn_local::spawn_local;
 
+    #[cfg(feature = "default")]
     mod spawn_local;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -64,7 +64,10 @@ mod timer {
     pub type Timer = smol::Timer;
 }
 
-#[cfg(any(all(target_arch = "wasm32", feature = "default"), feature = "unstable"))]
+#[cfg(any(
+    all(target_arch = "wasm32", feature = "default"),
+    all(feature = "unstable", not(feature = "default"))
+))]
 mod timer {
     use std::pin::Pin;
     use std::task::Poll;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -90,6 +90,7 @@ mod timer {
     }
 }
 
+#[cfg(any(feature = "unstable", feature = "default"))]
 pub(crate) use timer::*;
 
 /// Defers evaluation of a block of code until the end of the scope.


### PR DESCRIPTION
Same as #647 which I broke during the switch to smol