### PR TITLE
Add rust-version 1.63

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = [
   "Contributors to async-std",
 ]
 edition = "2018"
+rust-version = "1.63"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/async-rs/async-std"
 homepage = "https://async.rs"


### PR DESCRIPTION
This is the same MSRV as async-io .

That this was missing was raised at https://github.com/open-telemetry/opentelemetry-rust/pull/2082