### PR TITLE
io: export write::*

### DIFF
--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -285,7 +285,7 @@ cfg_std! {
     pub use repeat::{repeat, Repeat};
     pub use seek::Seek;
     pub use sink::{sink, Sink};
-    pub use write::Write;
+    pub use write::*;
 
     pub mod prelude;
 


### PR DESCRIPTION
We weren't exporting WriteExt.
We already do that with read::*
