### PR TITLE
Fix CI errors about unused-macro-rules

### DIFF
--- a/src/stream/product.rs
+++ b/src/stream/product.rs
@@ -27,8 +27,8 @@ use core::ops::Mul;
 use core::num::Wrapping;
 use crate::stream::stream::StreamExt;
 
-macro_rules! integer_product {
-    (@impls $one: expr, $($a:ty)*) => ($(
+macro_rules! num_product {
+    ($one:expr, $($a:ty)*) => ($(
         impl Product for $a {
             fn product<'a, S>(stream: S) -> Pin<Box<dyn Future<Output = Self>+ 'a>>
             where
@@ -46,32 +46,18 @@ macro_rules! integer_product {
             }
         }
     )*);
+}
+
+macro_rules! integer_product {
     ($($a:ty)*) => (
-        integer_product!(@impls 1, $($a)*);
-        integer_product!(@impls Wrapping(1), $(Wrapping<$a>)*);
+        num_product!(1, $($a)*);
+        num_product!(Wrapping(1), $(Wrapping<$a>)*);
     );
 }
 
 macro_rules! float_product {
-    ($($a:ty)*) => ($(
-        impl Product for $a {
-            fn product<'a, S>(stream: S) -> Pin<Box<dyn Future<Output = Self>+ 'a>>
-                where S: Stream<Item = $a> + 'a,
-            {
-                Box::pin(async move { stream.fold(1.0, |a, b| a * b).await } )
-            }
-        }
-        impl<'a> Product<&'a $a> for $a {
-            fn product<'b, S>(stream: S) -> Pin<Box<dyn Future<Output = Self>+ 'b>>
-                where S: Stream<Item = &'a $a> + 'b,
-            {
-                Box::pin(async move { stream.fold(1.0, |a, b| a * b).await } )
-            }
-        }
-    )*);
     ($($a:ty)*) => (
-        float_product!($($a)*);
-        float_product!($(Wrapping<$a>)*);
+        num_product!(1.0, $($a)*);
     );
 }
 

--- a/src/stream/sum.rs
+++ b/src/stream/sum.rs
@@ -27,8 +27,8 @@ use crate::stream::stream::StreamExt;
 use core::num::Wrapping;
 use core::ops::Add;
 
-macro_rules! integer_sum {
-    (@impls $zero: expr, $($a:ty)*) => ($(
+macro_rules! num_sum {
+    ($zero:expr, $($a:ty)*) => ($(
         impl Sum for $a {
             fn sum<'a, S>(stream: S) -> Pin<Box<dyn Future<Output = Self>+ 'a>>
             where
@@ -46,32 +46,18 @@ macro_rules! integer_sum {
             }
         }
     )*);
+}
+
+macro_rules! integer_sum {
     ($($a:ty)*) => (
-        integer_sum!(@impls 0, $($a)*);
-        integer_sum!(@impls Wrapping(0), $(Wrapping<$a>)*);
+        num_sum!(0, $($a)*);
+        num_sum!(Wrapping(0), $(Wrapping<$a>)*);
     );
 }
 
 macro_rules! float_sum {
-    ($($a:ty)*) => ($(
-        impl Sum for $a {
-            fn sum<'a, S>(stream: S) -> Pin<Box<dyn Future<Output = Self> + 'a>>
-                where S: Stream<Item = $a> + 'a,
-            {
-                Box::pin(async move { stream.fold(0.0, |a, b| a + b).await } )
-            }
-        }
-        impl<'a> Sum<&'a $a> for $a {
-            fn sum<'b, S>(stream: S) -> Pin<Box<dyn Future<Output = Self> + 'b>>
-                where S: Stream<Item = &'a $a> + 'b,
-            {
-                Box::pin(async move { stream.fold(0.0, |a, b| a + b).await } )
-            }
-        }
-    )*);
     ($($a:ty)*) => (
-        float_sum!(@impls 0.0, $($a)*);
-        float_sum!(@impls Wrapping(0.0), $(Wrapping<$a>)*);
+        num_sum!(0.0, $($a)*);
     );
 }
 


### PR DESCRIPTION
float_product and float_sum had unused rules, because they weren't
successfully using their second branch, and weren't successfully
defining wrapping types.

That then led to the discovery that those types *can't* be defined,
because std doesn't actually define any operations on `Wrapping<f32>` or
`Wrapping<f64>`. So, drop those portions of the float macros.

Fix that, and in the process, unify the integer and float macros.