### PR TITLE
Fix double drop in StreamExt::cycle

### DIFF
--- a/src/stream/stream/cycle.rs
+++ b/src/stream/stream/cycle.rs
@@ -1,14 +1,19 @@
-use core::mem::ManuallyDrop;
 use core::pin::Pin;
+
+use futures_core::ready;
+use pin_project_lite::pin_project;
 
 use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
-/// A stream that will repeatedly yield the same list of elements.
-#[derive(Debug)]
-pub struct Cycle<S> {
-    orig: S,
-    source: ManuallyDrop<S>,
+pin_project! {
+    /// A stream that will repeatedly yield the same list of elements.
+    #[derive(Debug)]
+    pub struct Cycle<S> {
+        orig: S,
+        #[pin]
+        source: S,
+    }
 }
 
 impl<S> Cycle<S>
@@ -18,15 +23,7 @@ where
     pub(crate) fn new(source: S) -> Self {
         Self {
             orig: source.clone(),
-            source: ManuallyDrop::new(source),
-        }
-    }
-}
-
-impl<S> Drop for Cycle<S> {
-    fn drop(&mut self) {
-        unsafe {
-            ManuallyDrop::drop(&mut self.source);
+            source,
         }
     }
 }
@@ -38,17 +35,14 @@ where
     type Item = S::Item;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        unsafe {
-            let this = self.get_unchecked_mut();
+        let mut this = self.project();
 
-            match futures_core::ready!(Pin::new_unchecked(&mut *this.source).poll_next(cx)) {
-                Some(item) => Poll::Ready(Some(item)),
-                None => {
-                    ManuallyDrop::drop(&mut this.source);
-                    this.source = ManuallyDrop::new(this.orig.clone());
-                    Pin::new_unchecked(&mut *this.source).poll_next(cx)
-                }
+        match ready!(this.source.as_mut().poll_next(cx)) {
+            None => {
+                this.source.set(this.orig.clone());
+                this.source.poll_next(cx)
             }
+            item => Poll::Ready(item),
         }
     }
 }


### PR DESCRIPTION
`StreamExt::cycle` drop `source` field without updating field if `source` field's destructor panicked.

https://github.com/async-rs/async-std/blob/11196c853dc42e86d608c4ed29af1a8f0c5c5084/src/stream/stream/cycle.rs#L47-L48

This is unsound because it causes double drop if the user catches panic in the scope where the `Cycle` is alive.

Repro:

```rust
#[test]
#[should_panic(expected = "second")]
fn test() {
    use async_std::stream::*;
    use futures::task::{noop_waker, Context, Poll};
    use std::{panic, pin::Pin, thread};

    #[derive(Clone, Default)]
    struct S {
        dropped: bool,
    }

    impl Stream for S {
        type Item = ();

        fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
            Poll::Ready(None)
        }
    }

    impl Drop for S {
        fn drop(&mut self) {
            if !thread::panicking() {
                if std::mem::replace(&mut self.dropped, true) {
                    panic!("second")
                } else {
                    panic!("first")
                }
            }
        }
    }

    let mut s = Box::pin(S::default().cycle());
    let w = noop_waker();
    let cx = &mut Context::from_waker(&w);
    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
        let _ = s.as_mut().poll_next(cx); // <-- dropped the first clone of `s`
    }));
    // <-- dropped the first clone of`s` again since `source` field wasn't updated
}
```