### PR TITLE
Remove old bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,0 @@
-status = [
-    "Build and test (ubuntu-latest, nightly)",
-    "Build and test (windows-latest, nightly)",
-    "Build and test (macOS-latest, nightly)",
-    "Checking fmt and docs",
-    "Clippy check",
-]


### PR DESCRIPTION
This seems to be an artifact from when we used bors rather than GitHub
Actions.
