### PR TITLE
Replace deprecated compare_and_swap with compare_exchange

### DIFF
--- a/src/task/task_local.rs
+++ b/src/task/task_local.rs
@@ -124,9 +124,9 @@ impl<T: Send + 'static> LocalKey<T> {
                 std::process::abort();
             }
 
-            match key.compare_and_swap(0, counter, Ordering::AcqRel) {
-                0 => counter,
-                k => k,
+            match key.compare_exchange(0, counter, Ordering::AcqRel, Ordering::Acquire) {
+                Ok(_) => counter,
+                Err(k) => k,
             }
         }
 


### PR DESCRIPTION
`compare_and_swap` is deprecated in 1.50. (https://github.com/rust-lang/rust/pull/79261)
This patch replaces the uses of `compare_and_swap` with `compare_exchange`.

See also the document about `compare_and_swap` -> `compare_exchange(_weak)` migration: https://doc.rust-lang.org/nightly/core/sync/atomic/struct.AtomicUsize.html#migrating-to-compare_exchange-and-compare_exchange_weak