### PR TITLE
fix wrong link.

### DIFF
--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -103,7 +103,7 @@
 //! the desired task name to [`Builder::name`]. To retrieve the task name from within the
 //! task, use [`Task::name`].
 //!
-//! [`Arc`]: ../gsync/struct.Arc.html
+//! [`Arc`]: ../sync/struct.Arc.html
 //! [`spawn`]: fn.spawn.html
 //! [`JoinHandle`]: struct.JoinHandle.html
 //! [`JoinHandle::task`]: struct.JoinHandle.html#method.task


### PR DESCRIPTION
fixes #954  The link to Arc in v1.9.0 was also wrong, so I fixed that as well.