### PR TITLE
Improve `extension_trait!`

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -309,14 +309,6 @@ macro_rules! extension_trait {
         extension_trait!(@ext ($($head)* -> $f) $($tail)*);
     };
 
-    // Parse the return type in an extension method.
-    (@doc ($($head:tt)*) -> impl Future<Output = $out:ty> + $lt:lifetime [$f:ty] $($tail:tt)*) => {
-        extension_trait!(@doc ($($head)* -> borrowed::ImplFuture<$lt, $out>) $($tail)*);
-    };
-    (@ext ($($head:tt)*) -> impl Future<Output = $out:ty> + $lt:lifetime [$f:ty] $($tail:tt)*) => {
-        extension_trait!(@ext ($($head)* -> $f) $($tail)*);
-    };
-
     // Parse a token.
     (@doc ($($head:tt)*) $token:tt $($tail:tt)*) => {
         extension_trait!(@doc ($($head)* $token) $($tail)*);


### PR DESCRIPTION
The `extension_trait!` macro is an example of a "push-down accumulation" macro. Unfortunately, such macros are inherently quadratic to run, because the accumulated tokens must be reparsed for every recursive invocation. Some of the `extension_trait!` inputs are large -- the one in `src/stream/stream/mod.rs` is over 2,000 lines. As a result, the compile time of `async-std` is dominated by macro expansion.

This PR adjusts `extension_trait!` in a way that reduces its compile time without affecting its functionality. For a `cargo check` build of the leaf crate on my Linux box I saw compile time reductions of about 25%. The two commits both have roughly equal effect on compile time.