### PR TITLE
Export `BufReadExt` and `SeekExt` from `async_std::io`

### DIFF
--- a/src/io/buf_read/mod.rs
+++ b/src/io/buf_read/mod.rs
@@ -239,7 +239,7 @@ pub trait BufReadExt: BufRead {
 
 impl<T: BufRead + ?Sized> BufReadExt for T {}
 
-pub fn read_until_internal<R: BufReadExt + ?Sized>(
+pub(crate) fn read_until_internal<R: BufReadExt + ?Sized>(
     mut reader: Pin<&mut R>,
     cx: &mut Context<'_>,
     byte: u8,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -275,7 +275,7 @@ cfg_std! {
     #[doc(inline)]
     pub use std::io::{Error, ErrorKind, IoSlice, IoSliceMut, Result, SeekFrom};
 
-    pub use buf_read::{BufRead, Lines, Split};
+    pub use buf_read::*;
     pub use buf_reader::BufReader;
     pub use buf_writer::{BufWriter, IntoInnerError};
     pub use copy::copy;
@@ -283,7 +283,7 @@ cfg_std! {
     pub use empty::{empty, Empty};
     pub use read::*;
     pub use repeat::{repeat, Repeat};
-    pub use seek::Seek;
+    pub use seek::*;
     pub use sink::{sink, Sink};
     pub use write::*;
 


### PR DESCRIPTION
`async_std::io` exports `Read`, `ReadExt`, `Write`, `WriteExt`,
`BufRead`, and `Seek`. But it does not export `BufReadExt` and
`SeekExt`; those only appear in `async_std::io::prelude`.

Export both `BufReadExt` and `SeekExt` from `async_std::io`. This makes
it easier for code not using the prelude to import all of the I/O traits
it uses from the same module.
