### PR TITLE
Fix some clippy warnings

### DIFF
--- a/examples/a-chat/main.rs
+++ b/examples/a-chat/main.rs
@@ -5,7 +5,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>
 
 fn main() -> Result<()> {
     let mut args = std::env::args();
-    match (args.nth(1).as_ref().map(String::as_str), args.next()) {
+    match (args.nth(1).as_deref(), args.next()) {
         (Some("client"), None) => client::main(),
         (Some("server"), None) => server::main(),
         _ => Err("Usage: a-chat [client|server]".into()),

--- a/src/fs/dir_builder.rs
+++ b/src/fs/dir_builder.rs
@@ -36,7 +36,8 @@ impl DirBuilder {
     ///
     /// let builder = DirBuilder::new();
     /// ```
-    pub fn new() -> DirBuilder {
+    #[must_use]
+    pub const fn new() -> DirBuilder {
         #[cfg(not(unix))]
         let builder = DirBuilder { recursive: false };
 

--- a/src/fs/dir_entry.rs
+++ b/src/fs/dir_entry.rs
@@ -47,6 +47,7 @@ impl DirEntry {
     /// #
     /// # Ok(()) }) }
     /// ```
+    #[must_use]
     pub fn path(&self) -> PathBuf {
         self.0.path().into()
     }
@@ -147,6 +148,7 @@ impl DirEntry {
     /// #
     /// # Ok(()) }) }
     /// ```
+    #[must_use]
     pub fn file_name(&self) -> OsString {
         self.0.file_name()
     }

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -871,6 +871,7 @@ impl LockGuard<State> {
 
     // This function does nothing because we're not sure about `AsyncWrite::poll_close()`'s exact
     // semantics nor whether it will stay in the `AsyncWrite` trait.
+    #[allow(clippy::unused_self)]
     fn poll_close(self, _: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(Ok(()))
     }
@@ -899,7 +900,8 @@ mod tests {
                     drop(clone);
                     buf.len()
                 })
-            }).await;
+            })
+            .await;
             assert_eq!(len as u64, file.metadata().await.unwrap().len());
         });
     }

--- a/src/fs/open_options.rs
+++ b/src/fs/open_options.rs
@@ -80,6 +80,7 @@ impl OpenOptions {
     /// #
     /// # Ok(()) }) }
     /// ```
+    #[must_use]
     pub fn new() -> OpenOptions {
         OpenOptions(std::fs::OpenOptions::new())
     }

--- a/src/fs/read_dir.rs
+++ b/src/fs/read_dir.rs
@@ -80,7 +80,7 @@ enum State {
 
 impl ReadDir {
     /// Creates an asynchronous `ReadDir` from a synchronous handle.
-    pub(crate) fn new(inner: std::fs::ReadDir) -> ReadDir {
+    pub(crate) const fn new(inner: std::fs::ReadDir) -> ReadDir {
         ReadDir(State::Idle(Some(inner)))
     }
 }

--- a/src/io/buf_reader.rs
+++ b/src/io/buf_reader.rs
@@ -115,7 +115,7 @@ impl<R> BufReader<R> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub fn get_ref(&self) -> &R {
+    pub const fn get_ref(&self) -> &R {
         &self.inner
     }
 

--- a/src/io/buf_writer.rs
+++ b/src/io/buf_writer.rs
@@ -211,7 +211,7 @@ impl<W: Write> BufWriter<W> {
         self.project().inner
     }
 
-    /// Consumes BufWriter, returning the underlying writer
+    /// Consumes `BufWriter`, returning the underlying writer
     ///
     /// This method will not write leftover data, it will be lost.
     /// For method that will attempt to write before returning the writer see [`poll_into_inner`]
@@ -263,7 +263,7 @@ impl<W: Write> BufWriter<W> {
 
     /// Poll buffer flushing until completion
     ///
-    /// This is used in types that wrap around BufWrite, one such example: [`LineWriter`]
+    /// This is used in types that wrap around `BufWrite`, one such example: [`LineWriter`]
     ///
     /// [`LineWriter`]: struct.LineWriter.html
     fn poll_flush_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/src/io/empty.rs
+++ b/src/io/empty.rs
@@ -22,7 +22,8 @@ use crate::task::{Context, Poll};
 /// #
 /// # Ok(()) }) }
 /// ```
-pub fn empty() -> Empty {
+#[must_use]
+pub const fn empty() -> Empty {
     Empty { _private: () }
 }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -39,7 +39,7 @@
 //! nickname: readers and writers. So you'll sometimes see 'a reader' instead
 //! of 'a type that implements the [`Read`] trait'. Much easier!
 //!
-//! ## Seek and BufRead
+//! ## `Seek` and `BufRead`
 //!
 //! Beyond that, there are two important traits that are provided: [`Seek`]
 //! and [`BufRead`]. Both of these build on top of a reader to control
@@ -70,7 +70,7 @@
 //! [`BufRead`] uses an internal buffer to provide a number of other ways to read, but
 //! to show it off, we'll need to talk about buffers in general. Keep reading!
 //!
-//! ## BufReader and BufWriter
+//! ## `BufReader` and `BufWriter`
 //!
 //! Byte-based interfaces are unwieldy and can be inefficient, as we'd need to be
 //! making near-constant calls to the operating system. To help with this,
@@ -214,7 +214,7 @@
 //!
 //! [functions-list]: #functions-1
 //!
-//! ## io::Result
+//! ## `io::Result`
 //!
 //! Last, but certainly not least, is [`io::Result`]. This type is used
 //! as the return type of many `std::io` functions that can cause an error, and

--- a/src/io/read/chain.rs
+++ b/src/io/read/chain.rs
@@ -63,7 +63,7 @@ impl<T, U> Chain<T, U> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub fn get_ref(&self) -> (&T, &U) {
+    pub const fn get_ref(&self) -> (&T, &U) {
         (&self.first, &self.second)
     }
 
@@ -157,10 +157,10 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
 
     fn consume(self: Pin<&mut Self>, amt: usize) {
         let this = self.project();
-        if !*this.done_first {
-            this.first.consume(amt)
-        } else {
+        if *this.done_first {
             this.second.consume(amt)
+        } else {
+            this.first.consume(amt)
         }
     }
 }

--- a/src/io/read/mod.rs
+++ b/src/io/read/mod.rs
@@ -485,7 +485,7 @@ mod tests {
     #[test]
     fn test_read_by_ref() {
         crate::task::block_on(async {
-            let mut f = io::Cursor::new(vec![0u8, 1, 2, 3, 4, 5, 6, 7, 8]);
+            let mut f = io::Cursor::new(vec![0_u8, 1, 2, 3, 4, 5, 6, 7, 8]);
             let mut buffer = Vec::new();
             let mut other_buffer = Vec::new();
 

--- a/src/io/read/take.rs
+++ b/src/io/read/take.rs
@@ -49,7 +49,7 @@ impl<T> Take<T> {
     /// #
     /// #     Ok(()) }) }
     /// ```
-    pub fn limit(&self) -> u64 {
+    pub const fn limit(&self) -> u64 {
         self.limit
     }
 
@@ -229,7 +229,7 @@ mod tests {
         let source: io::Cursor<Vec<u8>> = io::Cursor::new(vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
 
         task::block_on(async move {
-            let mut buffer = [0u8; 5];
+            let mut buffer = [0_u8; 5];
 
             // read at most five bytes
             let mut handle = source.take(5);

--- a/src/io/repeat.rs
+++ b/src/io/repeat.rs
@@ -23,7 +23,8 @@ use crate::task::{Context, Poll};
 /// #
 /// # Ok(()) }) }
 /// ```
-pub fn repeat(byte: u8) -> Repeat {
+#[must_use]
+pub const fn repeat(byte: u8) -> Repeat {
     Repeat { byte }
 }
 

--- a/src/io/sink.rs
+++ b/src/io/sink.rs
@@ -19,7 +19,8 @@ use crate::task::{Context, Poll};
 /// #
 /// # Ok(()) }) }
 /// ```
-pub fn sink() -> Sink {
+#[must_use]
+pub const fn sink() -> Sink {
     Sink { _private: () }
 }
 

--- a/src/io/stderr.rs
+++ b/src/io/stderr.rs
@@ -1,6 +1,6 @@
+use std::future::Future;
 use std::pin::Pin;
 use std::sync::Mutex;
-use std::future::Future;
 
 use crate::io::{self, Write};
 use crate::task::{spawn_blocking, Context, JoinHandle, Poll};
@@ -30,6 +30,7 @@ use crate::task::{spawn_blocking, Context, JoinHandle, Poll};
 /// #
 /// # Ok(()) }) }
 /// ```
+#[must_use]
 pub fn stderr() -> Stderr {
     Stderr(Mutex::new(State::Idle(Some(Inner {
         stderr: std::io::stderr(),
@@ -150,16 +151,15 @@ impl Write for Stderr {
                     // Check if the operation has completed.
                     if let Some(Operation::Flush(res)) = inner.last_op.take() {
                         return Poll::Ready(res);
-                    } else {
-                        let mut inner = opt.take().unwrap();
-
-                        // Start the operation asynchronously.
-                        *state = State::Busy(spawn_blocking(move || {
-                            let res = std::io::Write::flush(&mut inner.stderr);
-                            inner.last_op = Some(Operation::Flush(res));
-                            State::Idle(Some(inner))
-                        }));
                     }
+                    let mut inner = opt.take().unwrap();
+
+                    // Start the operation asynchronously.
+                    *state = State::Busy(spawn_blocking(move || {
+                        let res = std::io::Write::flush(&mut inner.stderr);
+                        inner.last_op = Some(Operation::Flush(res));
+                        State::Idle(Some(inner))
+                    }));
                 }
                 // Poll the asynchronous operation the stderr is currently blocked on.
                 State::Busy(task) => *state = futures_core::ready!(Pin::new(task).poll(cx)),

--- a/src/io/timeout.rs
+++ b/src/io/timeout.rs
@@ -67,7 +67,7 @@ where
         let this = self.project();
         match this.future.poll(cx) {
             Poll::Pending => {}
-            other => return other,
+            other @ Poll::Ready(..) => return other,
         }
 
         if this.timeout.poll(cx).is_ready() {

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -146,6 +146,7 @@ impl TcpListener {
     /// #
     /// # Ok(()) }) }
     /// ```
+    #[must_use]
     pub fn incoming(&self) -> Incoming<'_> {
         Incoming {
             listener: self,

--- a/src/os/unix/net/listener.rs
+++ b/src/os/unix/net/listener.rs
@@ -127,6 +127,7 @@ impl UnixListener {
     /// #
     /// # Ok(()) }) }
     /// ```
+    #[must_use]
     pub fn incoming(&self) -> Incoming<'_> {
         Incoming {
             listener: self,

--- a/src/path/ancestors.rs
+++ b/src/path/ancestors.rs
@@ -21,7 +21,7 @@ use crate::path::Path;
 ///
 /// [`ancestors`]: struct.Path.html#method.ancestors
 /// [`Path`]: struct.Path.html
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Ancestors<'a> {
     pub(crate) next: Option<&'a Path>,
 }

--- a/src/path/components.rs
+++ b/src/path/components.rs
@@ -42,6 +42,7 @@ impl<'a> Components<'a> {
     ///
     /// assert_eq!(Path::new("foo/bar.txt"), components.as_path());
     /// ```
+    #[must_use]
     pub fn as_path(&self) -> &'a Path {
         self.inner.as_path().into()
     }

--- a/src/path/iter.rs
+++ b/src/path/iter.rs
@@ -32,7 +32,7 @@ impl<'a> Iter<'a> {
     ///
     /// assert_eq!(Path::new("foo/bar.txt"), iter.as_path());
     /// ```
-    pub fn as_path(&self) -> &'a Path {
+    #[must_use] pub fn as_path(&self) -> &'a Path {
         self.inner.as_path()
     }
 }

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -91,6 +91,7 @@ impl Path {
     /// let os_str = Path::new("foo.txt").as_os_str();
     /// assert_eq!(os_str, OsStr::new("foo.txt"));
     /// ```
+    #[must_use]
     pub fn as_os_str(&self) -> &OsStr {
         self.inner.as_os_str()
     }
@@ -111,6 +112,7 @@ impl Path {
     /// let path = Path::new("foo.txt");
     /// assert_eq!(path.to_str(), Some("foo.txt"));
     /// ```
+    #[must_use]
     pub fn to_str(&self) -> Option<&str> {
         self.inner.to_str()
     }
@@ -136,6 +138,7 @@ impl Path {
     ///
     /// Had `path` contained invalid unicode, the `to_string_lossy` call might
     /// have returned `"fo�.txt"`.
+    #[must_use]
     pub fn to_string_lossy(&self) -> Cow<'_, str> {
         self.inner.to_string_lossy()
     }
@@ -152,6 +155,7 @@ impl Path {
     /// let path_buf = Path::new("foo.txt").to_path_buf();
     /// assert_eq!(path_buf, PathBuf::from("foo.txt"));
     /// ```
+    #[must_use]
     pub fn to_path_buf(&self) -> PathBuf {
         PathBuf::from(self.inner.to_path_buf())
     }
@@ -174,6 +178,7 @@ impl Path {
     ///
     /// assert!(!Path::new("foo.txt").is_absolute());
     /// ```
+    #[must_use]
     pub fn is_absolute(&self) -> bool {
         self.inner.is_absolute()
     }
@@ -191,6 +196,7 @@ impl Path {
     ///
     /// assert!(Path::new("foo.txt").is_relative());
     /// ```
+    #[must_use]
     pub fn is_relative(&self) -> bool {
         self.inner.is_relative()
     }
@@ -211,6 +217,7 @@ impl Path {
     ///
     /// assert!(Path::new("/etc/passwd").has_root());
     /// ```
+    #[must_use]
     pub fn has_root(&self) -> bool {
         self.inner.has_root()
     }
@@ -234,6 +241,7 @@ impl Path {
     /// assert_eq!(grand_parent, Path::new("/"));
     /// assert_eq!(grand_parent.parent(), None);
     /// ```
+    #[must_use]
     pub fn parent(&self) -> Option<&Path> {
         self.inner.parent().map(|p| p.into())
     }
@@ -260,7 +268,8 @@ impl Path {
     /// assert_eq!(ancestors.next(), Some(Path::new("/").into()));
     /// assert_eq!(ancestors.next(), None);
     /// ```
-    pub fn ancestors(&self) -> Ancestors<'_> {
+    #[must_use]
+    pub const fn ancestors(&self) -> Ancestors<'_> {
         Ancestors { next: Some(&self) }
     }
 
@@ -287,6 +296,7 @@ impl Path {
     /// assert_eq!(None, Path::new("foo.txt/..").file_name());
     /// assert_eq!(None, Path::new("/").file_name());
     /// ```
+    #[must_use]
     pub fn file_name(&self) -> Option<&OsStr> {
         self.inner.file_name()
     }
@@ -387,6 +397,7 @@ impl Path {
     ///
     /// assert_eq!("foo", path.file_stem().unwrap());
     /// ```
+    #[must_use]
     pub fn file_stem(&self) -> Option<&OsStr> {
         self.inner.file_stem()
     }
@@ -412,6 +423,7 @@ impl Path {
     ///
     /// assert_eq!("rs", path.extension().unwrap());
     /// ```
+    #[must_use]
     pub fn extension(&self) -> Option<&OsStr> {
         self.inner.extension()
     }
@@ -510,6 +522,7 @@ impl Path {
     /// assert_eq!(components.next(), Some(Component::Normal(OsStr::new("foo.txt"))));
     /// assert_eq!(components.next(), None);
     /// ```
+    #[must_use]
     pub fn components(&self) -> Components<'_> {
         Components {
             inner: self.inner.components(),
@@ -538,6 +551,7 @@ impl Path {
     /// assert_eq!(it.next(), Some(OsStr::new("foo.txt")));
     /// assert_eq!(it.next(), None)
     /// ```
+    #[must_use]
     pub fn iter(&self) -> Iter<'_> {
         Iter {
             inner: self.components(),
@@ -558,6 +572,7 @@ impl Path {
     ///
     /// println!("{}", path.display());
     /// ```
+    #[must_use]
     pub fn display(&self) -> Display<'_> {
         self.inner.display()
     }
@@ -719,7 +734,7 @@ impl Path {
     /// # See Also
     ///
     /// This is a convenience function that coerces errors to false. If you want to
-    /// check errors, call [fs::metadata].
+    /// check errors, call [`fs::metadata`].
     ///
     /// [fs::metadata]: ../fs/fn.metadata.html
     #[cfg(not(target_os = "unknown"))]
@@ -750,8 +765,8 @@ impl Path {
     /// # See Also
     ///
     /// This is a convenience function that coerces errors to false. If you want to
-    /// check errors, call [fs::metadata] and handle its Result. Then call
-    /// [fs::Metadata::is_file] if it was Ok.
+    /// check errors, call [`fs::metadata`] and handle its Result. Then call
+    /// [`fs::Metadata::is_file`] if it was Ok.
     ///
     /// [fs::metadata]: ../fs/fn.metadata.html
     /// [fs::Metadata::is_file]: ../fs/struct.Metadata.html#method.is_file
@@ -787,8 +802,8 @@ impl Path {
     /// # See Also
     ///
     /// This is a convenience function that coerces errors to false. If you want to
-    /// check errors, call [fs::metadata] and handle its Result. Then call
-    /// [fs::Metadata::is_dir] if it was Ok.
+    /// check errors, call [`fs::metadata`] and handle its Result. Then call
+    /// [`fs::Metadata::is_dir`] if it was Ok.
     ///
     /// [fs::metadata]: ../fs/fn.metadata.html
     /// [fs::Metadata::is_dir]: ../fs/struct.Metadata.html#method.is_dir
@@ -814,6 +829,7 @@ impl Path {
     /// let path: Box<Path> = Path::new("foo.txt").into();
     /// let path_buf = path.into_path_buf();
     /// ```
+    #[must_use]
     pub fn into_path_buf(self: Box<Path>) -> PathBuf {
         let rw = Box::into_raw(self) as *mut std::path::Path;
         let inner = unsafe { Box::from_raw(rw) };
@@ -1015,9 +1031,9 @@ impl<'a> From<&'a std::path::Path> for &'a Path {
     }
 }
 
-impl<'a> Into<&'a std::path::Path> for &'a Path {
-    fn into(self) -> &'a std::path::Path {
-        std::path::Path::new(&self.inner)
+impl<'a> From<&'a Path> for &'a std::path::Path {
+    fn from(path: &'a Path) -> &'a std::path::Path {
+        std::path::Path::new(&path.inner)
     }
 }
 

--- a/src/path/pathbuf.rs
+++ b/src/path/pathbuf.rs
@@ -32,6 +32,7 @@ impl PathBuf {
     ///
     /// let path = PathBuf::new();
     /// ```
+    #[must_use]
     pub fn new() -> PathBuf {
         std::path::PathBuf::new().into()
     }
@@ -48,6 +49,7 @@ impl PathBuf {
     /// let p = PathBuf::from("/test");
     /// assert_eq!(Path::new("/test"), p.as_path());
     /// ```
+    #[must_use]
     pub fn as_path(&self) -> &Path {
         self.inner.as_path().into()
     }
@@ -182,6 +184,7 @@ impl PathBuf {
     /// let p = PathBuf::from("/the/head");
     /// let os_str = p.into_os_string();
     /// ```
+    #[must_use]
     pub fn into_os_string(self) -> OsString {
         self.inner.into_os_string()
     }
@@ -190,6 +193,7 @@ impl PathBuf {
     ///
     /// [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
     /// [`Path`]: struct.Path.html
+    #[must_use]
     pub fn into_boxed_path(self) -> Box<Path> {
         let rw = Box::into_raw(self.inner.into_boxed_path()) as *mut Path;
         unsafe { Box::from_raw(rw) }
@@ -271,7 +275,7 @@ impl Deref for PathBuf {
 
 impl Borrow<Path> for PathBuf {
     fn borrow(&self) -> &Path {
-        self.deref()
+        &*self
     }
 }
 
@@ -364,9 +368,9 @@ impl From<std::path::PathBuf> for PathBuf {
     }
 }
 
-impl Into<std::path::PathBuf> for PathBuf {
-    fn into(self) -> std::path::PathBuf {
-        self.inner
+impl From<PathBuf> for std::path::PathBuf {
+    fn from(path_buf: PathBuf) -> std::path::PathBuf {
+        path_buf.inner
     }
 }
 

--- a/src/stream/empty.rs
+++ b/src/stream/empty.rs
@@ -25,7 +25,8 @@ use crate::task::{Context, Poll};
 /// #
 /// # })
 /// ```
-pub fn empty<T>() -> Empty<T> {
+#[must_use]
+pub const fn empty<T>() -> Empty<T> {
     Empty {
         _marker: PhantomData,
     }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -154,7 +154,7 @@
 //! can call `next()` on your stream, until it reaches `None`. Let's go over
 //! that next.
 //!
-//! # while let Loops and IntoStream
+//! # while let Loops and `IntoStream`
 //!
 //! Rust's `while let` loop syntax is an idiomatic way to iterate over streams. Here's a basic
 //! example of `while let`:

--- a/src/stream/once.rs
+++ b/src/stream/once.rs
@@ -25,7 +25,7 @@ use crate::stream::DoubleEndedStream;
 /// #
 /// # })
 /// ```
-pub fn once<T>(t: T) -> Once<T> {
+pub const fn once<T>(t: T) -> Once<T> {
     Once { value: Some(t) }
 }
 

--- a/src/stream/stream/cloned.rs
+++ b/src/stream/stream/cloned.rs
@@ -13,7 +13,7 @@ pin_project! {
 }
 
 impl<S> Cloned<S> {
-    pub(super) fn new(stream: S) -> Self {
+    pub(super) const fn new(stream: S) -> Self {
         Self { stream }
     }
 }

--- a/src/stream/stream/cmp.rs
+++ b/src/stream/stream/cmp.rs
@@ -35,7 +35,7 @@ impl<L: Stream, R: Stream> CmpFuture<L, R> {
     }
 }
 
-impl<L: Stream, R: Stream> Future for CmpFuture<L, R>
+impl<L, R> Future for CmpFuture<L, R>
 where
     L: Stream + Sized,
     R: Stream<Item = L::Item> + Sized,

--- a/src/stream/stream/copied.rs
+++ b/src/stream/stream/copied.rs
@@ -13,7 +13,7 @@ pin_project! {
 }
 
 impl<S> Copied<S> {
-    pub(super) fn new(stream: S) -> Self {
+    pub(super) const fn new(stream: S) -> Self {
         Self { stream }
     }
 }

--- a/src/stream/stream/cycle.rs
+++ b/src/stream/stream/cycle.rs
@@ -42,7 +42,7 @@ where
                 this.source.set(this.orig.clone());
                 this.source.poll_next(cx)
             }
-            item => Poll::Ready(item),
+            item @ Some(..) => Poll::Ready(item),
         }
     }
 }

--- a/src/stream/stream/enumerate.rs
+++ b/src/stream/stream/enumerate.rs
@@ -15,7 +15,7 @@ pin_project! {
 }
 
 impl<S> Enumerate<S> {
-    pub(super) fn new(stream: S) -> Self {
+    pub(super) const fn new(stream: S) -> Self {
         Self { stream, i: 0 }
     }
 }

--- a/src/stream/stream/eq.rs
+++ b/src/stream/stream/eq.rs
@@ -33,7 +33,7 @@ where
     }
 }
 
-impl<L: Stream, R: Stream> Future for EqFuture<L, R>
+impl<L, R> Future for EqFuture<L, R>
 where
     L: Stream + Sized,
     R: Stream + Sized,

--- a/src/stream/stream/filter.rs
+++ b/src/stream/stream/filter.rs
@@ -22,7 +22,7 @@ pin_project! {
 }
 
 impl<S, P> Filter<S, P> {
-    pub(super) fn new(stream: S, predicate: P) -> Self {
+    pub(super) const fn new(stream: S, predicate: P) -> Self {
         Self {
             stream,
             predicate,

--- a/src/stream/stream/find_map.rs
+++ b/src/stream/stream/find_map.rs
@@ -30,13 +30,13 @@ where
         let item = futures_core::ready!(Pin::new(&mut *self.stream).poll_next(cx));
 
         match item {
-            Some(v) => match (&mut self.f)(v) {
-                Some(v) => Poll::Ready(Some(v)),
-                None => {
+            Some(v) => (&mut self.f)(v).map_or_else(
+                || {
                     cx.waker().wake_by_ref();
                     Poll::Pending
-                }
-            },
+                },
+                |v| Poll::Ready(Some(v)),
+            ),
             None => Poll::Ready(None),
         }
     }

--- a/src/stream/stream/fold.rs
+++ b/src/stream/stream/fold.rs
@@ -17,7 +17,7 @@ pin_project! {
 }
 
 impl<S, F, B> FoldFuture<S, F, B> {
-    pub(super) fn new(stream: S, init: B, f: F) -> Self {
+    pub(super) const fn new(stream: S, init: B, f: F) -> Self {
         Self {
             stream,
             f,

--- a/src/stream/stream/for_each.rs
+++ b/src/stream/stream/for_each.rs
@@ -17,7 +17,7 @@ pin_project! {
 }
 
 impl<S, F> ForEachFuture<S, F> {
-    pub(super) fn new(stream: S, f: F) -> Self {
+    pub(super) const fn new(stream: S, f: F) -> Self {
         Self {
             stream,
             f,

--- a/src/stream/stream/fuse.rs
+++ b/src/stream/stream/fuse.rs
@@ -22,7 +22,7 @@ pin_project! {
 }
 
 impl<S> Fuse<S> {
-    pub(super) fn new(stream: S) -> Self {
+    pub(super) const fn new(stream: S) -> Self {
         Self {
             stream,
             done: false,

--- a/src/stream/stream/ge.rs
+++ b/src/stream/stream/ge.rs
@@ -31,7 +31,7 @@ where
     }
 }
 
-impl<L: Stream, R: Stream> Future for GeFuture<L, R>
+impl<L, R> Future for GeFuture<L, R>
 where
     L: Stream,
     R: Stream,

--- a/src/stream/stream/gt.rs
+++ b/src/stream/stream/gt.rs
@@ -31,7 +31,7 @@ where
     }
 }
 
-impl<L: Stream, R: Stream> Future for GtFuture<L, R>
+impl<L, R> Future for GtFuture<L, R>
 where
     L: Stream + Sized,
     R: Stream + Sized,

--- a/src/stream/stream/inspect.rs
+++ b/src/stream/stream/inspect.rs
@@ -22,7 +22,7 @@ pin_project! {
 }
 
 impl<S, F> Inspect<S, F> {
-    pub(super) fn new(stream: S, f: F) -> Self {
+    pub(super) const fn new(stream: S, f: F) -> Self {
         Self {
             stream,
             f,

--- a/src/stream/stream/last.rs
+++ b/src/stream/stream/last.rs
@@ -17,7 +17,7 @@ pin_project! {
 }
 
 impl<S, T> LastFuture<S, T> {
-    pub(crate) fn new(stream: S) -> Self {
+    pub(crate) const fn new(stream: S) -> Self {
         Self { stream, last: None }
     }
 }

--- a/src/stream/stream/le.rs
+++ b/src/stream/stream/le.rs
@@ -31,7 +31,7 @@ where
     }
 }
 
-impl<L: Stream, R: Stream> Future for LeFuture<L, R>
+impl<L, R> Future for LeFuture<L, R>
 where
     L: Stream + Sized,
     R: Stream + Sized,

--- a/src/stream/stream/lt.rs
+++ b/src/stream/stream/lt.rs
@@ -31,7 +31,7 @@ where
     }
 }
 
-impl<L: Stream, R: Stream> Future for LtFuture<L, R>
+impl<L, R> Future for LtFuture<L, R>
 where
     L: Stream + Sized,
     R: Stream + Sized,

--- a/src/stream/stream/map.rs
+++ b/src/stream/stream/map.rs
@@ -16,7 +16,7 @@ pin_project! {
 }
 
 impl<S, F> Map<S, F> {
-    pub(crate) fn new(stream: S, f: F) -> Self {
+    pub(crate) const fn new(stream: S, f: F) -> Self {
         Self {
             stream,
             f,

--- a/src/stream/stream/max.rs
+++ b/src/stream/stream/max.rs
@@ -18,7 +18,7 @@ pin_project! {
 }
 
 impl<S, T> MaxFuture<S, T> {
-    pub(super) fn new(stream: S) -> Self {
+    pub(super) const fn new(stream: S) -> Self {
         Self { stream, max: None }
     }
 }

--- a/src/stream/stream/max_by.rs
+++ b/src/stream/stream/max_by.rs
@@ -19,7 +19,7 @@ pin_project! {
 }
 
 impl<S, F, T> MaxByFuture<S, F, T> {
-    pub(super) fn new(stream: S, compare: F) -> Self {
+    pub(super) const fn new(stream: S, compare: F) -> Self {
         Self {
             stream,
             compare,

--- a/src/stream/stream/max_by_key.rs
+++ b/src/stream/stream/max_by_key.rs
@@ -19,7 +19,7 @@ pin_project! {
 }
 
 impl<S, T, K> MaxByKeyFuture<S, T, K> {
-    pub(super) fn new(stream: S, key_by: K) -> Self {
+    pub(super) const fn new(stream: S, key_by: K) -> Self {
         Self {
             stream,
             max: None,

--- a/src/stream/stream/min.rs
+++ b/src/stream/stream/min.rs
@@ -18,7 +18,7 @@ pin_project! {
 }
 
 impl<S, T> MinFuture<S, T> {
-    pub(super) fn new(stream: S) -> Self {
+    pub(super) const fn new(stream: S) -> Self {
         Self { stream, min: None }
     }
 }

--- a/src/stream/stream/min_by.rs
+++ b/src/stream/stream/min_by.rs
@@ -19,7 +19,7 @@ pin_project! {
 }
 
 impl<S, F, T> MinByFuture<S, F, T> {
-    pub(super) fn new(stream: S, compare: F) -> Self {
+    pub(super) const fn new(stream: S, compare: F) -> Self {
         Self {
             stream,
             compare,

--- a/src/stream/stream/min_by_key.rs
+++ b/src/stream/stream/min_by_key.rs
@@ -19,7 +19,7 @@ pin_project! {
 }
 
 impl<S, T, K> MinByKeyFuture<S, T, K> {
-    pub(super) fn new(stream: S, key_by: K) -> Self {
+    pub(super) const fn new(stream: S, key_by: K) -> Self {
         Self {
             stream,
             min: None,

--- a/src/stream/stream/ne.rs
+++ b/src/stream/stream/ne.rs
@@ -33,7 +33,7 @@ where
     }
 }
 
-impl<L: Stream, R: Stream> Future for NeFuture<L, R>
+impl<L, R> Future for NeFuture<L, R>
 where
     L: Stream + Sized,
     R: Stream + Sized,

--- a/src/stream/stream/nth.rs
+++ b/src/stream/stream/nth.rs
@@ -1,6 +1,6 @@
+use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
-use core::future::Future;
 
 use crate::stream::Stream;
 
@@ -28,14 +28,15 @@ where
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let next = futures_core::ready!(Pin::new(&mut *self.stream).poll_next(cx));
         match next {
-            Some(v) => match self.n {
-                0 => Poll::Ready(Some(v)),
-                _ => {
+            Some(v) => {
+                if let 0 = self.n {
+                    Poll::Ready(Some(v))
+                } else {
                     self.n -= 1;
                     cx.waker().wake_by_ref();
                     Poll::Pending
                 }
-            },
+            }
             None => Poll::Ready(None),
         }
     }

--- a/src/stream/stream/partial_cmp.rs
+++ b/src/stream/stream/partial_cmp.rs
@@ -35,7 +35,7 @@ impl<L: Stream, R: Stream> PartialCmpFuture<L, R> {
     }
 }
 
-impl<L: Stream, R: Stream> Future for PartialCmpFuture<L, R>
+impl<L, R> Future for PartialCmpFuture<L, R>
 where
     L: Stream + Sized,
     R: Stream + Sized,

--- a/src/stream/stream/scan.rs
+++ b/src/stream/stream/scan.rs
@@ -22,7 +22,7 @@ pin_project! {
 }
 
 impl<S, St, F> Scan<S, St, F> {
-    pub(crate) fn new(stream: S, initial_state: St, f: F) -> Self {
+    pub(crate) const fn new(stream: S, initial_state: St, f: F) -> Self {
         Self {
             stream,
             state_f: (initial_state, f),

--- a/src/stream/stream/skip.rs
+++ b/src/stream/stream/skip.rs
@@ -22,7 +22,7 @@ pin_project! {
 }
 
 impl<S> Skip<S> {
-    pub(crate) fn new(stream: S, n: usize) -> Self {
+    pub(crate) const fn new(stream: S, n: usize) -> Self {
         Self { stream, n }
     }
 }

--- a/src/stream/stream/skip_while.rs
+++ b/src/stream/stream/skip_while.rs
@@ -22,7 +22,7 @@ pin_project! {
 }
 
 impl<S, P> SkipWhile<S, P> {
-    pub(crate) fn new(stream: S, predicate: P) -> Self {
+    pub(crate) const fn new(stream: S, predicate: P) -> Self {
         Self {
             stream,
             predicate: Some(predicate),

--- a/src/stream/stream/take.rs
+++ b/src/stream/stream/take.rs
@@ -22,7 +22,7 @@ pin_project! {
 }
 
 impl<S> Take<S> {
-    pub(super) fn new(stream: S, remaining: usize) -> Self {
+    pub(super) const fn new(stream: S, remaining: usize) -> Self {
         Self {
             stream,
             remaining,

--- a/src/stream/stream/take_while.rs
+++ b/src/stream/stream/take_while.rs
@@ -22,7 +22,7 @@ pin_project! {
 }
 
 impl<S, P> TakeWhile<S, P> {
-    pub(super) fn new(stream: S, predicate: P) -> Self {
+    pub(super) const fn new(stream: S, predicate: P) -> Self {
         Self {
             stream,
             predicate,

--- a/src/task/builder.rs
+++ b/src/task/builder.rs
@@ -17,12 +17,14 @@ pub struct Builder {
 impl Builder {
     /// Creates a new builder.
     #[inline]
-    pub fn new() -> Builder {
+    #[must_use]
+    pub const fn new() -> Builder {
         Builder { name: None }
     }
 
     /// Configures the name of the task.
     #[inline]
+    #[must_use]
     pub fn name(mut self, name: String) -> Builder {
         self.name = Some(name);
         self

--- a/src/task/current.rs
+++ b/src/task/current.rs
@@ -22,7 +22,7 @@ use crate::task::{Task, TaskLocalsWrapper};
 /// #
 /// # })
 /// ```
-pub fn current() -> Task {
+#[must_use] pub fn current() -> Task {
     TaskLocalsWrapper::get_current(|t| t.task().clone())
         .expect("`task::current()` called outside the context of a task")
 }

--- a/src/task/join_handle.rs
+++ b/src/task/join_handle.rs
@@ -46,7 +46,8 @@ impl<T> JoinHandle<T> {
     /// println!("id = {}", handle.task().id());
     /// #
     /// # })
-    pub fn task(&self) -> &Task {
+    #[must_use]
+    pub const fn task(&self) -> &Task {
         &self.task
     }
 

--- a/src/task/task.rs
+++ b/src/task/task.rs
@@ -25,7 +25,7 @@ impl Task {
 
     /// Gets the task's unique identifier.
     #[inline]
-    pub fn id(&self) -> TaskId {
+    #[must_use] pub const fn id(&self) -> TaskId {
         self.id
     }
 
@@ -34,6 +34,7 @@ impl Task {
     /// The name is configured by [`Builder::name`] before spawning.
     ///
     /// [`Builder::name`]: struct.Builder.html#method.name
+    #[must_use]
     pub fn name(&self) -> Option<&str> {
         self.name.as_ref().map(|s| s.as_str())
     }

--- a/src/task/task_local.rs
+++ b/src/task/task_local.rs
@@ -107,7 +107,7 @@ impl<T: Send + 'static> LocalKey<T> {
             let value: *const dyn Send = task.locals().get_or_insert(key, init);
 
             // Call the closure with the value passed as an argument.
-            f(&*(value as *const T))
+            f(&*value.cast::<T>())
         })
         .ok_or(AccessError { _private: () })
     }
@@ -176,7 +176,7 @@ pub(crate) struct LocalsMap {
 
 impl LocalsMap {
     /// Creates an empty map of task-locals.
-    pub fn new() -> LocalsMap {
+    pub const fn new() -> LocalsMap {
         LocalsMap {
             entries: UnsafeCell::new(Some(Vec::new())),
         }

--- a/src/task/task_locals_wrapper.rs
+++ b/src/task/task_locals_wrapper.rs
@@ -24,7 +24,7 @@ impl TaskLocalsWrapper {
     /// If the task is unnamed, the inner representation of the task will be lazily allocated on
     /// demand.
     #[inline]
-    pub(crate) fn new(task: Task) -> Self {
+    pub(crate) const fn new(task: Task) -> Self {
         Self {
             task,
             locals: LocalsMap::new(),
@@ -33,17 +33,17 @@ impl TaskLocalsWrapper {
 
     /// Gets the task's unique identifier.
     #[inline]
-    pub fn id(&self) -> TaskId {
+    pub const fn id(&self) -> TaskId {
         self.task.id()
     }
 
     /// Returns a reference to the inner `Task`.
-    pub(crate) fn task(&self) -> &Task {
+    pub(crate) const fn task(&self) -> &Task {
         &self.task
     }
 
     /// Returns the map holding task-local values.
-    pub(crate) fn locals(&self) -> &LocalsMap {
+    pub(crate) const fn locals(&self) -> &LocalsMap {
         &self.locals
     }
 

--- a/src/task/yield_now.rs
+++ b/src/task/yield_now.rs
@@ -40,12 +40,12 @@ impl Future for YieldNow {
     // does is re-schedule the future back to the end of the queue, giving room
     // for other futures to progress.
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if !self.0 {
+        if self.0 {
+            Poll::Ready(())
+        } else {
             self.0 = true;
             cx.waker().wake_by_ref();
             Poll::Pending
-        } else {
-            Poll::Ready(())
         }
     }
 }

--- a/tests/rwlock.rs
+++ b/tests/rwlock.rs
@@ -49,7 +49,8 @@ fn smoke() {
         let lock = RwLock::new(());
         drop(lock.read().await);
         drop(lock.write().await);
-        drop((lock.read().await, lock.read().await));
+        drop(lock.read().await);
+        drop(lock.read().await);
         drop(lock.write().await);
     });
 }


### PR DESCRIPTION
Fixes some clippy warnings like adding `const` and `#[must_use]` where we can, putting Rust identifiers in tick marks in the documentation, etc.

This may or may not involve breaking changes, so feel free to reject this if it is outside of scope for one PR or not good for right now.