### PR TITLE
Remove unused num_cpus dependency (handled by async_global_executor)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ default = [
   "futures-lite",
   "kv-log-macro",
   "log",
-  "num_cpus",
   "pin-project-lite",
   "gloo-timers",
 ]
@@ -71,7 +70,6 @@ futures-io = { version = "0.3.4", optional = true }
 kv-log-macro = { version = "1.0.6", optional = true }
 log = { version = "0.4.8", features = ["kv_unstable"], optional = true }
 memchr = { version = "2.3.3", optional = true }
-num_cpus = { version = "1.12.0", optional = true }
 once_cell = { version = "1.3.1", optional = true }
 pin-project-lite = { version = "0.2.0", optional = true }
 pin-utils = { version = "0.1.0-alpha.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,9 +267,10 @@
 //!
 //! * `ASYNC_STD_THREAD_COUNT`: The number of threads that the
 //! async-std runtime will start. By default, this is one per logical
-//! cpu as reported by the [num_cpus](num_cpus) crate, which may be
-//! different than the number of physical cpus. Async-std _will panic_
-//! if this is set to any value other than a positive integer.
+//! cpu as determined by [async-global-executor](async_global_executor),
+//! which may be different than the number of physical cpus. Async-std
+//! _will panic_ if this is set to any value other than a positive
+//! integer.
 //! * `ASYNC_STD_THREAD_NAME`: The name that async-std's runtime
 //! threads report to the operating system. The default value is
 //! `"async-std/runtime"`.


### PR DESCRIPTION
async-std doesn't use num_cpus directly, only via async_global_executor.
