### PR TITLE
Fix link in typo in src/task/mod.rs

### DIFF
--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -103,7 +103,7 @@
 //! the desired task name to [`Builder::name`]. To retrieve the task name from within the
 //! task, use [`Task::name`].
 //!
-//! [`Arc`]: ../gsync/struct.Arc.html
+//! [`Arc`]: ../sync/struct.Arc.html
 //! [`spawn`]: fn.spawn.html
 //! [`JoinHandle`]: struct.JoinHandle.html
 //! [`JoinHandle::task`]: struct.JoinHandle.html#method.task


### PR DESCRIPTION
This is currently a broken link, which you can see here https://docs.rs/async-std/1.8.0/async_std/task/index.html