### PR TITLE
Drop unused async-task

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ slab = { version = "0.4.2", optional = true }
 surf = { version = "1.0.3", optional = true }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
-async-global-executor = { version = "1.0.1", optional = true, features = ["async-io"] }
+async-global-executor = { version = "1.0.2", optional = true, features = ["async-io"] }
 async-io = { version = "1.0.1", optional = true }
 blocking = { version = "1.0.0", optional = true }
 futures-lite = { version = "1.0.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ default = [
   "std",
   "async-global-executor",
   "async-io",
-  "async-task",
   "blocking",
   "futures-lite",
   "kv-log-macro",
@@ -62,7 +61,6 @@ tokio02 = ["tokio"]
 
 [dependencies]
 async-attributes = { version = "1.1.1", optional = true }
-async-task = { version = "3.0.0", optional = true }
 async-mutex = { version = "1.1.3", optional = true }
 crossbeam-utils = { version = "0.7.2", optional = true }
 futures-core = { version = "0.3.4", optional = true, default-features = false }


### PR DESCRIPTION
We no longer directly depend on async-task.

While at it, pull in latest async-global-executor version with deadlock fix