### PR TITLE
run ci on wasm32-unknown-unknown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,26 @@ jobs:
     - name: test
       run: cross test --all --features unstable --target ${{ matrix.target }}
 
+  check_wasm:
+    name: Check wasm targets
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Install nightly with wasm32-unknown-unknown
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        target: wasm32-unknown-unknown
+        override: true
+
+    - name: check
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --target wasm32-unknown-unknown
+
   check_fmt_and_docs:
     name: Checking fmt and docs
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,14 +163,23 @@ jobs:
   check_wasm:
     name: Check wasm targets
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [nightly, beta, stable]
+
+    - name: Cache cargo registry
+      uses: actions/cache@v2
+      with:
+        path: ~/.cargo/registry
+        key: wasm32-${{ matrix.rust }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
 
     steps:
     - uses: actions/checkout@master
 
-    - name: Install nightly with wasm32-unknown-unknown
+    - name: Install rust with wasm32-unknown-unknown
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: ${{ matrix.rust }}
         target: wasm32-unknown-unknown
         override: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,12 +167,6 @@ jobs:
       matrix:
         rust: [nightly, beta, stable]
 
-    - name: Cache cargo registry
-      uses: actions/cache@v2
-      with:
-        path: ~/.cargo/registry
-        key: wasm32-${{ matrix.rust }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
-
     steps:
     - uses: actions/checkout@master
 
@@ -182,6 +176,12 @@ jobs:
         toolchain: ${{ matrix.rust }}
         target: wasm32-unknown-unknown
         override: true
+
+    - name: Cache cargo registry
+      uses: actions/cache@v2
+      with:
+        path: ~/.cargo/registry
+        key: wasm32-${{ matrix.rust }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
 
     - name: check
       uses: actions-rs/cargo@v1


### PR DESCRIPTION
The test failure on this branch represents an actual build error in 1.6.3 on wasm, breaking any wasm projects that depend on async-std. That build error is filed as #851. This PR tries to avoid this situation in the future by adding wasm to the async-std github CI.