### PR TITLE
Use the current major version of async-channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ once_cell = { version = "1.3.1", optional = true }
 pin-project-lite = { version = "0.2.0", optional = true }
 pin-utils = { version = "0.1.0-alpha.4", optional = true }
 slab = { version = "0.4.2", optional = true }
-async-channel = { version = "1.8.0", optional = true }
+async-channel = { version = "2.2.0", optional = true }
 
 # dev dependency, but they are not allowed to be optional :/
 surf = { version = "2.0.0", optional = true }


### PR DESCRIPTION
I didn’t attempt to audit the code and compare it to the breaking changes noted in https://github.com/smol-rs/async-channel/blob/v2.3.1/CHANGELOG.md#version-200. I did run `cargo test --no-fail-fast` and didn’t observe any regressions (`to_socket_addr_str_bad` panics for me both before and after this PR).