### PR TITLE
Update kv-log-macro to 1.0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default = [
 docs = ["attributes", "unstable", "default"]
 unstable = [
   "std",
-  "futures-timer",  
+  "futures-timer",
 ]
 attributes = ["async-attributes"]
 std = [
@@ -63,7 +63,7 @@ async-mutex = { version = "1.1.3", optional = true }
 crossbeam-utils = { version = "0.7.2", optional = true }
 futures-core = { version = "0.3.4", optional = true, default-features = false }
 futures-io = { version = "0.3.4", optional = true }
-kv-log-macro = { version = "1.0.4", optional = true }
+kv-log-macro = { version = "1.0.6", optional = true }
 log = { version = "0.4.8", features = ["kv_unstable"], optional = true }
 memchr = { version = "2.3.3", optional = true }
 num_cpus = { version = "1.12.0", optional = true }
@@ -105,4 +105,3 @@ required-features = ["unstable"]
 [[example]]
 name = "surf-web"
 required-features = ["surf"]
-


### PR DESCRIPTION
`async_std-1.6.2` uses `kv-log-macro-1.0.4`.
In `kv-log-macro-1.0.4::log_impl` every log levels were  changed to `Info` as shown [here](https://github.com/yoshuawuyts/kv-log-macro/blob/9c938867f56dd7ec4642301e726493967f5057a3/src/lib.rs#L89).
This has since been fixed [here](https://github.com/yoshuawuyts/kv-log-macro/compare/1.0.4...master#diff-b4aea3e418ccdb71239b96952d9cddb6L89).

This currently results in `async_std` trace logs being shown as info, which is a bit annoying, e.g.:
```
[2020-06-27][14:22:49][async_std::task::builder][INFO] spawn
[2020-06-27][14:22:49][async_std::task::builder][INFO] spawn
[2020-06-27][14:22:49][async_std::task::builder][INFO] spawn
[2020-06-27][14:22:49][async_std::task::builder][INFO] spawn
[2020-06-27][14:22:49][async_std::task::builder][INFO] spawn
[2020-06-27][14:22:49][async_std::task::builder][INFO] spawn
[2020-06-27][14:22:49][async_std::task::builder][INFO] spawn
[2020-06-27][14:22:49][async_std::task::builder][INFO] block_on
[2020-06-27][14:22:49][async_std::task::builder][INFO] block_on
```