### PR TITLE
stream: correct iterators in doc examples

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -164,7 +164,7 @@
 //! #
 //! # use async_std::prelude::*;
 //! # use async_std::stream;
-//! let mut values = stream::repeat(1u8).take(5);
+//! let mut values = stream::from_iter(1u8..6);
 //!
 //! while let Some(x) = values.next().await {
 //!     println!("{}", x);
@@ -183,7 +183,8 @@
 //!
 //! Unlike `std::iter::IntoIterator`, `IntoStream` does not have compiler
 //! support yet. This means that automatic conversions like with `for` loops
-//! doesn't occur yet, and `into_stream` will always have to be called manually.
+//! doesn't occur yet, and `into_stream` or `from_iter` as above will always
+//! have to be called manually.
 //!
 //! [`IntoStream`]: trait.IntoStream.html
 //! [`into_stream`]: trait.IntoStream.html#tymethod.into_stream
@@ -271,7 +272,7 @@
 //! #
 //! # use async_std::prelude::*;
 //! # use async_std::stream;
-//! let numbers = stream::repeat(1u8);
+//! let numbers = stream::from_iter(0u8..);
 //! let mut five_numbers = numbers.take(5);
 //!
 //! while let Some(number) = five_numbers.next().await {


### PR DESCRIPTION
Correct the iterators used in examples to produce the described output.

Currently in https://docs.rs/async-std/1.10.0/async_std/stream/index.html#while-let-loops-and-intostream the text after the code snippet says "This will print the numbers one through five" but because the code uses `stream::repeat(1u8).take(5)`, it will print `1` five times instead - modified to use `from_iter(1..6)`.  Similarly, in the Iinfinity" section https://docs.rs/async-std/1.10.0/async_std/stream/index.html#infinity, changed `stream::repeat(1u8)` to `stream::from_iter(0u8)` to produce the described result, "print the numbers `0` through `4`".

I believe the Section "while let Loops and IntoStream" https://docs.rs/async-std/1.10.0/async_std/stream/index.html#while-let-loops-and-intostream has more problems.  Is the `into_stream` used in this example? The explanation says: "we never called anything on our vector to produce a stream" - but as far as I see, there is no vector in the example, only `async_std::stream::Repeat` created with `repeat` - or a Stream in the modified example. Also `IntoStream` is supported only on unstable - I wonder if it would be better to rename the section to `while let Loops and FromIter` and talk about conversion of iterators into streams with `from_iter` instead of `into_stream`.

