### PR TITLE
Return SendError from Sender::send on disconnect.

### DIFF
--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -43,12 +43,12 @@ use crate::sync::WakerSet;
 /// let (s, r) = channel(1);
 ///
 /// // This call returns immediately because there is enough space in the channel.
-/// s.send(1usize).await;
+/// s.send(1usize).await.unwrap();
 ///
 /// task::spawn(async move {
 ///     // This call will have to wait because the channel is full.
 ///     // It will be able to complete only after the first message is received.
-///     s.send(2).await;
+///     s.send(2).await.unwrap();
 /// });
 ///
 /// task::sleep(Duration::from_secs(1)).await;
@@ -124,8 +124,8 @@ impl<T> Sender<T> {
     /// let (s, r) = channel(1);
     ///
     /// task::spawn(async move {
-    ///     s.send(1).await;
-    ///     s.send(2).await;
+    ///     s.send(1).await.unwrap();
+    ///     s.send(2).await.unwrap();
     /// });
     ///
     /// assert_eq!(r.recv().await?, 1);
@@ -243,7 +243,7 @@ impl<T> Sender<T> {
     /// let (s, r) = channel(1);
     ///
     /// assert!(s.is_empty());
-    /// s.send(0).await;
+    /// s.send(0).await.unwrap();
     /// assert!(!s.is_empty());
     /// #
     /// # })
@@ -264,7 +264,7 @@ impl<T> Sender<T> {
     /// let (s, r) = channel(1);
     ///
     /// assert!(!s.is_full());
-    /// s.send(0).await;
+    /// s.send(0).await.unwrap();
     /// assert!(s.is_full());
     /// #
     /// # })
@@ -285,8 +285,8 @@ impl<T> Sender<T> {
     /// let (s, r) = channel(2);
     /// assert_eq!(s.len(), 0);
     ///
-    /// s.send(1).await;
-    /// s.send(2).await;
+    /// s.send(1).await.unwrap();
+    /// s.send(2).await.unwrap();
     /// assert_eq!(s.len(), 2);
     /// #
     /// # })
@@ -349,9 +349,9 @@ impl<T> fmt::Debug for Sender<T> {
 /// let (s, r) = channel(100);
 ///
 /// task::spawn(async move {
-///     s.send(1usize).await;
+///     s.send(1usize).await.unwrap();
 ///     task::sleep(Duration::from_secs(1)).await;
-///     s.send(2).await;
+///     s.send(2).await.unwrap();
 /// });
 ///
 /// assert_eq!(r.recv().await?, 1); // Received immediately.
@@ -389,8 +389,8 @@ impl<T> Receiver<T> {
     /// let (s, r) = channel(1);
     ///
     /// task::spawn(async move {
-    ///     s.send(1usize).await;
-    ///     s.send(2).await;
+    ///     s.send(1usize).await.unwrap();
+    ///     s.send(2).await.unwrap();
     ///     // Then we drop the sender
     /// });
     ///
@@ -449,7 +449,7 @@ impl<T> Receiver<T> {
     ///
     /// let (s, r) = channel(1);
     ///
-    /// s.send(1u8).await;
+    /// s.send(1u8).await.unwrap();
     ///
     /// assert!(r.try_recv().is_ok());
     /// assert!(r.try_recv().is_err());
@@ -486,7 +486,7 @@ impl<T> Receiver<T> {
     /// let (s, r) = channel(1);
     ///
     /// assert!(r.is_empty());
-    /// s.send(0).await;
+    /// s.send(0).await.unwrap();
     /// assert!(!r.is_empty());
     /// #
     /// # })
@@ -507,7 +507,7 @@ impl<T> Receiver<T> {
     /// let (s, r) = channel(1);
     ///
     /// assert!(!r.is_full());
-    /// s.send(0).await;
+    /// s.send(0).await.unwrap();
     /// assert!(r.is_full());
     /// #
     /// # })
@@ -528,8 +528,8 @@ impl<T> Receiver<T> {
     /// let (s, r) = channel(2);
     /// assert_eq!(r.len(), 0);
     ///
-    /// s.send(1).await;
-    /// s.send(2).await;
+    /// s.send(1).await.unwrap();
+    /// s.send(2).await.unwrap();
     /// assert_eq!(r.len(), 2);
     /// #
     /// # })

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -185,7 +185,7 @@ mod rwlock;
 
 cfg_unstable! {
     pub use barrier::{Barrier, BarrierWaitResult};
-    pub use channel::{channel, Sender, Receiver, RecvError, TryRecvError, TrySendError};
+    pub use channel::{channel, Sender, Receiver, RecvError, TryRecvError, SendError, TrySendError};
     pub use condvar::Condvar;
 
     mod barrier;

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -26,10 +26,10 @@ fn smoke() {
     task::block_on(async {
         let (s, r) = channel(1);
 
-        s.send(7).await;
+        s.send(7).await.unwrap();
         assert_eq!(r.recv().await.unwrap(), 7);
 
-        s.send(8).await;
+        s.send(8).await.unwrap();
         assert_eq!(r.recv().await.unwrap(), 8);
 
         drop(s);
@@ -39,7 +39,7 @@ fn smoke() {
     task::block_on(async {
         let (s, r) = channel(10);
         drop(r);
-        s.send(1).await;
+        s.send(1).await.unwrap();
     });
 }
 
@@ -67,7 +67,7 @@ fn len_empty_full() {
         assert_eq!(r.is_empty(), true);
         assert_eq!(r.is_full(), false);
 
-        s.send(()).await;
+        s.send(()).await.unwrap();
 
         assert_eq!(s.len(), 1);
         assert_eq!(s.is_empty(), false);
@@ -76,7 +76,7 @@ fn len_empty_full() {
         assert_eq!(r.is_empty(), false);
         assert_eq!(r.is_full(), false);
 
-        s.send(()).await;
+        s.send(()).await.unwrap();
 
         assert_eq!(s.len(), 2);
         assert_eq!(s.is_empty(), false);
@@ -112,9 +112,9 @@ fn recv() {
         });
 
         task::sleep(ms(1500)).await;
-        s.send(7).await;
-        s.send(8).await;
-        s.send(9).await;
+        s.send(7).await.unwrap();
+        s.send(8).await.unwrap();
+        s.send(9).await.unwrap();
     })
 }
 
@@ -125,13 +125,13 @@ fn send() {
         let (s, r) = channel(1);
 
         spawn(async move {
-            s.send(7).await;
+            s.send(7).await.unwrap();
             task::sleep(ms(1000)).await;
-            s.send(8).await;
+            s.send(8).await.unwrap();
             task::sleep(ms(1000)).await;
-            s.send(9).await;
+            s.send(9).await.unwrap();
             task::sleep(ms(1000)).await;
-            s.send(10).await;
+            s.send(10).await.unwrap();
         });
 
         task::sleep(ms(1500)).await;
@@ -147,9 +147,9 @@ fn recv_after_disconnect() {
     task::block_on(async {
         let (s, r) = channel(100);
 
-        s.send(1).await;
-        s.send(2).await;
-        s.send(3).await;
+        s.send(1).await.unwrap();
+        s.send(2).await.unwrap();
+        s.send(3).await.unwrap();
 
         drop(s);
 
@@ -174,7 +174,7 @@ fn len() {
 
         for _ in 0..CAP / 10 {
             for i in 0..50 {
-                s.send(i).await;
+                s.send(i).await.unwrap();
                 assert_eq!(s.len(), i + 1);
             }
 
@@ -188,7 +188,7 @@ fn len() {
         assert_eq!(r.len(), 0);
 
         for i in 0..CAP {
-            s.send(i).await;
+            s.send(i).await.unwrap();
             assert_eq!(s.len(), i + 1);
         }
 
@@ -211,7 +211,7 @@ fn len() {
         });
 
         for i in 0..COUNT {
-            s.send(i).await;
+            s.send(i).await.unwrap();
             let len = s.len();
             assert!(len <= CAP);
         }
@@ -256,7 +256,7 @@ fn spsc() {
         });
 
         for i in 0..COUNT {
-            s.send(i).await;
+            s.send(i).await.unwrap();
         }
         drop(s);
 
@@ -292,7 +292,7 @@ fn mpmc() {
             let s = s.clone();
             tasks.push(spawn(async move {
                 for i in 0..COUNT {
-                    s.send(i).await;
+                    s.send(i).await.unwrap();
                 }
             }));
         }
@@ -320,7 +320,7 @@ fn oneshot() {
             let c2 = spawn(async move { s.send(0).await });
 
             c1.await;
-            c2.await;
+            c2.await.unwrap();
         }
     })
 }
@@ -360,13 +360,13 @@ fn drops() {
             });
 
             for _ in 0..steps {
-                s.send(DropCounter).await;
+                s.send(DropCounter).await.unwrap();
             }
 
             child.await;
 
             for _ in 0..additional {
-                s.send(DropCounter).await;
+                s.send(DropCounter).await.unwrap();
             }
 
             assert_eq!(DROPS.load(Ordering::SeqCst), steps);

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -36,7 +36,7 @@ fn merging_delayed_streams_work() {
 
     task::block_on(async move {
         task::sleep(std::time::Duration::from_millis(500)).await;
-        sender.send(92).await;
+        sender.send(92).await.unwrap();
         drop(sender);
         let xs = t.await;
         assert_eq!(xs, vec![92])
@@ -55,7 +55,7 @@ fn merging_delayed_streams_work() {
 
     task::block_on(async move {
         task::sleep(std::time::Duration::from_millis(500)).await;
-        sender.send(92).await;
+        sender.send(92).await.unwrap();
         drop(sender);
         let xs = t.await;
         assert_eq!(xs, vec![92])


### PR DESCRIPTION
Currently the `send` method for `Sender<T>` returns a Future that never finishes if the channel is disconnected. This issue was brought up and this fix was proposed in issue #880.
This changes brings the `send` method more inline with what the standard library's sender structs do, where they return an error on disconnect. 
If this pull request's fix isn't appropriate then hopefully it can at least get the ball rolling on something else.