### PR TITLE
fix wasm + no-std cargo interactions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,6 @@ jobs:
         command:  check
         args: --features unstable --all --bins --examples --tests
 
-    - name: check wasm
-      uses: actions-rs/cargo@v1
-      with:
-        command:  check
-        target: wasm32-unknown-unknown
-        override: true
-        args: --features unstable --all --bins --tests
-
     - name: check bench
       uses: actions-rs/cargo@v1
       if: matrix.rust == 'nightly'
@@ -163,13 +155,13 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --target wasm32-unknown-unknown --features wasm
+        args: --target wasm32-unknown-unknown --features wasm-bindgen
 
     - name: check unstable
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --target wasm32-unknown-unknown --tests --all --features unstable,wasm
+        args: --target wasm32-unknown-unknown --tests --all --features unstable,wasm-bindgen
         
   check_fmt_and_docs:
     name: Checking fmt and docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,13 +163,13 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --target wasm32-unknown-unknown 
+        args: --target wasm32-unknown-unknown --features wasm
 
     - name: check unstable
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --target wasm32-unknown-unknown --tests --all --features unstable
+        args: --target wasm32-unknown-unknown --tests --all --features unstable,wasm
         
   check_fmt_and_docs:
     name: Checking fmt and docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,24 +29,6 @@ jobs:
         toolchain: ${{ matrix.rust }}
         override: true
 
-    - name: Cache cargo registry
-      uses: actions/cache@v2
-      with:
-        path: ~/.cargo/registry
-        key: ${{ matrix.os }}-${{ matrix.rust }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
-
-    - name: Cache cargo index
-      uses: actions/cache@v2
-      with:
-        path: ~/.cargo/git
-        key: ${{ matrix.os }}-${{ matrix.rust }}-cargo-index-${{ hashFiles('**/Cargo.toml') }}
-
-    - name: Cache cargo build
-      uses: actions/cache@v2
-      with:
-        path: target
-        key: ${{ matrix.os }}-${{ matrix.rust }}-cargo-build-target-${{ hashFiles('**/Cargo.toml') }}
-
     - name: check
       uses: actions-rs/cargo@v1
       with:
@@ -176,12 +158,6 @@ jobs:
         toolchain: ${{ matrix.rust }}
         target: wasm32-unknown-unknown
         override: true
-
-    - name: Cache cargo registry
-      uses: actions/cache@v2
-      with:
-        path: ~/.cargo/registry
-        key: wasm32-${{ matrix.rust }}-cargo-registry-${{ hashFiles('**/Cargo.toml') }}
 
     - name: check
       uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,14 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --target wasm32-unknown-unknown
+        args: --target wasm32-unknown-unknown 
 
+    - name: check unstable
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --target wasm32-unknown-unknown --tests --all --features unstable
+        
   check_fmt_and_docs:
     name: Checking fmt and docs
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ blocking = { version = "0.5.2", optional = true }
 futures-lite = { version = "0.1.8", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-futures-timer = { version = "3.0.2", optional = true, features = ["wasm-bindgen"] }
+futures-timer = { version = "3.0.2", features = ["wasm-bindgen"] }
 wasm-bindgen-futures = { version = "0.4.10", optional = true }
 futures-channel = { version = "0.3.4", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,12 @@ std = [
   "once_cell",
   "pin-utils",
   "slab",
+  "async-mutex",
+]
+wasm = [
+  "futures-timer/wasm-bindgen",
   "wasm-bindgen-futures",
   "futures-channel",
-  "async-mutex",
 ]
 alloc = [
   "futures-core/alloc",
@@ -75,6 +78,8 @@ pin-project-lite = { version = "0.1.4", optional = true }
 pin-utils = { version = "0.1.0-alpha.4", optional = true }
 slab = { version = "0.4.2", optional = true }
 futures-timer = { version = "3.0.2", optional = true }
+wasm-bindgen-futures = { version = "0.4.10", optional = true }
+futures-channel = { version = "0.3.4", optional = true }
 
 # Devdepencency, but they are not allowed to be optional :/
 surf = { version = "1.0.3", optional = true }
@@ -85,13 +90,7 @@ async-io = { version = "0.1.8", optional = true }
 blocking = { version = "0.5.2", optional = true }
 futures-lite = { version = "0.1.8", optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-futures-timer = { version = "3.0.2", features = ["wasm-bindgen"] }
-wasm-bindgen-futures = { version = "0.4.10", optional = true }
-futures-channel = { version = "0.3.4", optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.3.10"
 
 [dependencies.tokio]
 version = "0.2"
@@ -105,6 +104,7 @@ rand = "0.7.3"
 tempfile = "3.1.0"
 futures = "0.3.4"
 rand_xorshift = "0.2.0"
+wasm-bindgen-test = "0.3.10"
 
 [[test]]
 name = "stream"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ std = [
   "slab",
   "async-mutex",
 ]
-wasm = [
+wasm-bindgen = [
   "futures-timer/wasm-bindgen",
   "wasm-bindgen-futures",
   "futures-channel",

--- a/src/task/join_handle.rs
+++ b/src/task/join_handle.rs
@@ -78,7 +78,17 @@ impl<T> Drop for JoinHandle<T> {
 impl<T> Future for JoinHandle<T> {
     type Output = T;
 
+    #[cfg(not(target_os = "unknown"))]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Pin::new(&mut self.handle.as_mut().unwrap()).poll(cx)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match Pin::new(&mut self.handle.as_mut().unwrap()).poll(cx) {
+            Poll::Ready(Ok(t)) => Poll::Ready(t),
+            Poll::Ready(Err(_)) => unreachable!("channel must not be canceled"),
+            Poll::Pending => Poll::Pending,
+        }
     }
 }

--- a/tests/collect.rs
+++ b/tests/collect.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "unstable")]
 #[test]
-fn test_send() -> async_std::io::Result<()> {
+fn test_send() {
     use async_std::prelude::*;
     use async_std::{stream, task};
 
@@ -14,7 +14,5 @@ fn test_send() -> async_std::io::Result<()> {
 
         // This line triggers a compilation error
         test_send_trait(&fut);
-
-        Ok(())
-    })
+    });
 }


### PR DESCRIPTION
This started as an extension of #863 disabling the build cache in ci and turned into an investigation of a cargo bug that pulls in wasm deps for no-std, breaking ci. The proposed fix in this pr also closes https://github.com/async-rs/async-std/issues/823