### PR TITLE
fix(rt): use task::block_on on spawned threads

### DIFF
--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -27,7 +27,7 @@ pub static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
     for _ in 0..thread_count {
         thread::Builder::new()
             .name(thread_name.clone())
-            .spawn(|| smol::run(future::pending::<()>()))
+            .spawn(|| crate::task::block_on(future::pending::<()>()))
             .expect("cannot start a runtime thread");
     }
     Runtime {}


### PR DESCRIPTION
This makes sure to capture threads into the recursive block_on detection.