### PR TITLE
feat: new channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ std = [
   "wasm-bindgen-futures",
   "futures-channel",
   "async-mutex",
+  "async-channel",
 ]
 alloc = [
   "futures-core/alloc",
@@ -74,9 +75,11 @@ once_cell = { version = "1.3.1", optional = true }
 pin-project-lite = { version = "0.2.0", optional = true }
 pin-utils = { version = "0.1.0-alpha.4", optional = true }
 slab = { version = "0.4.2", optional = true }
+async-channel = { version = "1.5.1", optional = true }
 
 # Devdepencency, but they are not allowed to be optional :/
 surf = { version = "2.0.0", optional = true }
+
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]
 async-global-executor = { version = "1.4.0", optional = true, features = ["async-io"] }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,0 +1,6 @@
+//! Channels
+
+#[cfg(feature = "unstable")]
+#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+#[doc(inline)]
+pub use async_channel::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,15 +106,14 @@
 //! [`io`], [`fs`], and [`net`] modules.
 //!
 //! The [`task`] module contains `async-std`'s task abstractions. [`sync`]
-//! contains further primitive shared memory types, including [`channel`],
-//! which contains the channel types for message passing.
+//! contains further primitive shared memory types. [`channel`]  contains the channel types for message passing.
 //!
 //! [files]: fs/struct.File.html
 //! [TCP]: net/struct.TcpStream.html
 //! [UDP]: net/struct.UdpSocket.html
 //! [`io`]: fs/struct.File.html
 //! [`sync`]: sync/index.html
-//! [`channel`]: sync/fn.channel.html
+//! [`channel`]: channel/index.html
 //!
 //! ## Timeouts, intervals, and delays
 //!
@@ -300,6 +299,7 @@ cfg_std! {
     pub mod os;
     pub mod prelude;
     pub mod sync;
+    pub mod channel;
 }
 
 cfg_default! {

--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::cell::UnsafeCell;
 use std::error::Error;
 use std::fmt::{self, Debug, Display};

--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -60,6 +60,7 @@ use crate::sync::WakerSet;
 /// ```
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+#[deprecated = "new channel api at async_std::channel"]
 pub fn channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
     let channel = Arc::new(Channel::with_capacity(cap));
     let s = Sender {
@@ -102,6 +103,7 @@ pub fn channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
 /// ```
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+#[deprecated = "new channel api at async_std::channel"]
 pub struct Sender<T> {
     /// The inner channel.
     channel: Arc<Channel<T>>,
@@ -363,6 +365,7 @@ impl<T> fmt::Debug for Sender<T> {
 /// ```
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
+#[deprecated = "new channel api at async_std::channel"]
 pub struct Receiver<T> {
     /// The inner channel.
     channel: Arc<Channel<T>>,
@@ -993,6 +996,7 @@ impl<T> Drop for Channel<T> {
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[derive(PartialEq, Eq)]
+#[deprecated = "new channel api at async_std::channel"]
 pub enum TrySendError<T> {
     /// The channel is full but not disconnected.
     Full(T),
@@ -1025,6 +1029,7 @@ impl<T> Display for TrySendError<T> {
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[derive(Debug, PartialEq, Eq)]
+#[deprecated = "new channel api at async_std::channel"]
 pub enum TryRecvError {
     /// The channel is empty but not disconnected.
     Empty,
@@ -1048,6 +1053,7 @@ impl Display for TryRecvError {
 #[cfg(feature = "unstable")]
 #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[derive(Debug, PartialEq, Eq)]
+#[deprecated = "new channel api at async_std::channel"]
 pub struct RecvError;
 
 impl Error for RecvError {}

--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -34,6 +34,7 @@ use crate::sync::WakerSet;
 /// # Examples
 ///
 /// ```
+/// #![allow(deprecated)]
 /// # fn main() -> Result<(), async_std::sync::RecvError> {
 /// # async_std::task::block_on(async {
 /// #
@@ -85,6 +86,7 @@ pub fn channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
 /// # Examples
 ///
 /// ```
+/// #![allow(deprecated)]
 /// # async_std::task::block_on(async {
 /// #
 /// use async_std::sync::channel;
@@ -119,6 +121,7 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// # fn main() -> Result<(), async_std::sync::RecvError> {
     /// # async_std::task::block_on(async {
     /// #
@@ -208,6 +211,7 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// # async_std::task::block_on(async {
     /// #
     /// use async_std::sync::channel;
@@ -227,6 +231,7 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// use async_std::sync::channel;
     ///
     /// let (s, _) = channel::<i32>(5);
@@ -241,6 +246,7 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// # async_std::task::block_on(async {
     /// #
     /// use async_std::sync::channel;
@@ -262,6 +268,7 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// # async_std::task::block_on(async {
     /// #
     /// use async_std::sync::channel;
@@ -283,6 +290,7 @@ impl<T> Sender<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// # async_std::task::block_on(async {
     /// #
     /// use async_std::sync::channel;
@@ -343,6 +351,7 @@ impl<T> fmt::Debug for Sender<T> {
 /// # Examples
 ///
 /// ```
+/// #![allow(deprecated)]
 /// # fn main() -> Result<(), async_std::sync::RecvError> {
 /// # async_std::task::block_on(async {
 /// #
@@ -386,6 +395,7 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// # fn main() -> Result<(), async_std::sync::RecvError> {
     /// # async_std::task::block_on(async {
     /// #
@@ -449,6 +459,7 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// # async_std::task::block_on(async {
     /// #
     /// use async_std::sync::channel;
@@ -471,6 +482,7 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// use async_std::sync::channel;
     ///
     /// let (_, r) = channel::<i32>(5);
@@ -485,6 +497,7 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// # async_std::task::block_on(async {
     /// #
     /// use async_std::sync::channel;
@@ -506,6 +519,7 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// # async_std::task::block_on(async {
     /// #
     /// use async_std::sync::channel;
@@ -527,6 +541,7 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
+    /// #![allow(deprecated)]
     /// # async_std::task::block_on(async {
     /// #
     /// use async_std::sync::channel;

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -185,6 +185,7 @@ mod rwlock;
 
 cfg_unstable! {
     pub use barrier::{Barrier, BarrierWaitResult};
+    #[allow(deprecated)]
     pub use channel::{channel, Sender, Receiver, RecvError, TryRecvError, TrySendError};
     pub use condvar::Condvar;
 

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "unstable")]
+#![allow(deprecated)]
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -5,9 +5,9 @@ use std::task::{Context, Poll};
 
 use pin_project_lite::pin_project;
 
+use async_std::channel::bounded as channel;
 use async_std::prelude::*;
 use async_std::stream;
-use async_std::sync::channel;
 use async_std::task;
 
 #[cfg(target_arch = "wasm32")]
@@ -36,7 +36,7 @@ fn merging_delayed_streams_work() {
 
     task::block_on(async move {
         task::sleep(std::time::Duration::from_millis(500)).await;
-        sender.send(92).await;
+        sender.send(92).await.unwrap();
         drop(sender);
         let xs = t.await;
         assert_eq!(xs, vec![92])
@@ -55,7 +55,7 @@ fn merging_delayed_streams_work() {
 
     task::block_on(async move {
         task::sleep(std::time::Duration::from_millis(500)).await;
-        sender.send(92).await;
+        sender.send(92).await.unwrap();
         drop(sender);
         let xs = t.await;
         assert_eq!(xs, vec![92])


### PR DESCRIPTION
- add new top level `channels` module (stable) based on `async-channel`
- deprecate `sync::channel`