### PR TITLE
Stabilize `std::task::spawn_blocking`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://book.async.rs/overview
 # [Unreleased]
 
 ## Added
+
+- `std::task_spawn_blocking` is now stabilized. We consider it a fundamental API for bridging between blocking code and async code, and we widely use it within async-std's own implementation.
+
 ## Removed
 ## Changed
 

--- a/src/task/mod.rs
+++ b/src/task/mod.rs
@@ -160,11 +160,7 @@ cfg_default! {
     mod task_locals_wrapper;
 
     #[cfg(not(target_os = "unknown"))]
-    #[cfg(any(feature = "unstable", test))]
     pub use spawn_blocking::spawn_blocking;
-    #[cfg(not(target_os = "unknown"))]
-    #[cfg(not(any(feature = "unstable", test)))]
-    pub(crate) use spawn_blocking::spawn_blocking;
 }
 
 cfg_unstable! {

--- a/src/task/spawn_blocking.rs
+++ b/src/task/spawn_blocking.rs
@@ -16,7 +16,6 @@ use crate::task::{self, JoinHandle};
 /// Basic usage:
 ///
 /// ```
-/// # #[cfg(feature = "unstable")]
 /// # async_std::task::block_on(async {
 /// #
 /// use async_std::task;
@@ -28,7 +27,6 @@ use crate::task::{self, JoinHandle};
 /// #
 /// # })
 /// ```
-#[cfg_attr(feature = "docs", doc(cfg(unstable)))]
 #[inline]
 pub fn spawn_blocking<F, T>(f: F) -> JoinHandle<T>
 where


### PR DESCRIPTION
Given how widely used spawn_blocking is within async-std itself, and how
useful it is for building other APIs, I think it makes sense to offer it
just as we do `spawn`, even though it isn't standard in Rust itself.
