### PR TITLE
switch to async-io + blocking + multitask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
         command:  check
         args: --features attributes
 
+    - name: build unstable only
+      uses: actions-rs/cargo@v1
+      with:
+        command:  build
+        args: --no-default-features --features unstable
+
     - name: tests
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ default = [
   "std",
   "async-io",
   "async-task",
+  "blocking",
   "kv-log-macro",
   "log",
   "num_cpus",
@@ -79,6 +80,7 @@ surf = { version = "1.0.3", optional = true }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 async-io = { version = "0.1.5", optional = true }
+blocking = { version = "0.5.0", optional = true }
 smol = { version = "0.1.17", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 [features]
 default = [
   "std",
+  "async-io",
   "async-task",
   "kv-log-macro",
   "log",
@@ -77,6 +78,7 @@ futures-timer = { version = "3.0.2", optional = true }
 surf = { version = "1.0.3", optional = true }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
+async-io = { version = "0.1.5", optional = true }
 smol = { version = "0.1.17", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ default = [
   "futures-lite",
   "kv-log-macro",
   "log",
+  "multitask",
   "num_cpus",
   "pin-project-lite",
-  "smol",
 ]
 docs = ["attributes", "unstable", "default"]
 unstable = [
@@ -57,7 +57,7 @@ alloc = [
   "futures-core/alloc",
   "pin-project-lite",
 ]
-tokio02 = ["smol/tokio02"]
+tokio02 = ["tokio"]
 
 [dependencies]
 async-attributes = { version = "1.1.1", optional = true }
@@ -83,7 +83,7 @@ surf = { version = "1.0.3", optional = true }
 async-io = { version = "0.1.5", optional = true }
 blocking = { version = "0.5.0", optional = true }
 futures-lite = { version = "0.1.8", optional = true }
-smol = { version = "0.1.17", optional = true }
+multitask = { version = "0.2.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures-timer = { version = "3.0.2", optional = true, features = ["wasm-bindgen"] }
@@ -92,6 +92,12 @@ futures-channel = { version = "0.3.4", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.10"
+
+[dependencies.tokio]
+version = "0.2"
+default-features = false
+features = ["rt-threaded"]
+optional = true
 
 [dev-dependencies]
 femme = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 [features]
 default = [
   "std",
+  "async-executor",
   "async-io",
   "async-task",
   "blocking",
   "futures-lite",
   "kv-log-macro",
   "log",
-  "multitask",
   "num_cpus",
   "pin-project-lite",
 ]
@@ -80,10 +80,10 @@ futures-timer = { version = "3.0.2", optional = true }
 surf = { version = "1.0.3", optional = true }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
+async-executor = { version = "0.1.1", features = ["async-io"], optional = true }
 async-io = { version = "0.1.5", optional = true }
 blocking = { version = "0.5.0", optional = true }
 futures-lite = { version = "0.1.8", optional = true }
-multitask = { version = "0.2.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures-timer = { version = "3.0.2", optional = true, features = ["wasm-bindgen"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ default = [
   "async-io",
   "async-task",
   "blocking",
+  "futures-lite",
   "kv-log-macro",
   "log",
   "num_cpus",
@@ -81,6 +82,7 @@ surf = { version = "1.0.3", optional = true }
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 async-io = { version = "0.1.5", optional = true }
 blocking = { version = "0.5.0", optional = true }
+futures-lite = { version = "0.1.8", optional = true }
 smol = { version = "0.1.17", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -315,7 +315,7 @@ impl Drop for File {
         // non-blocking fashion, but our only other option here is losing data remaining in the
         // write cache. Good task schedulers should be resilient to occasional blocking hiccups in
         // file destructors so we don't expect this to be a common problem in practice.
-        let _ = smol::block_on(self.flush());
+        let _ = futures_lite::future::block_on(self.flush());
     }
 }
 

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
 
-use smol::Async;
+use async_io::Async;
 
 use crate::io;
 use crate::net::{TcpStream, ToSocketAddrs};
@@ -81,7 +81,7 @@ impl TcpListener {
         let addrs = addrs.to_socket_addrs().await?;
 
         for addr in addrs {
-            match Async::<std::net::TcpListener>::bind(&addr) {
+            match Async::<std::net::TcpListener>::bind(addr) {
                 Ok(listener) => {
                     return Ok(TcpListener { watcher: listener });
                 }
@@ -227,7 +227,7 @@ cfg_unix! {
 
     impl IntoRawFd for TcpListener {
         fn into_raw_fd(self) -> RawFd {
-            self.watcher.into_raw_fd()
+            self.watcher.into_inner().unwrap().into_raw_fd()
         }
     }
 }
@@ -251,7 +251,7 @@ cfg_windows! {
 
     impl IntoRawSocket for TcpListener {
         fn into_raw_socket(self) -> RawSocket {
-            self.watcher.into_raw_socket()
+            self.watcher.into_inner().unwrap().into_raw_socket()
         }
     }
 }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -2,7 +2,7 @@ use std::io::{IoSlice, IoSliceMut};
 use std::net::SocketAddr;
 use std::pin::Pin;
 
-use smol::Async;
+use async_io::Async;
 
 use crate::io::{self, Read, Write};
 use crate::net::ToSocketAddrs;
@@ -77,7 +77,7 @@ impl TcpStream {
         let addrs = addrs.to_socket_addrs().await?;
 
         for addr in addrs {
-            match Async::<std::net::TcpStream>::connect(&addr).await {
+            match Async::<std::net::TcpStream>::connect(addr).await {
                 Ok(stream) => {
                     return Ok(TcpStream {
                         watcher: Arc::new(stream),

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-use smol::Async;
+use async_io::Async;
 
 use crate::net::ToSocketAddrs;
 use crate::utils::Context as _;
@@ -74,7 +74,7 @@ impl UdpSocket {
         let addrs = addrs.to_socket_addrs().await?;
 
         for addr in addrs {
-            match Async::<std::net::UdpSocket>::bind(&addr) {
+            match Async::<std::net::UdpSocket>::bind(addr) {
                 Ok(socket) => {
                     return Ok(UdpSocket { watcher: socket });
                 }
@@ -506,7 +506,7 @@ cfg_unix! {
 
     impl IntoRawFd for UdpSocket {
         fn into_raw_fd(self) -> RawFd {
-            self.watcher.into_raw_fd()
+            self.watcher.into_inner().unwrap().into_raw_fd()
         }
     }
 }
@@ -530,7 +530,7 @@ cfg_windows! {
 
     impl IntoRawSocket for UdpSocket {
         fn into_raw_socket(self) -> RawSocket {
-            self.watcher.into_raw_socket()
+            self.watcher.into_inner().unwrap().into_raw_socket()
         }
     }
 }

--- a/src/os/unix/net/datagram.rs
+++ b/src/os/unix/net/datagram.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::net::Shutdown;
 use std::os::unix::net::UnixDatagram as StdUnixDatagram;
 
-use smol::Async;
+use async_io::Async;
 
 use super::SocketAddr;
 use crate::io;
@@ -335,6 +335,6 @@ impl FromRawFd for UnixDatagram {
 
 impl IntoRawFd for UnixDatagram {
     fn into_raw_fd(self) -> RawFd {
-        self.watcher.into_raw_fd()
+        self.watcher.into_inner().unwrap().into_raw_fd()
     }
 }

--- a/src/os/unix/net/listener.rs
+++ b/src/os/unix/net/listener.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::os::unix::net::UnixListener as StdUnixListener;
 use std::pin::Pin;
 
-use smol::Async;
+use async_io::Async;
 
 use super::SocketAddr;
 use super::UnixStream;
@@ -217,6 +217,6 @@ impl FromRawFd for UnixListener {
 
 impl IntoRawFd for UnixListener {
     fn into_raw_fd(self) -> RawFd {
-        self.watcher.into_raw_fd()
+        self.watcher.into_inner().unwrap().into_raw_fd()
     }
 }

--- a/src/os/unix/net/stream.rs
+++ b/src/os/unix/net/stream.rs
@@ -5,7 +5,7 @@ use std::net::Shutdown;
 use std::os::unix::net::UnixStream as StdUnixStream;
 use std::pin::Pin;
 
-use smol::Async;
+use async_io::Async;
 
 use super::SocketAddr;
 use crate::io::{self, Read, Write};

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -5,5 +5,6 @@ cfg_std! {
 }
 
 cfg_unstable! {
+    #[cfg(feature = "default")]
     pub mod fs;
 }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -27,7 +27,7 @@ pub static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
     for _ in 0..thread_count {
         thread::Builder::new()
             .name(thread_name.clone())
-            .spawn(|| crate::task::block_on(future::pending::<()>()))
+            .spawn(|| crate::task::executor::run_global(future::pending::<()>()))
             .expect("cannot start a runtime thread");
     }
     Runtime {}

--- a/src/task/builder.rs
+++ b/src/task/builder.rs
@@ -169,7 +169,7 @@ impl Builder {
                         // The first call should use run.
                         smol::run(wrapped)
                     } else {
-                        smol::block_on(wrapped)
+                        futures_lite::future::block_on(wrapped)
                     };
                     num_nested_blocking.replace(num_nested_blocking.get() - 1);
                     res

--- a/src/task/executor.rs
+++ b/src/task/executor.rs
@@ -1,0 +1,91 @@
+use std::cell::RefCell;
+use std::future::Future;
+use std::task::{Context, Poll};
+
+static GLOBAL_EXECUTOR: once_cell::sync::Lazy<multitask::Executor> = once_cell::sync::Lazy::new(multitask::Executor::new);
+
+struct Executor {
+    local_executor: multitask::LocalExecutor,
+    parker: async_io::parking::Parker,
+}
+
+thread_local! {
+    static EXECUTOR: RefCell<Executor> = RefCell::new({
+        let (parker, unparker) = async_io::parking::pair();
+        let local_executor = multitask::LocalExecutor::new(move || unparker.unpark());
+        Executor { local_executor, parker }
+    });
+}
+
+pub(crate) fn spawn<F, T>(future: F) -> multitask::Task<T>
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    GLOBAL_EXECUTOR.spawn(future)
+}
+
+#[cfg(feature = "unstable")]
+pub(crate) fn local<F, T>(future: F) -> multitask::Task<T>
+where
+    F: Future<Output = T> + 'static,
+    T: 'static,
+{
+    EXECUTOR.with(|executor| executor.borrow().local_executor.spawn(future))
+}
+
+pub(crate) fn run<F, T>(future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    enter(|| EXECUTOR.with(|executor| {
+        let executor = executor.borrow();
+        let unparker = executor.parker.unparker();
+        let global_ticker = GLOBAL_EXECUTOR.ticker(move || unparker.unpark());
+        let unparker = executor.parker.unparker();
+        let waker = async_task::waker_fn(move || unparker.unpark());
+        let cx = &mut Context::from_waker(&waker);
+        pin_utils::pin_mut!(future);
+        loop {
+            if let Poll::Ready(res) = future.as_mut().poll(cx) {
+                return res;
+            }
+            if let Ok(false) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| executor.local_executor.tick() || global_ticker.tick())) {
+                executor.parker.park();
+            }
+        }
+    }))
+}
+
+/// Enters the tokio context if the `tokio` feature is enabled.
+fn enter<T>(f: impl FnOnce() -> T) -> T {
+    #[cfg(not(feature = "tokio02"))]
+    return f();
+
+    #[cfg(feature = "tokio02")]
+    {
+        use std::cell::Cell;
+        use tokio::runtime::Runtime;
+
+        thread_local! {
+            /// The level of nested `enter` calls we are in, to ensure that the outermost always
+            /// has a runtime spawned.
+            static NESTING: Cell<usize> = Cell::new(0);
+        }
+
+        /// The global tokio runtime.
+        static RT: once_cell::sync::Lazy<Runtime> = once_cell::sync::Lazy::new(|| Runtime::new().expect("cannot initialize tokio"));
+
+        NESTING.with(|nesting| {
+            let res = if nesting.get() == 0 {
+                nesting.replace(1);
+                RT.enter(f)
+            } else {
+                nesting.replace(nesting.get() + 1);
+                f()
+            };
+            nesting.replace(nesting.get() - 1);
+            res
+        })
+    }
+}

--- a/src/task/join_handle.rs
+++ b/src/task/join_handle.rs
@@ -18,7 +18,7 @@ pub struct JoinHandle<T> {
 }
 
 #[cfg(not(target_os = "unknown"))]
-type InnerHandle<T> = multitask::Task<T>;
+type InnerHandle<T> = async_executor::Task<T>;
 #[cfg(target_arch = "wasm32")]
 type InnerHandle<T> = futures_channel::oneshot::Receiver<T>;
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -148,6 +148,8 @@ cfg_default! {
     mod block_on;
     mod builder;
     mod current;
+    #[cfg(not(target_os = "unknown"))]
+    mod executor;
     mod join_handle;
     mod sleep;
     #[cfg(not(target_os = "unknown"))]

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -149,7 +149,7 @@ cfg_default! {
     mod builder;
     mod current;
     #[cfg(not(target_os = "unknown"))]
-    mod executor;
+    pub(crate) mod executor;
     mod join_handle;
     mod sleep;
     #[cfg(not(target_os = "unknown"))]

--- a/src/task/spawn_blocking.rs
+++ b/src/task/spawn_blocking.rs
@@ -1,4 +1,4 @@
-use crate::task::{JoinHandle, Task};
+use crate::task::{self, JoinHandle};
 
 /// Spawns a blocking task.
 ///
@@ -35,8 +35,5 @@ where
     F: FnOnce() -> T + Send + 'static,
     T: Send + 'static,
 {
-    once_cell::sync::Lazy::force(&crate::rt::RUNTIME);
-
-    let handle = smol::Task::blocking(async move { f() }).into();
-    JoinHandle::new(handle, Task::new(None))
+    task::spawn(async move { blocking::unblock!(f()) })
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,7 +66,7 @@ mod timer {
 
 #[cfg(any(feature = "unstable", feature = "default"))]
 pub(crate) fn timer_after(dur: std::time::Duration) -> timer::Timer {
-    #[cfg(not(target_os = "unknown"))]
+    #[cfg(all(not(target_os = "unknown"), feature = "default"))]
     once_cell::sync::Lazy::force(&crate::rt::RUNTIME);
 
     Timer::after(dur)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -61,7 +61,7 @@ pub(crate) trait Context {
 
 #[cfg(all(not(target_os = "unknown"), feature = "default"))]
 mod timer {
-    pub type Timer = smol::Timer;
+    pub type Timer = async_io::Timer;
 }
 
 #[cfg(any(feature = "unstable", feature = "default"))]
@@ -69,7 +69,7 @@ pub(crate) fn timer_after(dur: std::time::Duration) -> timer::Timer {
     #[cfg(all(not(target_os = "unknown"), feature = "default"))]
     once_cell::sync::Lazy::force(&crate::rt::RUNTIME);
 
-    Timer::after(dur)
+    Timer::new(dur)
 }
 
 #[cfg(any(
@@ -84,7 +84,7 @@ mod timer {
     pub(crate) struct Timer(futures_timer::Delay);
 
     impl Timer {
-        pub(crate) fn after(dur: std::time::Duration) -> Self {
+        pub(crate) fn new(dur: std::time::Duration) -> Self {
             Timer(futures_timer::Delay::new(dur))
         }
     }


### PR DESCRIPTION
smol now being divided in smaller crates, I tried porting async-std to those.

The async-io and blocking parts work fine and all tests seem to pass.

As of now, there are some tests hanging, namely because when we spawn a future from inside a block_on, it seems not to be polled, haven't figured out why yet.

The tokio enter function is directly copied from smol