### PR TITLE
Book: Accept Loop Variable Fixes

### DIFF
--- a/docs/src/patterns/accept-loop.md
+++ b/docs/src/patterns/accept-loop.md
@@ -124,7 +124,7 @@ async fn accept_loop(addr: impl ToSocketAddrs) -> Result<()> {
         let stream = match result {
             Err(ref e) if is_connection_error(e) => continue, // 1
             Err(e) => {
-                eprintln!("Error: {}. Pausing for 500ms."); // 3
+                eprintln!("Error: {}. Pausing for 500ms.", e); // 3
                 task::sleep(Duration::from_millis(500)).await; // 2
                 continue;
             }

--- a/docs/src/patterns/accept-loop.md
+++ b/docs/src/patterns/accept-loop.md
@@ -121,7 +121,7 @@ async fn accept_loop(addr: impl ToSocketAddrs) -> Result<()> {
     let listener = TcpListener::bind(addr).await?;
     let mut incoming = listener.incoming();
     while let Some(result) = incoming.next().await {
-        let stream = match stream {
+        let stream = match result {
             Err(ref e) if is_connection_error(e) => continue, // 1
             Err(e) => {
                 eprintln!("Error: {}. Pausing for 500ms."); // 3


### PR DESCRIPTION
In the [example accept loop](https://book.async.rs/patterns/accept-loop.html#handling-errors-manually) in the book, there are a couple of minor variable errors:

1. Should be matching on `result` instead of `stream`.
2. The call to `eprintln!` has a `{}` placeholder, but `e` needs to be passed in.