### PR TITLE
feat: move executor to async-global-executo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 [features]
 default = [
   "std",
-  "async-executor",
+  "async-global-executor",
   "async-io",
   "async-task",
   "blocking",
@@ -80,7 +80,7 @@ slab = { version = "0.4.2", optional = true }
 surf = { version = "1.0.3", optional = true }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
-async-executor = { version = "1.0.0", optional = true }
+async-global-executor = { version = "1.0.1", optional = true, features = ["async-io"] }
 async-io = { version = "1.0.1", optional = true }
 blocking = { version = "1.0.0", optional = true }
 futures-lite = { version = "1.0.0", optional = true }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -1,11 +1,8 @@
 //! The runtime.
 
 use std::env;
-use std::thread;
 
 use once_cell::sync::Lazy;
-
-use crate::future;
 
 /// Dummy runtime struct.
 pub struct Runtime {}
@@ -14,22 +11,8 @@ pub struct Runtime {}
 pub static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
     // Create an executor thread pool.
 
-    let thread_count = env::var("ASYNC_STD_THREAD_COUNT")
-        .map(|env| {
-            env.parse()
-                .expect("ASYNC_STD_THREAD_COUNT must be a number")
-        })
-        .unwrap_or_else(|_| num_cpus::get())
-        .max(1);
+    let thread_name = env::var("ASYNC_STD_THREAD_NAME").unwrap_or_else(|_| "async-std/runtime".to_string());
+    async_global_executor::init_with_config(async_global_executor::GlobalExecutorConfig::default().with_env_var("ASYNC_STD_THREAD_COUNT").with_thread_name(thread_name));
 
-    let thread_name =
-        env::var("ASYNC_STD_THREAD_NAME").unwrap_or_else(|_| "async-std/runtime".to_string());
-
-    for _ in 0..thread_count {
-        thread::Builder::new()
-            .name(thread_name.clone())
-            .spawn(|| crate::task::executor::run_global(future::pending::<()>()))
-            .expect("cannot start a runtime thread");
-    }
     Runtime {}
 });

--- a/src/task/builder.rs
+++ b/src/task/builder.rs
@@ -60,7 +60,7 @@ impl Builder {
         });
 
         let task = wrapped.tag.task().clone();
-        let handle = crate::task::executor::spawn(wrapped);
+        let handle = async_global_executor::spawn(wrapped);
 
         Ok(JoinHandle::new(handle, task))
     }
@@ -80,7 +80,7 @@ impl Builder {
         });
 
         let task = wrapped.tag.task().clone();
-        let handle = crate::task::executor::local(wrapped);
+        let handle = async_global_executor::spawn_local(wrapped);
 
         Ok(JoinHandle::new(handle, task))
     }

--- a/src/task/join_handle.rs
+++ b/src/task/join_handle.rs
@@ -18,7 +18,7 @@ pub struct JoinHandle<T> {
 }
 
 #[cfg(not(target_os = "unknown"))]
-type InnerHandle<T> = async_executor::Task<T>;
+type InnerHandle<T> = async_global_executor::Task<T>;
 #[cfg(target_arch = "wasm32")]
 type InnerHandle<T> = futures_channel::oneshot::Receiver<T>;
 


### PR DESCRIPTION
Based on #866 

This uses async-executor under the hood and is highly inspired by both smol and the async-executor implementation inside of async-std.

Pros:
- less code inside async-std, simpler integration
- shares the same executors with any other users of async-global-executor
- allows spawning local tasks on all of the global executor threads

Cons:
- adds one more extra dependency
- ???