### PR TITLE
Fix typo in DoubleEndedStream docs

### DIFF
--- a/src/stream/double_ended_stream/mod.rs
+++ b/src/stream/double_ended_stream/mod.rs
@@ -152,7 +152,7 @@ pub trait DoubleEndedStream: Stream {
     }
 
     #[doc = r#"
-            Returns the the frist element from the right that matches the predicate.
+            Returns the first element from the right that matches the predicate.
 
             # Examples
 


### PR DESCRIPTION
Fix typo in current [docs for DoubleEndedStream](https://docs.rs/async-std/1.9.0/async_std/stream/trait.DoubleEndedStream.html#method.rfind).