### PR TITLE
Fix vectored IO for TcpStream

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -307,6 +307,14 @@ impl Read for &TcpStream {
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut &*self.watcher).poll_read(cx, buf)
     }
+
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut &*self.watcher).poll_read_vectored(cx, bufs)
+    }
 }
 
 impl Write for TcpStream {
@@ -342,6 +350,14 @@ impl Write for &TcpStream {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut &*self.watcher).poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut &*self.watcher).poll_write_vectored(cx, bufs)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {


### PR DESCRIPTION
This change implements `Write::poll_write_vectored` and `Read::poll_read_vectored` on `TcpStream` using the vectored IO methods on the underlying stream. Previously, the `Write` and `Read` traits' default implementations were used, which just called `poll_write` and `poll_read` once for each `IoSlice`.

This change correctly results in `readv` and `writev` syscalls on Linux.