### PR TITLE
Fix compilation errors with `feature = io_safety`.

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -461,7 +461,7 @@ cfg_unix! {
 
         impl From<File> for OwnedFd {
             fn from(val: File) -> OwnedFd {
-                self.into_std_file().into()
+                val.into_std_file().into()
             }
         }
     }

--- a/src/io/stderr.rs
+++ b/src/io/stderr.rs
@@ -186,7 +186,9 @@ cfg_unix! {
 
         impl AsFd for Stderr {
             fn as_fd(&self) -> BorrowedFd<'_> {
-                std::io::stderr().as_fd()
+                unsafe {
+                    BorrowedFd::borrow_raw(std::io::stderr().as_raw_fd())
+                }
             }
         }
     }

--- a/src/io/stdin.rs
+++ b/src/io/stdin.rs
@@ -210,9 +210,11 @@ cfg_unix! {
     cfg_io_safety! {
         use crate::os::unix::io::{AsFd, BorrowedFd};
 
-        impl AsFd for Stderr {
+        impl AsFd for Stdin {
             fn as_fd(&self) -> BorrowedFd<'_> {
-                std::io::stdin().as_fd()
+                unsafe {
+                    BorrowedFd::borrow_raw(std::io::stdin().as_raw_fd())
+                }
             }
         }
     }

--- a/src/io/stdout.rs
+++ b/src/io/stdout.rs
@@ -186,7 +186,9 @@ cfg_unix! {
 
         impl AsFd for Stdout {
             fn as_fd(&self) -> BorrowedFd<'_> {
-                std::io::stdout().as_fd()
+                unsafe {
+                    BorrowedFd::borrow_raw(std::io::stdout().as_raw_fd())
+                }
             }
         }
     }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -434,7 +434,7 @@ cfg_unix! {
 
         impl From<TcpStream> for OwnedFd {
             fn from(stream: TcpStream) -> OwnedFd {
-                stream.watcher.into_inner().unwrap().into()
+                stream.watcher.get_ref().try_clone().unwrap().into()
             }
         }
     }

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -574,7 +574,7 @@ cfg_unix! {
 
         impl From<OwnedFd> for UdpSocket {
             fn from(fd: OwnedFd) -> UdpSocket {
-                std::net::TcpStream::from(fd).into()
+                std::net::UdpSocket::from(fd).into()
             }
         }
 

--- a/src/os/unix/net/datagram.rs
+++ b/src/os/unix/net/datagram.rs
@@ -352,7 +352,7 @@ cfg_io_safety! {
 
     impl From<OwnedFd> for UnixDatagram {
         fn from(fd: OwnedFd) -> UnixDatagram {
-            std::net::TcpStream::from(fd).into()
+            StdUnixDatagram::from(fd).into()
         }
     }
 

--- a/src/os/unix/net/listener.rs
+++ b/src/os/unix/net/listener.rs
@@ -245,7 +245,7 @@ cfg_io_safety! {
 
     impl From<OwnedFd> for UnixListener {
         fn from(fd: OwnedFd) -> UnixListener {
-            std::net::TcpStream::from(fd).into()
+            std::os::unix::net::UnixListener::from(fd).into()
         }
     }
 

--- a/src/os/unix/net/stream.rs
+++ b/src/os/unix/net/stream.rs
@@ -276,13 +276,13 @@ cfg_io_safety! {
 
     impl From<OwnedFd> for UnixStream {
         fn from(fd: OwnedFd) -> UnixStream {
-            std::net::TcpStream::from(fd).into()
+            std::os::unix::net::UnixStream::from(fd).into()
         }
     }
 
     impl From<UnixStream> for OwnedFd {
         fn from(stream: UnixStream) -> OwnedFd {
-            stream.watcher.into_inner().unwrap().into()
+            stream.watcher.get_ref().try_clone().unwrap().into()
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -246,7 +246,7 @@ macro_rules! cfg_default {
 macro_rules! cfg_io_safety {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "io-safety")]
+            #[cfg(feature = "io_safety")]
             $item
         )*
     }


### PR DESCRIPTION
Fix a typo of "io-safety" in place of "io_safety", and fix various compilation errors exposed by this fix.