### PR TITLE
ci: update actions/cache to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,19 +30,19 @@ jobs:
         override: true
 
     - name: Cache cargo registry
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.cargo/registry
         key: ${{ matrix.os }}-${{ matrix.rust }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
 
     - name: Cache cargo index
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.cargo/git
         key: ${{ matrix.os }}-${{ matrix.rust }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
 
     - name: Cache cargo build
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: target
         key: ${{ matrix.os }}-${{ matrix.rust }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
@@ -58,7 +58,7 @@ jobs:
       with:
         command:  check
         args: --features unstable --all --bins --examples --tests
-        
+
     - name: check wasm
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
For some reason, the cargo index was never cached in Github Actions (e.g. https://github.com/async-rs/async-std/runs/746758946?check_suite_focus=true#step:5:7).
We had the same issue and updating https://github.com/actions/cache to [v2](https://github.com/actions/cache/releases/tag/v2.0.0) seems to have fixed it.