### PR TITLE
Update pin-project-lite to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ log = { version = "0.4.8", features = ["kv_unstable"], optional = true }
 memchr = { version = "2.3.3", optional = true }
 num_cpus = { version = "1.12.0", optional = true }
 once_cell = { version = "1.3.1", optional = true }
-pin-project-lite = { version = "0.1.4", optional = true }
+pin-project-lite = { version = "0.2.0", optional = true }
 pin-utils = { version = "0.1.0-alpha.4", optional = true }
 slab = { version = "0.4.2", optional = true }
 

--- a/src/net/addr.rs
+++ b/src/net/addr.rs
@@ -68,6 +68,9 @@ pub enum ToSocketAddrsFuture<I> {
     Done,
 }
 
+// The field of `Self::Resolving` is `Unpin`, and the field of `Self::Ready` is never pinned.
+impl<I> Unpin for ToSocketAddrsFuture<I> {}
+
 /// Wrap `std::io::Error` with additional message
 ///
 /// Keeps the original error kind and stores the original I/O error as `source`.
@@ -84,7 +87,7 @@ impl<I: Iterator<Item = SocketAddr>> Future for ToSocketAddrsFuture<I> {
     type Output = io::Result<I>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = unsafe { self.get_unchecked_mut() };
+        let this = self.get_mut();
         let state = mem::replace(this, ToSocketAddrsFuture::Done);
 
         match state {


### PR DESCRIPTION
This release added support for enum. We can remove some unsafe code.