### PR TITLE
Add `TryFrom` impls to convert async types to corresponding sync types

### DIFF
--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -252,6 +252,16 @@ impl From<std::net::TcpListener> for TcpListener {
     }
 }
 
+impl std::convert::TryFrom<TcpListener> for std::net::TcpListener {
+    type Error = io::Error;
+    /// Converts a `TcpListener` into its synchronous equivalent.
+    fn try_from(listener: TcpListener) -> io::Result<std::net::TcpListener> {
+        let inner = listener.watcher.into_inner()?;
+        inner.set_nonblocking(false)?;
+        Ok(inner)
+    }
+}
+
 cfg_unix! {
     use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -532,6 +532,16 @@ impl From<std::net::UdpSocket> for UdpSocket {
     }
 }
 
+impl std::convert::TryFrom<UdpSocket> for std::net::UdpSocket {
+    type Error = io::Error;
+    /// Converts a `UdpSocket` into its synchronous equivalent.
+    fn try_from(listener: UdpSocket) -> io::Result<std::net::UdpSocket> {
+        let inner = listener.watcher.into_inner()?;
+        inner.set_nonblocking(false)?;
+        Ok(inner)
+    }
+}
+
 cfg_unix! {
     use crate::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 

--- a/src/os/unix/net/datagram.rs
+++ b/src/os/unix/net/datagram.rs
@@ -311,6 +311,16 @@ impl From<StdUnixDatagram> for UnixDatagram {
     }
 }
 
+impl std::convert::TryFrom<UnixDatagram> for StdUnixDatagram {
+    type Error = io::Error;
+    /// Converts a `UnixDatagram` into its synchronous equivalent.
+    fn try_from(listener: UnixDatagram) -> io::Result<StdUnixDatagram> {
+        let inner = listener.watcher.into_inner()?;
+        inner.set_nonblocking(false)?;
+        Ok(inner)
+    }
+}
+
 impl AsRawFd for UnixDatagram {
     fn as_raw_fd(&self) -> RawFd {
         self.watcher.as_raw_fd()

--- a/src/os/unix/net/listener.rs
+++ b/src/os/unix/net/listener.rs
@@ -205,6 +205,16 @@ impl From<StdUnixListener> for UnixListener {
     }
 }
 
+impl std::convert::TryFrom<UnixListener> for StdUnixListener {
+    type Error = io::Error;
+    /// Converts a `UnixListener` into its synchronous equivalent.
+    fn try_from(listener: UnixListener) -> io::Result<StdUnixListener> {
+        let inner = listener.watcher.into_inner()?;
+        inner.set_nonblocking(false)?;
+        Ok(inner)
+    }
+}
+
 impl AsRawFd for UnixListener {
     fn as_raw_fd(&self) -> RawFd {
         self.watcher.as_raw_fd()


### PR DESCRIPTION
Add `TryFrom` implementations to convert `TcpListener`, `TcpStream`,
`UdpSocket`, `UnixDatagram`, `UnixListener`, and `UnixStream` to their
synchronous equivalents, including putting them back into blocking mode.

This does not add such an impl for `File`, because `std::fs::File` does not
provide a `set_nonblocking` method.
