### PR TITLE
Apply clippy fixes

### DIFF
--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -696,7 +696,7 @@ impl LockGuard<State> {
         // file. This call should not block because it doesn't touch the actual file on disk.
         if pos == SeekFrom::Current(0) {
             // Poll the internal file cursor.
-            let internal = (&*self.file).seek(SeekFrom::Current(0))?;
+            let internal = (&*self.file).stream_position()?;
 
             // Factor in the difference caused by caching.
             let actual = match self.mode {
@@ -714,7 +714,7 @@ impl LockGuard<State> {
                 if let Some(new) = (start as i64).checked_add(diff) {
                     if 0 <= new && new <= self.cache.len() as i64 {
                         // Poll the internal file cursor.
-                        let internal = (&*self.file).seek(SeekFrom::Current(0))?;
+                        let internal = (&*self.file).stream_position()?;
 
                         // Adjust the current position in the read cache.
                         self.mode = Mode::Reading(new as usize);

--- a/src/future/poll_fn.rs
+++ b/src/future/poll_fn.rs
@@ -44,6 +44,6 @@ where
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        (&mut self.f)(cx)
+        (self.f)(cx)
     }
 }

--- a/src/io/buf_read/lines.rs
+++ b/src/io/buf_read/lines.rs
@@ -50,7 +50,7 @@ impl<R: BufRead> Stream for Lines<R> {
                 this.buf.pop();
             }
         }
-        Poll::Ready(Some(Ok(mem::replace(this.buf, String::new()))))
+        Poll::Ready(Some(Ok(mem::take(this.buf))))
     }
 }
 
@@ -62,7 +62,7 @@ pub fn read_line_internal<R: BufRead + ?Sized>(
     read: &mut usize,
 ) -> Poll<io::Result<usize>> {
     let ret = futures_core::ready!(read_until_internal(reader, cx, b'\n', bytes, read));
-    if str::from_utf8(&bytes).is_err() {
+    if str::from_utf8(bytes).is_err() {
         Poll::Ready(ret.and_then(|_| {
             Err(io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/src/io/buf_read/mod.rs
+++ b/src/io/buf_read/mod.rs
@@ -136,7 +136,7 @@ pub trait BufReadExt: BufRead {
     {
         ReadLineFuture {
             reader: self,
-            bytes: unsafe { mem::replace(buf.as_mut_vec(), Vec::new()) },
+            bytes: unsafe { std::mem::take(buf.as_mut_vec()) },
             buf,
             read: 0,
         }

--- a/src/io/buf_read/read_line.rs
+++ b/src/io/buf_read/read_line.rs
@@ -29,7 +29,7 @@ impl<T: BufRead + Unpin + ?Sized> Future for ReadLineFuture<'_, T> {
         let reader = Pin::new(reader);
 
         let ret = futures_core::ready!(read_until_internal(reader, cx, b'\n', bytes, read));
-        if str::from_utf8(&bytes).is_err() {
+        if str::from_utf8(bytes).is_err() {
             Poll::Ready(ret.and_then(|_| {
                 Err(io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/src/io/buf_read/split.rs
+++ b/src/io/buf_read/split.rs
@@ -46,6 +46,6 @@ impl<R: BufRead> Stream for Split<R> {
         if this.buf[this.buf.len() - 1] == *this.delim {
             this.buf.pop();
         }
-        Poll::Ready(Some(Ok(mem::replace(this.buf, vec![]))))
+        Poll::Ready(Some(Ok(mem::take(this.buf))))
     }
 }

--- a/src/io/read/chain.rs
+++ b/src/io/read/chain.rs
@@ -144,7 +144,7 @@ impl<T: BufRead, U: BufRead> BufRead for Chain<T, U> {
         let this = self.project();
         if !*this.done_first {
             match futures_core::ready!(this.first.poll_fill_buf(cx)) {
-                Ok(buf) if buf.is_empty() => {
+                Ok([]) => {
                     *this.done_first = true;
                 }
                 Ok(buf) => return Poll::Ready(Ok(buf)),

--- a/src/io/read/mod.rs
+++ b/src/io/read/mod.rs
@@ -168,7 +168,7 @@ pub trait ReadExt: Read {
         let start_len = buf.len();
         ReadToStringFuture {
             reader: self,
-            bytes: unsafe { mem::replace(buf.as_mut_vec(), Vec::new()) },
+            bytes: unsafe { mem::take(buf.as_mut_vec()) },
             buf,
             start_len,
         }

--- a/src/io/read/read_exact.rs
+++ b/src/io/read/read_exact.rs
@@ -20,7 +20,7 @@ impl<T: Read + Unpin + ?Sized> Future for ReadExactFuture<'_, T> {
 
         while !buf.is_empty() {
             let n = futures_core::ready!(Pin::new(&mut *reader).poll_read(cx, buf))?;
-            let (_, rest) = mem::replace(buf, &mut []).split_at_mut(n);
+            let (_, rest) = mem::take(buf).split_at_mut(n);
             *buf = rest;
 
             if n == 0 {

--- a/src/io/read/read_to_string.rs
+++ b/src/io/read/read_to_string.rs
@@ -29,7 +29,7 @@ impl<T: Read + Unpin + ?Sized> Future for ReadToStringFuture<'_, T> {
         let reader = Pin::new(reader);
 
         let ret = futures_core::ready!(read_to_end_internal(reader, cx, bytes, *start_len));
-        if str::from_utf8(&bytes).is_err() {
+        if str::from_utf8(bytes).is_err() {
             Poll::Ready(ret.and_then(|_| {
                 Err(io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/src/io/write/write_all.rs
+++ b/src/io/write/write_all.rs
@@ -20,7 +20,7 @@ impl<T: Write + Unpin + ?Sized> Future for WriteAllFuture<'_, T> {
 
         while !buf.is_empty() {
             let n = futures_core::ready!(Pin::new(&mut **writer).poll_write(cx, buf))?;
-            let (_, rest) = mem::replace(buf, &[]).split_at(n);
+            let (_, rest) = mem::take(buf).split_at(n);
             *buf = rest;
 
             if n == 0 {

--- a/src/net/addr.rs
+++ b/src/net/addr.rs
@@ -280,6 +280,6 @@ impl ToSocketAddrs for String {
         impl Future<Output = Self::Iter>,
         ToSocketAddrsFuture<Self::Iter>
     ) {
-        (&**self).to_socket_addrs()
+        (**self).to_socket_addrs()
     }
 }

--- a/src/path/path.rs
+++ b/src/path/path.rs
@@ -261,7 +261,7 @@ impl Path {
     /// assert_eq!(ancestors.next(), None);
     /// ```
     pub fn ancestors(&self) -> Ancestors<'_> {
-        Ancestors { next: Some(&self) }
+        Ancestors { next: Some(self) }
     }
 
     /// Returns the final component of the `Path`, if there is one.
@@ -1011,7 +1011,7 @@ impl_cmp_os_str!(&'a Path, OsString);
 
 impl<'a> From<&'a std::path::Path> for &'a Path {
     fn from(path: &'a std::path::Path) -> &'a Path {
-        &Path::new(path.as_os_str())
+        Path::new(path.as_os_str())
     }
 }
 

--- a/src/stream/from_fn.rs
+++ b/src/stream/from_fn.rs
@@ -62,7 +62,7 @@ where
     type Item = T;
 
     fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let item = (&mut self.f)();
+        let item = (self.f)();
         Poll::Ready(item)
     }
 }

--- a/src/stream/repeat_with.rs
+++ b/src/stream/repeat_with.rs
@@ -78,7 +78,7 @@ where
     type Item = T;
 
     fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let item = (&mut self.f)();
+        let item = (self.f)();
         Poll::Ready(Some(item))
     }
 }

--- a/src/stream/stream/all.rs
+++ b/src/stream/stream/all.rs
@@ -37,7 +37,7 @@ where
 
         match next {
             Some(v) => {
-                let result = (&mut self.f)(v);
+                let result = (self.f)(v);
 
                 if result {
                     // don't forget to wake this task again to pull the next item from stream

--- a/src/stream/stream/any.rs
+++ b/src/stream/stream/any.rs
@@ -37,7 +37,7 @@ where
 
         match next {
             Some(v) => {
-                let result = (&mut self.f)(v);
+                let result = (self.f)(v);
 
                 if result {
                     Poll::Ready(true)

--- a/src/stream/stream/find.rs
+++ b/src/stream/stream/find.rs
@@ -30,7 +30,7 @@ where
         let item = futures_core::ready!(Pin::new(&mut *self.stream).poll_next(cx));
 
         match item {
-            Some(v) if (&mut self.p)(&v) => Poll::Ready(Some(v)),
+            Some(v) if (self.p)(&v) => Poll::Ready(Some(v)),
             Some(_) => {
                 cx.waker().wake_by_ref();
                 Poll::Pending

--- a/src/stream/stream/find_map.rs
+++ b/src/stream/stream/find_map.rs
@@ -30,7 +30,7 @@ where
         let item = futures_core::ready!(Pin::new(&mut *self.stream).poll_next(cx));
 
         match item {
-            Some(v) => match (&mut self.f)(v) {
+            Some(v) => match (self.f)(v) {
                 Some(v) => Poll::Ready(Some(v)),
                 None => {
                     cx.waker().wake_by_ref();

--- a/src/stream/stream/position.rs
+++ b/src/stream/stream/position.rs
@@ -36,7 +36,7 @@ where
 
         match next {
             Some(v) => {
-                if (&mut self.predicate)(v) {
+                if (self.predicate)(v) {
                     Poll::Ready(Some(self.index))
                 } else {
                     cx.waker().wake_by_ref();

--- a/src/stream/stream/try_fold.rs
+++ b/src/stream/stream/try_fold.rs
@@ -38,7 +38,7 @@ where
             match next {
                 Some(v) => {
                     let old = self.acc.take().unwrap();
-                    let new = (&mut self.f)(old, v);
+                    let new = (self.f)(old, v);
 
                     match new {
                         Ok(o) => self.acc = Some(o),

--- a/src/stream/stream/try_for_each.rs
+++ b/src/stream/stream/try_for_each.rs
@@ -33,7 +33,7 @@ where
             match item {
                 None => return Poll::Ready(Ok(())),
                 Some(v) => {
-                    let res = (&mut self.f)(v);
+                    let res = (self.f)(v);
                     if let Err(e) = res {
                         return Poll::Ready(Err(e));
                     }

--- a/src/task/builder.rs
+++ b/src/task/builder.rs
@@ -154,7 +154,7 @@ impl Builder {
 
         thread_local! {
             /// Tracks the number of nested block_on calls.
-            static NUM_NESTED_BLOCKING: Cell<usize> = Cell::new(0);
+            static NUM_NESTED_BLOCKING: Cell<usize> = const { Cell::new(0) };
         }
 
         // Run the future as a task.

--- a/src/task/task_id.rs
+++ b/src/task/task_id.rs
@@ -22,7 +22,7 @@ impl TaskId {
         static COUNTER: AtomicUsize = AtomicUsize::new(1);
 
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        if id > usize::max_value() / 2 {
+        if id > usize::MAX / 2 {
             std::process::abort();
         }
         TaskId(id)

--- a/src/task/task_local.rs
+++ b/src/task/task_local.rs
@@ -120,7 +120,7 @@ impl<T: Send + 'static> LocalKey<T> {
             static COUNTER: AtomicU32 = AtomicU32::new(1);
 
             let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
-            if counter > u32::max_value() / 2 {
+            if counter > u32::MAX / 2 {
                 std::process::abort();
             }
 

--- a/src/task/task_locals_wrapper.rs
+++ b/src/task/task_locals_wrapper.rs
@@ -6,7 +6,7 @@ use crate::utils::abort_on_panic;
 
 thread_local! {
     /// A pointer to the currently running task.
-    static CURRENT: Cell<*const TaskLocalsWrapper> = Cell::new(ptr::null_mut());
+    static CURRENT: Cell<*const TaskLocalsWrapper> = const { Cell::new(ptr::null_mut()) };
 }
 
 /// A wrapper to store task local data.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -71,7 +71,7 @@ pub(crate) fn timer_after(dur: std::time::Duration) -> timer::Timer {
     Timer::after(dur)
 }
 
-#[cfg(any(all(target_arch = "wasm32", feature = "default"),))]
+#[cfg(all(target_arch = "wasm32", feature = "default"))]
 mod timer {
     use std::pin::Pin;
     use std::task::Poll;

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -60,7 +60,7 @@ fn smoke_std_stream_to_async_listener() -> io::Result<()> {
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let addr = listener.local_addr()?;
 
-        let mut std_stream = std::net::TcpStream::connect(&addr)?;
+        let mut std_stream = std::net::TcpStream::connect(addr)?;
         std_stream.write_all(THE_WINTERS_TALE)?;
 
         let mut buf = vec![0; 1024];

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -96,7 +96,7 @@ async fn ping_pong_server(listener: UnixListener, iterations: u32) -> std::io::R
             let mut s = s?;
             let n = s.read(&mut buf[..]).await?;
             assert_eq!(&buf[..n], PING);
-            s.write_all(&PONG).await?;
+            s.write_all(PONG).await?;
         }
     }
     Ok(())
@@ -106,7 +106,7 @@ async fn ping_pong_client(socket: &std::path::PathBuf, iterations: u32) -> std::
     let mut buf = [0; 1024];
     for _ix in 0..iterations {
         let mut socket = UnixStream::connect(&socket).await?;
-        socket.write_all(&PING).await?;
+        socket.write_all(PING).await?;
         let n = async_std::io::timeout(TEST_TIMEOUT, socket.read(&mut buf[..])).await?;
         assert_eq!(&buf[..n], PONG);
     }


### PR DESCRIPTION
Most of these are based on the automatic `clippy --fix` changes, with some many changes to reduce the noise.
`max_value()` to `MAX` and the cfg change are manual.

Note I dont see any substantive overlap with https://github.com/async-rs/async-std/pull/948 , so I guess that the clippy warnings from 2021 have all since been addressed and that PR can be closed.