### PR TITLE
Remove rustfmt.toml - zero changes to formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-version = "Two"


### PR DESCRIPTION
rustfmt's `version = "Two"` option doesn't result in any formatting
changes anywhere in async-std, but it prevents formatting with a stable
toolchain. Remove rustfmt.toml and allow formatting to work on stable
rustfmt.
