### PR TITLE
docs: update cargo-edit link in the installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ using Rust's familiar stdlib API.
 
 ## Installation
 
-With [cargo add][cargo-add] installed run:
+With [cargo-edit](https://github.com/killercup/cargo-edit) installed run:
 
 ```sh
 $ cargo add async-std


### PR DESCRIPTION
The project `cargo-add` has been deprecated in favor of `cargo-edit`: https://github.com/withoutboats/cargo-add