### PR TITLE
ci: disable ppc64 cross build for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         target:
           - i686-unknown-linux-gnu
           - powerpc-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
+#          - powerpc64-unknown-linux-gnu
           - mips-unknown-linux-gnu
           - arm-linux-androideabi
 


### PR DESCRIPTION
It's broken, see #839